### PR TITLE
feat: infer package and project name for upgrade from config

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade.test.js.snap
+++ b/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade.test.js.snap
@@ -1,27 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp) 1`] = `
+exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
 "Snapshot Diff:
 - First value
 + Second value
 
-@@ -1,5 +1,5 @@
-- diff --git a/RnDiffApp/android/build.gradle b/RnDiffApp/android/build.gradle
-+ diff --git a/TestApp/android/build.gradle b/TestApp/android/build.gradle
-  index 85d8f2f8..a1e80854 100644
-- --- a/RnDiffApp/android/build.gradle
-- +++ b/RnDiffApp/android/build.gradle
-+ --- a/TestApp/android/build.gradle
-+ +++ b/TestApp/android/build.gradle
-  @@ -9,8 +9,8 @@ buildscript {
-@@ -28,6 +28,6 @@
+@@ -1,9 +1,9 @@
+- diff --git a/RnDiffApp/android/app/src/main/AndroidManifest.xml b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ diff --git a/TestApp/android/app/src/main/AndroidManifest.xml b/TestApp/android/app/src/main/AndroidManifest.xml
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/AndroidManifest.xml
+- +++ b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ --- a/TestApp/android/app/src/main/AndroidManifest.xml
++ +++ b/TestApp/android/app/src/main/AndroidManifest.xml
+  @@ -1,8 +1,7 @@
+   <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+- -    package=\\"com.rndiffapp\\">
+- +  package=\\"com.rndiffapp\\">
++ -    package=\\"com.testapp\\">
++ +  package=\\"com.testapp\\">
   
-- diff --git a/RnDiffApp/package.json b/RnDiffApp/package.json
-+ diff --git a/TestApp/package.json b/TestApp/package.json
-  index 4e617645..c82829bd 100644
-- --- a/RnDiffApp/package.json
-- +++ b/RnDiffApp/package.json
-+ --- a/TestApp/package.json
-+ +++ b/TestApp/package.json
-  @@ -7,14 +7,14 @@"
+@@ -14,6 +14,6 @@
+         android:name=\\".MainApplication\\"
+- diff --git a/RnDiffApp/ios/RnDiffApp/AppDelegate.h b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ diff --git a/TestApp/ios/TestApp/AppDelegate.h b/TestApp/ios/TestApp/AppDelegate.h
+  index 4b5644f2..2726d5e1 100644
+- --- a/RnDiffApp/ios/RnDiffApp/AppDelegate.h
+- +++ b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ --- a/TestApp/ios/TestApp/AppDelegate.h
++ +++ b/TestApp/ios/TestApp/AppDelegate.h
+  @@ -5,9 +5,10 @@
+@@ -29,6 +29,6 @@
+   @property (nonatomic, strong) UIWindow *window;
+- diff --git a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ diff --git a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
+- +++ b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ --- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
++ +++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+  "
+`;
+
+exports[`works with --name-ios and --name-android: RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app) 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -1,9 +1,9 @@
+- diff --git a/RnDiffApp/android/app/src/main/AndroidManifest.xml b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ diff --git a/CustomIos/android/app/src/main/AndroidManifest.xml b/CustomIos/android/app/src/main/AndroidManifest.xml
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/AndroidManifest.xml
+- +++ b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ --- a/CustomIos/android/app/src/main/AndroidManifest.xml
++ +++ b/CustomIos/android/app/src/main/AndroidManifest.xml
+  @@ -1,8 +1,7 @@
+   <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+- -    package=\\"com.rndiffapp\\">
+- +  package=\\"com.rndiffapp\\">
++ -    package=\\"co.uk.customandroid.app\\">
++ +  package=\\"co.uk.customandroid.app\\">
+  
+@@ -14,6 +14,6 @@
+         android:name=\\".MainApplication\\"
+- diff --git a/RnDiffApp/ios/RnDiffApp/AppDelegate.h b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ diff --git a/CustomIos/ios/CustomIos/AppDelegate.h b/CustomIos/ios/CustomIos/AppDelegate.h
+  index 4b5644f2..2726d5e1 100644
+- --- a/RnDiffApp/ios/RnDiffApp/AppDelegate.h
+- +++ b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ --- a/CustomIos/ios/CustomIos/AppDelegate.h
++ +++ b/CustomIos/ios/CustomIos/AppDelegate.h
+  @@ -5,9 +5,10 @@
+@@ -29,6 +29,6 @@
+   @property (nonatomic, strong) UIWindow *window;
+- diff --git a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ diff --git a/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java b/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
+- +++ b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ --- a/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java
++ +++ b/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java
+  "
 `;

--- a/packages/cli/src/commands/upgrade/__tests__/sample.patch
+++ b/packages/cli/src/commands/upgrade/__tests__/sample.patch
@@ -1,51 +1,33 @@
-diff --git a/RnDiffApp/android/build.gradle b/RnDiffApp/android/build.gradle
-index 85d8f2f8..a1e80854 100644
---- a/RnDiffApp/android/build.gradle
-+++ b/RnDiffApp/android/build.gradle
-@@ -9,8 +9,8 @@ buildscript {
-         supportLibVersion = "27.1.1"
-     }
-     repositories {
--        jcenter()
-         google()
-+        jcenter()
-     }
-     dependencies {
-         classpath 'com.android.tools.build:gradle:3.1.4'
-@@ -23,12 +23,12 @@ buildscript {
- allprojects {
-     repositories {
-         mavenLocal()
-+        google()
-         jcenter()
-         maven {
-             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-             url "$rootDir/../node_modules/react-native/android"
-         }
--        google()
-     }
- }
+diff --git a/RnDiffApp/android/app/src/main/AndroidManifest.xml b/RnDiffApp/android/app/src/main/AndroidManifest.xml
+index bc3a9310..f3e0d155 100644
+--- a/RnDiffApp/android/app/src/main/AndroidManifest.xml
++++ b/RnDiffApp/android/app/src/main/AndroidManifest.xml
+@@ -1,8 +1,7 @@
+ <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+-    package="com.rndiffapp">
++  package="com.rndiffapp">
 
-diff --git a/RnDiffApp/package.json b/RnDiffApp/package.json
-index 4e617645..c82829bd 100644
---- a/RnDiffApp/package.json
-+++ b/RnDiffApp/package.json
-@@ -7,14 +7,14 @@
-     "test": "jest"
-   },
-   "dependencies": {
--    "react": "16.5.0",
--    "react-native": "0.57.0"
-+    "react": "16.6.1",
-+    "react-native": "0.57.7"
-   },
-   "devDependencies": {
-     "babel-jest": "23.6.0",
-     "jest": "23.6.0",
--    "metro-react-native-babel-preset": "0.47.1",
--    "react-test-renderer": "16.5.0"
-+    "metro-react-native-babel-preset": "0.49.2",
-+    "react-test-renderer": "16.6.1"
-   },
-   "jest": {
-     "preset": "react-native"
+     <uses-permission android:name="android.permission.INTERNET" />
+-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+     <application
+       android:name=".MainApplication"
+diff --git a/RnDiffApp/ios/RnDiffApp/AppDelegate.h b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
+index 4b5644f2..2726d5e1 100644
+--- a/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++++ b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
+@@ -5,9 +5,10 @@
+  * LICENSE file in the root directory of this source tree.
+  */
+
++#import <React/RCTBridgeDelegate.h>
+ #import <UIKit/UIKit.h>
+
+-@interface AppDelegate : UIResponder <UIApplicationDelegate>
++@interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
+
+ @property (nonatomic, strong) UIWindow *window;
+diff --git a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
+index bc3a9310..f3e0d155 100644
+--- a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++++ b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -172,7 +172,24 @@ success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
-  await upgrade.func([newVersion], ctx, opts);
+  await upgrade.func(
+    [newVersion],
+    {
+      ...ctx,
+      project: {
+        ...ctx.project,
+        ios: {
+          ...ctx.project.ios,
+          projectName: 'TestApp.xcodeproj',
+        },
+        android: {
+          ...ctx.project.android,
+          packageName: 'com.testapp',
+        },
+      },
+    },
+    opts,
+  );
   expect(flushOutput()).toMatchInlineSnapshot(`
 "info Fetching diff between v0.57.8 and v0.58.4...
 [fs] write tmp-upgrade-rn.patch
@@ -196,7 +213,9 @@ success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the
     snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
       contextLines: 1,
     }),
-  ).toMatchSnapshot('RnDiffApp is replaced with app name (TestApp)');
+  ).toMatchSnapshot(
+    'RnDiffApp is replaced with app name (TestApp and com.testapp)',
+  );
 }, 60000);
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
@@ -267,4 +286,32 @@ info You may find these resources helpful:
 • Comparison between versions: https://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8..version/0.58.4
 • Git diff: https://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8..version/0.58.4.diff"
 `);
+}, 60000);
+test('works with --name-ios and --name-android', async () => {
+  (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
+  await upgrade.func(
+    [newVersion],
+    {
+      ...ctx,
+      project: {
+        ...ctx.project,
+        ios: {
+          ...ctx.project.ios,
+          projectName: 'CustomIos.xcodeproj',
+        },
+        android: {
+          ...ctx.project.android,
+          packageName: 'co.uk.customandroid.app',
+        },
+      },
+    },
+    opts,
+  );
+  expect(
+    snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
+      contextLines: 1,
+    }),
+  ).toMatchSnapshot(
+    'RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app)',
+  );
 }, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -8,6 +8,7 @@ import upgrade from '../upgrade';
 import {fetch} from '../../../tools/fetch';
 import logger from '../../../tools/logger';
 import loadConfig from '../../../tools/config';
+import merge from '../../../tools/merge';
 
 jest.mock('https');
 jest.mock('fs');
@@ -174,20 +175,12 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
   await upgrade.func(
     [newVersion],
-    {
-      ...ctx,
+    merge(ctx, {
       project: {
-        ...ctx.project,
-        ios: {
-          ...ctx.project.ios,
-          projectName: 'TestApp.xcodeproj',
-        },
-        android: {
-          ...ctx.project.android,
-          packageName: 'com.testapp',
-        },
+        ios: {projectName: 'TestApp.xcodeproj'},
+        android: {packageName: 'com.testapp'},
       },
-    },
+    }),
     opts,
   );
   expect(flushOutput()).toMatchInlineSnapshot(`
@@ -291,20 +284,12 @@ test('works with --name-ios and --name-android', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
   await upgrade.func(
     [newVersion],
-    {
-      ...ctx,
+    merge(ctx, {
       project: {
-        ...ctx.project,
-        ios: {
-          ...ctx.project.ios,
-          projectName: 'CustomIos.xcodeproj',
-        },
-        android: {
-          ...ctx.project.android,
-          packageName: 'co.uk.customandroid.app',
-        },
+        ios: {projectName: 'CustomIos.xcodeproj'},
+        android: {packageName: 'co.uk.customandroid.app'},
       },
-    },
+    }),
     opts,
   );
   expect(

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -11,7 +11,7 @@ import {fetch} from '../../tools/fetch';
 import legacyUpgrade from './legacyUpgrade';
 
 type FlagsT = {
-  legacy: boolean,
+  legacy: boolean | void,
 };
 
 const rnDiffPurgeUrl =
@@ -38,11 +38,8 @@ const getRNPeerDeps = async (
   return JSON.parse(stdout);
 };
 
-const getPatch = async (currentVersion, newVersion, projectDir) => {
+const getPatch = async (currentVersion, newVersion, projectDir, config) => {
   let patch;
-
-  const rnDiffAppName = 'RnDiffApp';
-  const {name} = require(path.join(projectDir, 'package.json'));
 
   logger.info(`Fetching diff between v${currentVersion} and v${newVersion}...`);
 
@@ -60,9 +57,32 @@ const getPatch = async (currentVersion, newVersion, projectDir) => {
     return null;
   }
 
-  return patch
-    .replace(new RegExp(rnDiffAppName, 'g'), name)
-    .replace(new RegExp(rnDiffAppName.toLowerCase(), 'g'), name.toLowerCase());
+  let patchWithRenamedProjects = patch;
+
+  // rn-diff-purge only supports iOS and Android platforms
+  if (config.project.ios) {
+    patchWithRenamedProjects = patchWithRenamedProjects.replace(
+      new RegExp('RnDiffApp', 'g'),
+      // $FlowFixMe - poor typings of ProjectConfigIOST
+      config.project.ios.projectName.replace('.xcodeproj', ''),
+    );
+  }
+
+  if (config.project.android) {
+    patchWithRenamedProjects = patchWithRenamedProjects
+      .replace(
+        new RegExp('com\\.rndiffapp', 'g'),
+        // $FlowFixMe - poor typings of ProjectConfigAndroidT
+        config.project.android.packageName,
+      )
+      .replace(
+        new RegExp('com\\.rndiffapp'.split('.').join('/'), 'g'),
+        // $FlowFixMe - poor typings of ProjectConfigAndroidT
+        config.project.android.packageName.split('.').join('/'),
+      );
+  }
+
+  return patchWithRenamedProjects;
 };
 
 const getVersionToUpgradeTo = async (argv, currentVersion, projectDir) => {
@@ -214,7 +234,7 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
     return;
   }
 
-  const patch = await getPatch(currentVersion, newVersion, projectDir);
+  const patch = await getPatch(currentVersion, newVersion, projectDir, ctx);
 
   if (patch === null) {
     return;
@@ -293,7 +313,7 @@ const upgradeCommand = {
   func: upgrade,
   options: [
     {
-      command: '--legacy',
+      command: '--legacy [boolean]',
       description:
         "Legacy implementation. Upgrade your app's template files to the latest version; run this after " +
         'updating the react-native version in your package.json and running npm install',

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -2,7 +2,6 @@
  * @flow
  */
 import path from 'path';
-import deepmerge from 'deepmerge';
 import {mapValues} from 'lodash';
 
 import findDependencies from './findDependencies';
@@ -18,21 +17,12 @@ import {
 import {type ConfigT} from './types.flow';
 
 import assign from '../assign';
-
+import merge from '../merge';
 /**
  * Built-in platforms
  */
 import * as ios from '@react-native-community/cli-platform-ios';
 import * as android from '@react-native-community/cli-platform-android';
-
-/**
- * `deepmerge` concatenates arrays by default instead of overwriting them.
- * We define custom merging function for arrays to change that behaviour
- */
-const merge = (...objs: Object[]) =>
-  deepmerge(...objs, {
-    arrayMerge: (destinationArray, sourceArray, options) => sourceArray,
-  });
 
 /**
  * Loads CLI configuration

--- a/packages/cli/src/tools/config/types.flow.js
+++ b/packages/cli/src/tools/config/types.flow.js
@@ -52,6 +52,7 @@ type ProjectParamsAndroidT = {
   settingsGradlePath?: string,
   assetsPath?: string,
   buildGradlePath?: string,
+  packageName?: string,
 };
 
 /**

--- a/packages/cli/src/tools/merge.js
+++ b/packages/cli/src/tools/merge.js
@@ -1,0 +1,15 @@
+/**
+ * @flow
+ */
+
+import deepmerge from 'deepmerge';
+
+/**
+ * `deepmerge` concatenates arrays by default instead of overwriting them.
+ * We define custom merging function for arrays to change that behaviour
+ */
+export default function merge(...objs: Array<{[key: string]: any}>) {
+  return deepmerge(...objs, {
+    arrayMerge: (destinationArray, sourceArray, options) => sourceArray,
+  });
+}

--- a/packages/platform-android/src/config/index.js
+++ b/packages/platform-android/src/config/index.js
@@ -84,6 +84,7 @@ export function projectConfig(folder, userConfig = {}) {
     settingsGradlePath,
     assetsPath,
     mainFilePath,
+    packageName,
   };
 }
 


### PR DESCRIPTION
Summary:
---------

We can infer package name (for Android) and project name (for iOS) from the config.
This should produce better results than current solution, because we don't need to make assumptions about project name to be synced with package.json.

Supersedes and closes https://github.com/react-native-community/react-native-cli/pull/276
Closes https://github.com/react-native-community/react-native-cli/issues/190

cc @Krizzu, mind testing this branch on your project?


Test Plan:
----------

Added a test
