### PR TITLE
chore: don't apply RN config automatically

### DIFF
--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
@@ -83,6 +83,15 @@ Object {
 }
 `;
 
+exports[`should not add default React Native config when one present 1`] = `
+Array [
+  Object {
+    "func": [Function],
+    "name": "test",
+  },
+]
+`;
+
 exports[`should read \`rnpm\` config from a dependency and transform it to a new format 1`] = `
 Object {
   "assets": Array [],

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -217,3 +217,22 @@ test('should automatically put "react-native" into haste config', () => {
   const {haste} = loadConfig(DIR);
   expect(haste).toMatchSnapshot();
 });
+
+test('should not add default React Native config when one present', () => {
+  writeFiles(DIR, {
+    'node_modules/react-native/package.json': '{}',
+    'node_modules/react-native/react-native.config.js': `module.exports = {
+      commands: [{
+        name: 'test',
+        func: () => {},
+      }]
+    }`,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1"
+      }
+    }`,
+  });
+  const {commands} = loadConfig(DIR);
+  expect(commands).toMatchSnapshot();
+});

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -38,10 +38,18 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
         readLegacyDependencyConfigFromDisk(root) ||
         readDependencyConfigFromDisk(root);
 
-      // @todo: Move this to React Native in the future
+      /**
+       * This workaround is neccessary for development only before
+       * first 0.60.0-rc.0 gets released and we can switch to it
+       * while testing.
+       */
       if (dependencyName === 'react-native') {
-        config.platforms = {ios, android};
-        config.commands = [...ios.commands, ...android.commands];
+        if (Object.keys(config.platforms).length === 0) {
+          config.platforms = {ios, android};
+        }
+        if (config.commands.length === 0) {
+          config.commands = [...ios.commands, ...android.commands];
+        }
       }
 
       const isPlatform = Object.keys(config.platforms).length > 0;


### PR DESCRIPTION
Summary:
---------

Thanks to this change, CLI will not add default React Native configuration when one is present. I can now go to React Native, add the configuration and release it and CLI will pick that one.

The below temporary workaround allows us to run on 0.59, where config is not yet present.
