### PR TITLE
fix: give a better error message when CocoaPods linking fails

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -195,8 +195,8 @@ if $0 == __FILE__
       @podfile.use_native_modules({ "pkg-1" => @ios_package })
       @podfile.use_native_modules({ "pkg-1" => @ios_package, "pkg-2" => @ios_package })
       @printed_messages.must_equal [
-        "Detected native module pod for ios-dep",
-        "Detected native module pods for ios-dep, and ios-dep"
+        "Detected React Native module pod for ios-dep",
+        "Detected React Native module pods for ios-dep, and ios-dep"
       ]
     end
 

--- a/packages/platform-ios/src/link-pods/findLineToAddPod.js
+++ b/packages/platform-ios/src/link-pods/findLineToAddPod.js
@@ -15,7 +15,7 @@ export default function findLineToAddPod(podLines, firstTargetLine) {
   // match function definition, like: post_install do |installer| (some Podfiles have function defined inside main target
   const functionDefinition = /^\s*[a-z_]+\s+do(\s+\|[a-z]+\|)?/g;
 
-  for (let i = firstTargetLine, len = podLines.length; i < len; i++) {
+  for (let i = firstTargetLine; i < podLines.length - 1; i++) {
     const matchNextConstruct =
       podLines[i].match(nextTarget) || podLines[i].match(functionDefinition);
     const matchEnd = podLines[i].match(endOfCurrentTarget);

--- a/packages/platform-ios/src/link-pods/findMarkedLinesInPodfile.js
+++ b/packages/platform-ios/src/link-pods/findMarkedLinesInPodfile.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-const MARKER_TEXT = '# Add new pods below this line';
+export const MARKER_TEXT = '# Add new pods below this line';
 
 export default function findMarkedLinesInPodfile(podLines) {
   const result = [];

--- a/packages/platform-ios/src/link-pods/findPodTargetLine.js
+++ b/packages/platform-ios/src/link-pods/findPodTargetLine.js
@@ -8,7 +8,6 @@
  */
 
 export default function findPodTargetLine(podLines, projectName) {
-  console.log(projectName);
   const targetName = projectName.replace('.xcodeproj', '');
   // match first target definition in file: target 'target_name' do
   const targetRegex = new RegExp(`target ('|")${targetName}('|") do`, 'g');

--- a/packages/platform-ios/src/link-pods/findPodTargetLine.js
+++ b/packages/platform-ios/src/link-pods/findPodTargetLine.js
@@ -8,6 +8,7 @@
  */
 
 export default function findPodTargetLine(podLines, projectName) {
+  console.log(projectName);
   const targetName = projectName.replace('.xcodeproj', '');
   // match first target definition in file: target 'target_name' do
   const targetRegex = new RegExp(`target ('|")${targetName}('|") do`, 'g');

--- a/packages/platform-ios/src/link-pods/registerNativeModule.js
+++ b/packages/platform-ios/src/link-pods/registerNativeModule.js
@@ -40,7 +40,7 @@ function getLinesToAddEntry(podLines, {projectName}) {
       inlineString(`
         We couldn't find a target to add a CocoaPods dependency.
         
-        Make sure that you have a ${chalk.bold(
+        Make sure that you have a ${chalk.dim(
           `target '${projectName.replace('.xcodeproj', '')}' do`,
         )} line in your Podfile.
         

--- a/packages/platform-ios/src/link-pods/registerNativeModule.js
+++ b/packages/platform-ios/src/link-pods/registerNativeModule.js
@@ -6,11 +6,15 @@
  *
  * @format
  */
+import chalk from 'chalk';
+import {CLIError, inlineString} from '@react-native-community/cli-tools';
 
 import readPodfile from './readPodfile';
 import findPodTargetLine from './findPodTargetLine';
 import findLineToAddPod from './findLineToAddPod';
-import findMarkedLinesInPodfile from './findMarkedLinesInPodfile';
+import findMarkedLinesInPodfile, {
+  MARKER_TEXT,
+} from './findMarkedLinesInPodfile';
 import addPodEntry from './addPodEntry';
 import savePodFile from './savePodFile';
 
@@ -31,5 +35,21 @@ function getLinesToAddEntry(podLines, {projectName}) {
     return linesToAddPodWithMarker;
   }
   const firstTargetLined = findPodTargetLine(podLines, projectName);
+  if (firstTargetLined === null) {
+    throw new CLIError(
+      inlineString(`
+        We couldn't find a target to add a CocoaPods dependency.
+        
+        Make sure that you have a ${chalk.bold(
+          `target '${projectName.replace('.xcodeproj', '')}' do`,
+        )} line in your Podfile.
+        
+        Alternatively, include ${chalk.dim(
+          MARKER_TEXT,
+        )} in a Podfile where we should add
+        linked dependencies.
+    `),
+    );
+  }
   return findLineToAddPod(podLines, firstTargetLined);
 }

--- a/packages/platform-ios/src/link-pods/registerNativeModule.js
+++ b/packages/platform-ios/src/link-pods/registerNativeModule.js
@@ -40,13 +40,13 @@ function getLinesToAddEntry(podLines, {projectName}) {
       inlineString(`
         We couldn't find a target to add a CocoaPods dependency.
         
-        Make sure that you have a ${chalk.dim(
+        Make sure that you have a "${chalk.dim(
           `target '${projectName.replace('.xcodeproj', '')}' do`,
-        )} line in your Podfile.
+        )}" line in your Podfile.
         
-        Alternatively, include ${chalk.dim(
+        Alternatively, include "${chalk.dim(
           MARKER_TEXT,
-        )} in a Podfile where we should add
+        )}" in a Podfile where we should add
         linked dependencies.
     `),
     );


### PR DESCRIPTION
Summary:
---------

Right now, when Podfile doesn't have a market text or the target name is different, link fails with a cryptic message. This adds an explicit error message.

Fixes #273 

Test Plan:
----------

Use a Podfile w/o market text and change the name of the target. See the error happen.