### PR TITLE
fix: add new line to the help message

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -79,7 +79,7 @@ function printHelpInformation(examples, pkg) {
     output = output.concat([chalk.bold('\nExample usage:'), formattedUsage]);
   }
 
-  return output.concat('').join('\n');
+  return output.join('\n').concat('\n');
 }
 
 function printUnknownCommand(cmdName) {

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -79,7 +79,7 @@ function printHelpInformation(examples, pkg) {
     output = output.concat([chalk.bold('\nExample usage:'), formattedUsage]);
   }
 
-  return output.join('\n');
+  return output.concat('').join('\n');
 }
 
 function printUnknownCommand(cmdName) {


### PR DESCRIPTION
Summary:
---------
There is a problem with the line break of command help as below.

<img width="561" src="https://user-images.githubusercontent.com/3139234/56199103-3484bd80-6077-11e9-9c00-9aa4f45bc185.png">

Test Plan:
----------

Not required.