### PR TITLE
Check `ios-deploy` installation before proceeding to build on device

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -191,7 +191,7 @@ async function runOnSimulator(xcodeProject, scheme, args: FlagsT) {
 
 async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
   const isIOSDeployInstalled = child_process.spawnSync(
-    'ioxs-deploy',
+    'ios-deploy',
     ['--version'],
     {encoding: 'utf8'},
   );

--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -191,16 +191,17 @@ async function runOnSimulator(xcodeProject, scheme, args: FlagsT) {
 
 async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
   const isIOSDeployInstalled = child_process.spawnSync(
-    'ios-deploy',
+    'ioxs-deploy',
     ['--version'],
     {encoding: 'utf8'},
   );
 
   if (isIOSDeployInstalled.error) {
-    throw new Error(`Failed to install the app on the device because we couldn't execute the "ios-deploy" command.
-      Please install it by running "${chalk.bold(
+    throw new CLIError(
+      `Failed to install the app on the device because we couldn't execute the "ios-deploy" command. Please install it by running "${chalk.bold(
         'npm install -g ios-deploy',
-      )}" and try again.`);
+      )}" and try again.`,
+    );
   }
 
   const appName = await buildProject(
@@ -227,11 +228,14 @@ async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
   );
 
   if (iosDeployOutput.error) {
-    throw new Error(`Failed to install the app on the device. We've encountered an error in "ios-deploy" command.
-      Here are more details: ${isIOSDeployInstalled.error.message}`);
+    throw new CLIError(
+      `Failed to install the app on the device. We've encountered an error in "ios-deploy" command: ${
+        iosDeployOutput.error.message
+      }`,
+    );
   }
 
-  return logger.info('App installed on device.');
+  return logger.success('Installed the app on the device.');
 }
 
 function buildProject(xcodeProject, udid, scheme, args: FlagsT) {

--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -190,6 +190,18 @@ async function runOnSimulator(xcodeProject, scheme, args: FlagsT) {
 }
 
 async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
+  const isIOSDeployInstalled = child_process.spawnSync(
+    'ios-deploy',
+    ['--version'],
+    {encoding: 'utf8'},
+  );
+
+  if (isIOSDeployInstalled.error) {
+    return logger.error(
+      '** INSTALLATION FAILED **\nMake sure you have ios-deploy installed globally.\n(e.g "npm install -g ios-deploy")',
+    );
+  }
+
   const appName = await buildProject(
     xcodeProject,
     selectedDevice.udid,
@@ -214,12 +226,12 @@ async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
   );
 
   if (iosDeployOutput.error) {
-    logger.error(
-      '** INSTALLATION FAILED **\nMake sure you have ios-deploy installed globally.\n(e.g "npm install -g ios-deploy")',
+    return logger.error(
+      '** INSTALLATION FAILED **\nThere was an internal error with ios-deploy.',
     );
-  } else {
-    logger.info('** INSTALLATION SUCCEEDED **');
   }
+
+  return logger.info('** INSTALLATION SUCCEEDED **');
 }
 
 function buildProject(xcodeProject, udid, scheme, args: FlagsT) {

--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -197,9 +197,10 @@ async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
   );
 
   if (isIOSDeployInstalled.error) {
-    return logger.error(
-      '** INSTALLATION FAILED **\nMake sure you have ios-deploy installed globally.\n(e.g "npm install -g ios-deploy")',
-    );
+    throw new Error(`Failed to install the app on the device because we couldn't execute the "ios-deploy" command.
+      Please install it by running "${chalk.bold(
+        'npm install -g ios-deploy',
+      )}" and try again.`);
   }
 
   const appName = await buildProject(
@@ -226,12 +227,11 @@ async function runOnDevice(selectedDevice, scheme, xcodeProject, args: FlagsT) {
   );
 
   if (iosDeployOutput.error) {
-    return logger.error(
-      '** INSTALLATION FAILED **\nThere was an internal error with ios-deploy.',
-    );
+    throw new Error(`Failed to install the app on the device. We've encountered an error in "ios-deploy" command.
+      Here are more details: ${isIOSDeployInstalled.error.message}`);
   }
 
-  return logger.info('** INSTALLATION SUCCEEDED **');
+  return logger.info('App installed on device.');
 }
 
 function buildProject(xcodeProject, udid, scheme, args: FlagsT) {


### PR DESCRIPTION
Summary:
---------

This PR fixes #330, it checks if `ios-deploy` is installed or not before it actually starts building.

Test Plan:
----------

- Run `npm uninstall -g ios-deploy`;
- Run the CLI with `--device` argument and wait for it to fail;
- Run `npm i -g ios-deploy`;
- Run the CLI again and see it working.

cc @thymikee

---

### Error about `ios-deploy` not installed
![image](https://user-images.githubusercontent.com/6207220/56423345-e7d5f800-62ab-11e9-9acf-e5336685904a.png)

### Random error when executing `ios-deploy`
![image](https://user-images.githubusercontent.com/6207220/56423377-12c04c00-62ac-11e9-863a-82c12800893a.png)

