### PR TITLE
feat: support platforms that ship with project 

### DIFF
--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -124,7 +124,7 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
       get assets() {
         return findAssets(projectRoot, userConfig.assets);
       },
-      platforms: {},
+      platforms: userConfig.platforms,
       haste: {
         providesModuleNodeModules: [],
         platforms: [],

--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -34,9 +34,7 @@ export function readConfigFromDisk(rootFolder: string): UserConfigT {
 
   const {config} = explorer.searchSync(rootFolder) || {config: undefined};
 
-  const result = Joi.validate(config, schema.projectConfig, {
-    stripUnknown: true,
-  });
+  const result = Joi.validate(config, schema.projectConfig);
 
   if (result.error) {
     throw new JoiError(result.error);
@@ -59,9 +57,7 @@ export function readDependencyConfigFromDisk(
 
   const {config} = explorer.searchSync(rootFolder) || {config: undefined};
 
-  const result = Joi.validate(config, schema.dependencyConfig, {
-    stripUnknown: true,
-  });
+  const result = Joi.validate(config, schema.dependencyConfig);
 
   if (result.error) {
     throw new JoiError(result.error);

--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -34,7 +34,9 @@ export function readConfigFromDisk(rootFolder: string): UserConfigT {
 
   const {config} = explorer.searchSync(rootFolder) || {config: undefined};
 
-  const result = Joi.validate(config, schema.projectConfig);
+  const result = Joi.validate(config, schema.projectConfig, {
+    stripUnknown: true,
+  });
 
   if (result.error) {
     throw new JoiError(result.error);
@@ -57,7 +59,9 @@ export function readDependencyConfigFromDisk(
 
   const {config} = explorer.searchSync(rootFolder) || {config: undefined};
 
-  const result = Joi.validate(config, schema.dependencyConfig);
+  const result = Joi.validate(config, schema.dependencyConfig, {
+    stripUnknown: true,
+  });
 
   if (result.error) {
     throw new JoiError(result.error);

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -85,7 +85,7 @@ export const dependencyConfig = t
         projectConfig: t.func(),
         linkConfig: t.func(),
       }),
-    ).default(),
+    ).default({}),
     commands: t
       .array()
       .items(command)
@@ -170,5 +170,13 @@ export const projectConfig = t
       .array()
       .items(command)
       .default([]),
+    platforms: map(
+      t.string(),
+      t.object({
+        dependencyConfig: t.func(),
+        projectConfig: t.func(),
+        linkConfig: t.func(),
+      }),
+    ).default({}),
   })
   .default();

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -91,6 +91,7 @@ export const dependencyConfig = t
       .items(command)
       .default([]),
   })
+  .unknown(true)
   .default();
 
 /**
@@ -179,4 +180,5 @@ export const projectConfig = t
       }),
     ).default({}),
   })
+  .unknown(true)
   .default();

--- a/types/index.js
+++ b/types/index.js
@@ -195,7 +195,7 @@ export type UserDependencyConfigT = {
  */
 export type UserConfigT = {
   /**
-   * Shares some structure with ConfigT, except that haste, root, platforms
+   * Shares some structure with ConfigT, except that haste and root
    * are calculated and can't be defined
    */
   ...$Diff<ConfigT, {haste: any, root: any}>,

--- a/types/index.js
+++ b/types/index.js
@@ -198,7 +198,7 @@ export type UserConfigT = {
    * Shares some structure with ConfigT, except that haste, root, platforms
    * are calculated and can't be defined
    */
-  ...$Diff<ConfigT, {haste: any, root: any, platforms: any}>,
+  ...$Diff<ConfigT, {haste: any, root: any}>,
   reactNativePath: ?string,
 
   // Additional project settings


### PR DESCRIPTION
Summary:
---------

React Native (and other packages) can define commands and platforms to be picked by the CLI. When running from source, they are treated as `project`, not as a `dependency`, hence `platforms` are ignored.

This adds support for `platforms` to be defined on per `project` basis too.

Added `stripUnknown` so they can co-exist.

TLDR; Nothing changes, but `Joi` validator will not strip it out now.