### PR TITLE
fix: prevent unnecessary actions if build failed

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -22,6 +22,7 @@ import {
   isPackagerRunning,
   logger,
   getDefaultUserTerminal,
+  CLIError,
 } from '@react-native-community/cli-tools';
 
 // Verifies this is an Android project
@@ -120,10 +121,7 @@ function runOnSpecificDevice(
   const devices = adb.getDevices(adbPath);
   if (devices && devices.length > 0) {
     if (devices.indexOf(args.deviceId) !== -1) {
-      if (!buildApk(gradlew)) {
-        return;
-      }
-
+      buildApk(gradlew);
       installAndLaunchOnDevice(
         args,
         args.deviceId,
@@ -152,13 +150,12 @@ function buildApk(gradlew) {
     execFileSync(gradlew, ['build', '-x', 'lint'], {
       stdio: [process.stdin, process.stdout, process.stderr],
     });
-
-    return true;
-  } catch (e) {
-    logger.error('Could not build the app, read the error above for details.');
+  } catch (error) {
+    throw new CLIError(
+      'Could not build the app, read the error above for details',
+      error,
+    );
   }
-
-  return false;
 }
 
 function tryInstallAppOnDevice(args, adbPath, device) {

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -120,7 +120,10 @@ function runOnSpecificDevice(
   const devices = adb.getDevices(adbPath);
   if (devices && devices.length > 0) {
     if (devices.indexOf(args.deviceId) !== -1) {
-      buildApk(gradlew);
+      if (!buildApk(gradlew)) {
+        return;
+      }
+
       installAndLaunchOnDevice(
         args,
         args.deviceId,
@@ -149,9 +152,13 @@ function buildApk(gradlew) {
     execFileSync(gradlew, ['build', '-x', 'lint'], {
       stdio: [process.stdin, process.stdout, process.stderr],
     });
+
+    return true;
   } catch (e) {
     logger.error('Could not build the app, read the error above for details.');
   }
+
+  return false;
 }
 
 function tryInstallAppOnDevice(args, adbPath, device) {


### PR DESCRIPTION
Summary:
---------

```bash
react-native run-android --deviceId=emulator-5554
```

If the build fails, the APK that was built before is installed and executed.

```bash
BUILD FAILED in 5s
320 actionable tasks: 5 executed, 315 up-to-date
error Could not build the app, read the error above for details.
info Running /Users/snow/Library/Android/sdk/platform-tools/adb -s emulator-5554 reverse tcp:8081 tcp:8081
error Not found the correct install APK file!
Could not install the app on the device, read the error above for details.
info Starting the app on emulator-5554 (/Users/snow/Library/Android/sdk/platform-tools/adb -s emulator-5554 shell am start -n me.mycake/me.mycake.MainActivity)...
Starting: Intent { cmp=me.mycake/.MainActivity }
Warning: Activity not started, its current task has been brought to the front
```

I think this is unnecessary. I'm sure execution should be stopped so that we can immediately recognize and face on the error condition, as shown below.

```bash
BUILD FAILED in 4s
320 actionable tasks: 5 executed, 315 up-to-date
error Could not build the app, read the error above for details.
```

Test Plan:
----------

Not required.
