### PR TITLE
Add support for assetPlugins argument to start command

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -20,6 +20,7 @@ import loadMetroConfig from '../../tools/loadMetroConfig';
 
 export type Args = {|
   assetExts?: string[],
+  assetPlugins?: string[],
   cert?: string,
   customLogReporterPath?: string,
   host?: string,

--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -54,6 +54,12 @@ async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {
     reporter,
   });
 
+  if (args.assetPlugins) {
+    metroConfig.transformer.assetPlugins = args.assetPlugins.map(plugin =>
+      require.resolve(plugin),
+    );
+  }
+
   const middlewareManager = new MiddlewareManager({
     host: args.host,
     port: metroConfig.server.port,

--- a/packages/cli/src/commands/server/server.js
+++ b/packages/cli/src/commands/server/server.js
@@ -31,6 +31,12 @@ export default {
       parse: (val: string) => val.split(','),
     },
     {
+      command: '--assetPlugins [list]',
+      description:
+        'Specify any additional asset plugins to be used by the packager by full filepath',
+      parse: (val: string) => val.split(','),
+    },
+    {
       command: '--assetExts [list]',
       description:
         'Specify any additional asset extensions to be used by the packager',


### PR DESCRIPTION
Summary:
---------

**This pull request adds support for loading `assetPlugins` through flags to the CLI `start` command.**

This option is probably unknown to you because I don't think anybody uses it except Expo and it happens behind the scenes 😆. In Expo projects we depend on the `assetPlugins` configuration option for the asset system in order to inject the md5 hash for each asset into the asset metadata within AssetRegistry. In the meto versioned used by react-native@0.57, support for `assetPlugins` in the query param for bundles was broken along with a refactor for configuration. In order to ship SDK 31 we patched our fork of react-native to make local-cli always include this plugin (https://github.com/expo/react-native/commit/d41bc86fd9fec9c55ae72bd4cdc1508097f7796b) but now that react-native-cli is a separate package it's a bit more complicated -- plus, a fix to the underlying problem is important too. Additionally, using `assetPlugins` in the bundle URL confused users often as it would appear in their error messages as a red herring.

As a follow up to this pull request I will be doing one of the following:

- Sending a pull request to Metro to change the `loadConfig` function to accept the `assetPlugins` option, which will simplify this in the future.
- OR, depending on discussions with CLI folks, we may want to add the `hashAssetFiles` behavior by default in the CLI. We'll need to discuss it further but I think there is a good argument for why this can be useful in general.

Test Plan:
----------

- Create a project with `react-native init`
- Pull in the code from this patch to your local version of react-native-cli
- Add `md5-file` to your project `yarn add md5-file`
- Create a file called `exampleAssetPlugin.js` in the root of your project, put this in it:

```js
const md5File = require('md5-file/promise');

module.exports = function exampleAssetPlugin(asset) {
  return Promise.all(asset.files.map(md5File)).then(hashes => {
    asset.fileHashes = hashes;
    return asset;
  });
};
```

- Run the project with `yarn start --assetPlugins `pwd`/hashAssetFiles` and add the following code to `App.js` (copy an image there and replace the name below with the name of that image):

```js
import { getAssetByID } from 'react-native/Libraries/Image/AssetRegistry';
alert(JSON.stringify(getAssetByID(require('./some-image-in-your-project.png'))));
```

You will see that the asset metadata now includes the `fileHashes` property with md5 hashes.

Other:
-------

If this lands I will backport it to 1.x so that we can release an update that will work with react-native@0.59.