### PR TITLE
fix: line endings on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Summary:
---------

This pull request introduces a `.gitattributes` file into this repo to force `git` to use `lf` rather than `crlf` line endings on Windows. Without it, running `yarn lint` results in thousands of errors like this for Windows users:

```
   6:3   error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   6:3   error  Delete `␍`                                       prettier/prettier
   7:11  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   7:11  error  Delete `␍`                                       prettier/prettier
   8:16  error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   8:16  error  Delete `␍`                                       prettier/prettier
   9:4   error  Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style
   9:4   error  Delete `␍`                                       prettier/prettier
```

This fix is the one suggested by the ESLint documentation:

https://eslint.org/docs/rules/linebreak-style#using-this-rule-with-version-control-systems


Test Plan:
----------

Running `yarn lint` works properly on Windows with this fix in place.
