### PR TITLE
Better name selecting for upgrade command

### DIFF
--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -38,11 +38,18 @@ const getRNPeerDeps = async (
   return JSON.parse(stdout);
 };
 
+const getProjectName = projectDir => {
+  const {name: appJsonName} = require(path.join(projectDir, 'app.json'));
+  const {name: pckJsonName} = require(path.join(projectDir, 'package.json'));
+
+  return appJsonName !== pckJsonName ? appJsonName : pckJsonName;
+};
+
 const getPatch = async (currentVersion, newVersion, projectDir) => {
   let patch;
 
   const rnDiffAppName = 'RnDiffApp';
-  const {name} = require(path.join(projectDir, 'package.json'));
+  const name = getProjectName(projectDir);
 
   logger.info(`Fetching diff between v${currentVersion} and v${newVersion}...`);
 


### PR DESCRIPTION
Summary:
---------

Small change regarding upgrade command.
Before, if `name` value in `package.json` has changed since you init'ed a project, `react-native upgrade` would fail. This is because directory paths in diffing were selected based on that `name` value.

Now, we check if names (from `package.json` and `app.json`) are different, and if so, use the one from `app.json` (to keep `name` value in `package.json` untouched).


Test Plan:
----------

Probably green CI should be sufficient. 
