### PR TITLE
fix: prevent run-android failure when updating APK

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -166,9 +166,9 @@ function tryInstallAppOnDevice(args, adbPath, device) {
     );
 
     const pathToApk = `${buildDirectory}/${apkFile}`;
-    const adbArgs = ['-s', device, 'install', pathToApk];
+    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
     logger.info(
-      `Installing the app on the device (cd android && adb -s ${device} install ${pathToApk}`,
+      `Installing the app on the device (cd android && adb -s ${device} install -r -d ${pathToApk}`,
     );
     execFileSync(adbPath, adbArgs, {
       stdio: [process.stdin, process.stdout, process.stderr],

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -166,9 +166,9 @@ function tryInstallAppOnDevice(args, adbPath, device) {
     );
 
     const pathToApk = `${buildDirectory}/${apkFile}`;
-    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
+    const adbArgs = ['-s', device, 'install', '-rd', pathToApk];
     logger.info(
-      `Installing the app on the device (cd android && adb -s ${device} install -r -d ${pathToApk}`,
+      `Installing the app on the device (cd android && adb -s ${device} install -rd ${pathToApk}`,
     );
     execFileSync(adbPath, adbArgs, {
       stdio: [process.stdin, process.stdout, process.stderr],


### PR DESCRIPTION
Summary:
---------

If we run `react-native run-android` while it's already installed, it will fail with the following error.

```bash
info Installing the app on the device (cd android && adb -s emulator-5554 install app/build/outputs/apk/debug/app-x86-debug.apk
adb: failed to install app/build/outputs/apk/debug/app-x86-debug.apk: Failure [INSTALL_FAILED_ALREADY_EXISTS: Attempt to re-install me.mycake without first uninstalling.]
```

In the development phase, I think using adb's install options below is much more efficient.

```
-r : Reinstall an existing app, keeping its data.
-d : Allow version code downgrade.
```


Test Plan:
----------

Not required.
