### PR TITLE
Follow symlinks until a non-symlink is found

### DIFF
--- a/packages/cli/src/tools/findSymlinkedModules.js
+++ b/packages/cli/src/tools/findSymlinkedModules.js
@@ -106,6 +106,7 @@ function resolveSymlinkPaths(maybeSymlinkPaths, ignoredPaths) {
     }
 
     if (
+      visited.length > 0 &&
       ignoredPaths.indexOf(resolvedPath) < 0 &&
       fs.existsSync(resolvedPath)
     ) {

--- a/packages/cli/src/tools/findSymlinkedModules.js
+++ b/packages/cli/src/tools/findSymlinkedModules.js
@@ -85,16 +85,32 @@ function findModuleSymlinks(
 }
 
 function resolveSymlinkPaths(maybeSymlinkPaths, ignoredPaths) {
-  return maybeSymlinkPaths.reduce((links, maybeSymlinkPath) => {
-    if (fs.lstatSync(maybeSymlinkPath).isSymbolicLink()) {
-      const resolved = path.resolve(
-        path.dirname(maybeSymlinkPath),
-        fs.readlinkSync(maybeSymlinkPath),
-      );
-      if (ignoredPaths.indexOf(resolved) === -1 && fs.existsSync(resolved)) {
-        links.push(resolved);
+  return maybeSymlinkPaths.reduce((resolvedPaths, maybeSymlinkPath) => {
+    const visited = [];
+
+    let resolvedPath = maybeSymlinkPath;
+    while (fs.lstatSync(resolvedPath).isSymbolicLink()) {
+      const index = visited.indexOf(resolvedPath);
+      if (index !== -1) {
+        throw Error(
+          'Infinite symlink recursion detected:\n  ' +
+            visited.slice(index).join('\n  '),
+        );
       }
+
+      visited.push(resolvedPath);
+      resolvedPath = path.resolve(
+        path.dirname(resolvedPath),
+        fs.readlinkSync(resolvedPath),
+      );
     }
-    return links;
+
+    if (
+      ignoredPaths.indexOf(resolvedPath) < 0 &&
+      fs.existsSync(resolvedPath)
+    ) {
+      resolvedPaths.push(resolvedPath);
+    }
+    return resolvedPaths;
   }, []);
 }


### PR DESCRIPTION
Summary:
---------

In `node_modules`, follow symlinks until the "real path" is found.

Migrated from here: https://github.com/facebook/react-native/commit/fa6191f6ac65a8a303a22933e183e1f5a7381976


Test Plan:
----------

None yet.
