### PR TITLE
fix: publish native_modules.rb file

### DIFF
--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -8,6 +8,7 @@
     "xcode": "^2.0.0"
   },
   "files": [
-    "build"
+    "build",
+    "native_modules.rb"
   ]
 }


### PR DESCRIPTION
Summary:
---------

We forgot to put it in publish list in #256 

Test Plan:
----------

`npm pack` sees it now
