### PR TITLE
fix: pass maxWorkers arg to server

### DIFF
--- a/packages/cli/src/commands/bundle/buildBundle.js
+++ b/packages/cli/src/commands/bundle/buildBundle.js
@@ -24,6 +24,7 @@ async function buildBundle(
   output: typeof outputBundle = outputBundle,
 ) {
   const config = await loadMetroConfig(ctx, {
+    maxWorkers: args.maxWorkers,
     resetCache: args.resetCache,
     config: args.config,
   });


### PR DESCRIPTION
Summary:
---------

I've noticed that the `max-workers` CLI flag is not behaving as expected for the bundle command.

We need it in one of our CI builds where the container is a bit memory-starved and the default of `numberOfWorkers = numberOfCores` isn't always accurate in a virtualized environment.

This fix ensures the flag makes it to the server config and that the number of node processes reflect the number provided + 1.


Test Plan:
----------

I made a reproduction repo: https://github.com/sterlingwes/rn-cli-repro

The values in the "expected output" reflect the fact:

* i already have a node process running for an unrelated task
* the number of node processes should be `maxWorkersValue + 1`, since there's a parent node process that spawns the child workers

So in the success case, `maxWorkers: 2` would lead to 3 node processes for the RN cli