### PR TITLE
feat: Improve configuration when project is a dependency too

### DIFF
--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -20,21 +20,18 @@ import * as schema from './schema';
 
 import {logger} from '@react-native-community/cli-tools';
 
-/**
- * Places to look for the new configuration
- */
-const searchPlaces = ['react-native.config.js', 'package.json'];
+const CONFIG_NAME = 'react-native.config.js';
 
 /**
  * Reads a project configuration as defined by the user in the current
  * workspace.
  */
 export function readConfigFromDisk(rootFolder: string): UserConfigT {
-  const explorer = cosmiconfig('react-native', {searchPlaces});
+  const config = require(path.join(rootFolder, CONFIG_NAME));
 
-  const {config} = explorer.searchSync(rootFolder) || {config: undefined};
-
-  const result = Joi.validate(config, schema.projectConfig);
+  const result = Joi.validate(config, schema.projectConfig, {
+    stripUnknown: true,
+  });
 
   if (result.error) {
     throw new JoiError(result.error);
@@ -50,14 +47,11 @@ export function readConfigFromDisk(rootFolder: string): UserConfigT {
 export function readDependencyConfigFromDisk(
   rootFolder: string,
 ): UserDependencyConfigT {
-  const explorer = cosmiconfig('react-native', {
-    stopDir: rootFolder,
-    searchPlaces,
+  const config = require(path.join(rootFolder, CONFIG_NAME));
+
+  const result = Joi.validate(config, schema.dependencyConfig, {
+    stripUnknown: true,
   });
-
-  const {config} = explorer.searchSync(rootFolder) || {config: undefined};
-
-  const result = Joi.validate(config, schema.dependencyConfig);
 
   if (result.error) {
     throw new JoiError(result.error);

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -40,42 +40,23 @@ const command = t.object({
  */
 export const dependencyConfig = t
   .object({
-    dependency: t
-      .object({
-        platforms: map(t.string(), t.any())
-          .keys({
-            ios: t
-              .object({
-                project: t.string(),
-                sharedLibraries: t.array().items(t.string()),
-                libraryFolder: t.string(),
-              })
-              .default({}),
-            android: t
-              .object({
-                sourceDir: t.string(),
-                manifestPath: t.string(),
-                packageImportPath: t.string(),
-                packageInstance: t.string(),
-              })
-              .default({}),
+    dependency: map(t.string(), t.any())
+      .keys({
+        ios: t
+          .object({
+            project: t.string(),
+            sharedLibraries: t.array().items(t.string()),
+            libraryFolder: t.string(),
           })
-          .default(),
-        assets: t
-          .array()
-          .items(t.string())
-          .default([]),
-        hooks: map(t.string(), t.string()).default({}),
-        params: t
-          .array()
-          .items(
-            t.object({
-              name: t.string(),
-              type: t.string(),
-              message: t.string(),
-            }),
-          )
-          .default([]),
+          .default({}),
+        android: t
+          .object({
+            sourceDir: t.string(),
+            manifestPath: t.string(),
+            packageImportPath: t.string(),
+            packageInstance: t.string(),
+          })
+          .default({}),
       })
       .default(),
     platforms: map(
@@ -89,6 +70,21 @@ export const dependencyConfig = t
     commands: t
       .array()
       .items(command)
+      .default([]),
+    assets: t
+      .array()
+      .items(t.string())
+      .default([]),
+    hooks: map(t.string(), t.string()).default({}),
+    params: t
+      .array()
+      .items(
+        t.object({
+          name: t.string(),
+          type: t.string(),
+          message: t.string(),
+        }),
+      )
       .default([]),
   })
   .default();
@@ -165,10 +161,6 @@ export const projectConfig = t
     assets: t
       .array()
       .items(t.string())
-      .default([]),
-    commands: t
-      .array()
-      .items(command)
       .default([]),
   })
   .default();

--- a/types/index.js
+++ b/types/index.js
@@ -171,15 +171,19 @@ export type PlatformsT = $PropertyType<ConfigT, 'platforms'>;
 export type UserDependencyConfigT = {
   // Additional dependency settings
   dependency: {
-    platforms: {
-      android: DependencyParamsAndroidT,
-      ios: ProjectParamsIOST,
-      [key: string]: any,
-    },
-    assets: string[],
-    hooks: HooksT,
-    params: InquirerPromptT[],
+    android: DependencyParamsAndroidT,
+    ios: ProjectParamsIOST,
+    [key: string]: any,
   },
+
+  // An array of assets
+  assets: string[],
+
+  // Hooks
+  hooks: HooksT,
+
+  // Params that dependency wants to ask during linking
+  params: InquirerPromptT[],
 
   // An array of commands that ship with the dependency
   commands: CommandT[],


### PR DESCRIPTION
Summary:
---------

This PR does few things I've observed while working on a React Native integration right now. React Native is a special case, because it's a project that can be a dependency too. What does it mean? When you run `react-native start` from a project, React Native is your dependency that adds iOS and Android platforms to the CLI. However, when you run from inside React Native (e.g. to check RNTester), React Native is your project. This PR brings back a 1.x feature, so that CLI will attempt reading dependency configuration in such case too, assuming we might be running from source (or having inline platforms/commands bundled with the app).

Outline:
- Allow project to have both project configuration and dependency configuration at the same time. That way, when you run `RNTester` from inside a project that exports a platform, CLI will pick it automatically. That was the original design goal, but I haven't implemented it before. It also cleans up the `projectConfig` a bit, because it removes `platforms` and `commands` from it and moves them to a `dependencyConfig`.
- Since project can now have dependency config too, I removed `commands` property from a project since its defined on a dependency already.
- I also removed `dependency.platforms` to just `dependency` to align it with `project`. 
- Added `stripUnknown` flag to Joi, so that single `react-native.config.js` can have both configs (projectConfig schema will treat dependencyConfig schema keys as unknown, so this prevents that behaviour).
