### PR TITLE
Support functions in default

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -125,7 +125,7 @@ const addCommand = (command: CommandT, ctx: ConfigT) => {
       opt.command,
       opt.description,
       opt.parse || defaultOptParser,
-      opt.default,
+      typeof opt.default === 'function' ? opt.default(ctx) : opt.default,
     ),
   );
 };

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -22,7 +22,9 @@ const command = t.object({
       command: t.string().required(),
       description: t.string(),
       parse: t.func(),
-      default: t.alternatives().try([t.bool(), t.number(), t.string()]),
+      default: t
+        .alternatives()
+        .try([t.bool(), t.number(), t.string(), t.func()]),
     }),
   ),
   examples: t.array().items(

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -362,7 +362,7 @@ export default {
       command: '--terminal [string]',
       description:
         'Launches the Metro Bundler in a new window using the specified terminal path.',
-      default: getDefaultUserTerminal(),
+      default: getDefaultUserTerminal,
     },
   ],
 };

--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -452,7 +452,7 @@ export default {
       command: '--terminal [string]',
       description:
         'Launches the Metro Bundler in a new window using the specified terminal path.',
-      default: getDefaultUserTerminal(),
+      default: getDefaultUserTerminal,
     },
   ],
 };

--- a/types/index.js
+++ b/types/index.js
@@ -10,7 +10,11 @@ export type CommandT = {
     command: string,
     description?: string,
     parse?: (val: string) => any,
-    default?: string | boolean | number,
+    default?:
+      | string
+      | boolean
+      | number
+      | ((ctx: ConfigT) => string | boolean | number),
   }>,
   examples?: Array<{
     desc: string,


### PR DESCRIPTION
Summary:
---------

I was pretty sure this has landed, but turns out - I've never merged the PR: https://github.com/react-native-community/cli/pull/287/files#diff-97059d274ee5d7bbcc5730ddee2a98daR126 

This change is needed to support functions as defaults (lazily called with config to get a default value) - we will need that in other commands in the future.

I am also moving current `getDefaultUserTerminal` to be executed lazily. That way, the value of `default` is a function and it passes the validation.