### PR TITLE
Do not throw on invalid packages

### DIFF
--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
@@ -176,6 +176,6 @@ Object {
 }
 `;
 
-exports[`should skip packages that have invalid configuration 1`] = `Object {}`;
+exports[`should skip packages that have invalid configuration: dependencies config 1`] = `Object {}`;
 
-exports[`should skip packages that have invalid configuration 2`] = `"Package [1mreact-native[22m has been ignored because it contains invalid configuration. Reason: [2mUnknown option invalidProperty with value \\"5\\" was found. This is either a typing error or a user mistake. Fixing it will remove this message.[22m"`;
+exports[`should skip packages that have invalid configuration: logged warning 1`] = `"Package [1mreact-native[22m has been ignored because it contains invalid configuration. Reason: [2mUnknown option invalidProperty with value \\"5\\" was found. This is either a typing error or a user mistake. Fixing it will remove this message.[22m"`;

--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
@@ -175,3 +175,5 @@ Object {
   },
 }
 `;
+
+exports[`should skip packages that have invalid configuration 1`] = `Object {}`;

--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
@@ -177,3 +177,5 @@ Object {
 `;
 
 exports[`should skip packages that have invalid configuration 1`] = `Object {}`;
+
+exports[`should skip packages that have invalid configuration 2`] = `"Package [1mreact-native[22m has been ignored because it contains invalid configuration. Reason: [2mUnknown option invalidProperty with value \\"5\\" was found. This is either a typing error or a user mistake. Fixing it will remove this message.[22m"`;

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -236,3 +236,19 @@ test('should not add default React Native config when one present', () => {
   const {commands} = loadConfig(DIR);
   expect(commands).toMatchSnapshot();
 });
+
+test('should skip packages that have invalid configuration', () => {
+  writeFiles(DIR, {
+    'node_modules/react-native/package.json': '{}',
+    'node_modules/react-native/react-native.config.js': `module.exports = {
+      invalidProperty: 5
+    }`,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1"
+      }
+    }`,
+  });
+  const {dependencies} = loadConfig(DIR);
+  expect(dependencies).toMatchSnapshot();
+});

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -10,6 +10,8 @@ import {
   getTempDirectory,
 } from '../../../../../../jest/helpers';
 
+import {logger} from '@react-native-community/cli-tools';
+
 const DIR = getTempDirectory('resolve_config_path_test');
 
 // Removes string from all key/values within an object
@@ -249,6 +251,8 @@ test('should skip packages that have invalid configuration', () => {
       }
     }`,
   });
+  const spy = jest.spyOn(logger, 'warn');
   const {dependencies} = loadConfig(DIR);
-  expect(dependencies).toMatchSnapshot();
+  expect(dependencies).toMatchSnapshot('dependencies config');
+  expect(spy.mock.calls[0][0]).toMatchSnapshot('logged warning');
 });

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -57,7 +57,7 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
       /**
        * This workaround is neccessary for development only before
        * first 0.60.0-rc.0 gets released and we can switch to it
-       * while
+       * while testing
        */
       if (dependencyName === 'react-native') {
         if (Object.keys(config.platforms).length === 0) {

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -57,7 +57,7 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
       /**
        * This workaround is neccessary for development only before
        * first 0.60.0-rc.0 gets released and we can switch to it
-       * while testing
+       * while testing.
        */
       if (dependencyName === 'react-native') {
         if (Object.keys(config.platforms).length === 0) {

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -3,6 +3,7 @@
  */
 import path from 'path';
 import {mapValues} from 'lodash';
+import chalk from 'chalk';
 
 import findDependencies from './findDependencies';
 import resolveReactNativePath from './resolveReactNativePath';
@@ -23,6 +24,7 @@ import merge from '../merge';
  */
 import * as ios from '@react-native-community/cli-platform-ios';
 import * as android from '@react-native-community/cli-platform-android';
+import {logger, inlineString} from '@react-native-community/cli-tools';
 
 /**
  * Loads CLI configuration
@@ -34,14 +36,28 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
     (acc: ConfigT, dependencyName) => {
       const root = path.join(projectRoot, 'node_modules', dependencyName);
 
-      const config =
-        readLegacyDependencyConfigFromDisk(root) ||
-        readDependencyConfigFromDisk(root);
+      let config;
+      try {
+        config =
+          readLegacyDependencyConfigFromDisk(root) ||
+          readDependencyConfigFromDisk(root);
+      } catch (error) {
+        logger.warn(
+          inlineString(`
+            Package ${chalk.bold(
+              dependencyName,
+            )} has been ignored because it contains invalid configuration.
+
+            Reason: ${chalk.dim(error.message)}
+          `),
+        );
+        return acc;
+      }
 
       /**
        * This workaround is neccessary for development only before
        * first 0.60.0-rc.0 gets released and we can switch to it
-       * while testing.
+       * while
        */
       if (dependencyName === 'react-native') {
         if (Object.keys(config.platforms).length === 0) {

--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -6,6 +6,7 @@
 import Joi from 'joi';
 import cosmiconfig from 'cosmiconfig';
 import path from 'path';
+import chalk from 'chalk';
 
 import {
   type UserDependencyConfigT,
@@ -116,9 +117,9 @@ export function readLegacyDependencyConfigFromDisk(
 
   // @todo: paste a link to documentation that explains the migration steps
   logger.warn(
-    `Package '${path.basename(
-      name,
-    )}' is using deprecated "rnpm" config that will stop working from next release. Consider upgrading to the new config format.`,
+    `Package ${chalk.bold(
+      path.basename(name),
+    )} is using deprecated "rnpm" config that will stop working from next release. Consider upgrading to the new config format.`,
   );
 
   const result = Joi.validate(transformedConfig, schema.dependencyConfig);

--- a/packages/tools/src/errors.js
+++ b/packages/tools/src/errors.js
@@ -26,4 +26,5 @@ export class CLIError extends Error {
   }
 }
 
-export const inlineString = str => str.replace(/(\s{2,})/gm, ' ').trim();
+export const inlineString = (str: string) =>
+  str.replace(/(\s{2,})/gm, ' ').trim();

--- a/packages/tools/src/errors.js
+++ b/packages/tools/src/errors.js
@@ -11,7 +11,7 @@
  */
 export class CLIError extends Error {
   constructor(msg: string, originError?: Error | string) {
-    super(msg.replace(/(\s{2,})/gm, ' ').trim());
+    super(inlineString(msg));
     if (originError) {
       this.stack =
         typeof originError === 'string'
@@ -25,3 +25,5 @@ export class CLIError extends Error {
     }
   }
 }
+
+export const inlineString = str => str.replace(/(\s{2,})/gm, ' ').trim();


### PR DESCRIPTION
Summary:
---------

Some packages can have invalid configuration. Our convention was to throw an error in that case. It is very likely some packages can have invalid configuration (since it was super wild and never standardised), so it's better to simply ignore them and print an appropriate warning. 


Test Plan:
----------

Do a broken configuration for any of your dependencies and run `config`. Package should be excluded.
