### PR TITLE
fix: read `haste` configuration from legacy config

### DIFF
--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.js.snap
@@ -93,7 +93,7 @@ Array [
 ]
 `;
 
-exports[`should read \`rnpm\` config from a dependency and transform it to a new format 1`] = `
+exports[`should read \`rnpm\` config from a dependency and transform it to a new format: foo config 1`] = `
 Object {
   "assets": Array [],
   "hooks": Object {},
@@ -115,6 +115,20 @@ Object {
     },
   },
   "root": "<<REPLACED>>/node_modules/react-native-foo",
+}
+`;
+
+exports[`should read \`rnpm\` config from a dependency and transform it to a new format: haste config 1`] = `
+Object {
+  "platforms": Array [
+    "ios",
+    "android",
+    "dummy",
+  ],
+  "providesModuleNodeModules": Array [
+    "react-native",
+    "react-native-dummy",
+  ],
 }
 `;
 

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -130,6 +130,10 @@ test('should read `rnpm` config from a dependency and transform it to a new form
       "rnpm": {
         "ios": {
           "project": "./customLocation/customProject.xcodeproj"
+        },
+        "haste": {
+          "platforms": ["dummy"],
+          "providesModuleNodeModules": ["react-native-dummy"]
         }
       }
     }`,
@@ -140,8 +144,11 @@ test('should read `rnpm` config from a dependency and transform it to a new form
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
-  expect(removeString(dependencies['react-native-foo'], DIR)).toMatchSnapshot();
+  const {dependencies, haste} = loadConfig(DIR);
+  expect(removeString(dependencies['react-native-foo'], DIR)).toMatchSnapshot(
+    'foo config',
+  );
+  expect(haste).toMatchSnapshot('haste config');
 });
 
 test('should load commands from "react-native-foo" and "react-native-bar" packages', () => {

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -70,6 +70,17 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
 
       const isPlatform = Object.keys(config.platforms).length > 0;
 
+      /**
+       * Legacy `rnpm` config required `haste` to be defined. With new config,
+       * we do it automatically.
+       *
+       * Remove this once `rnpm` config is deprecated.
+       */
+      const haste = config.haste || {
+        providesModuleNodeModules: isPlatform ? [dependencyName] : [],
+        platforms: Object.keys(config.platforms),
+      };
+
       return assign({}, acc, {
         dependencies: assign({}, acc.dependencies, {
           // $FlowExpectedError: Dynamic getters are not supported
@@ -105,10 +116,11 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
           ...config.platforms,
         },
         haste: {
-          providesModuleNodeModules: acc.haste.providesModuleNodeModules.concat(
-            isPlatform ? dependencyName : [],
-          ),
-          platforms: [...acc.haste.platforms, ...Object.keys(config.platforms)],
+          providesModuleNodeModules: [
+            ...acc.haste.providesModuleNodeModules,
+            ...haste.providesModuleNodeModules,
+          ],
+          platforms: [...acc.haste.platforms, ...haste.platforms],
         },
       });
     },

--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -109,6 +109,7 @@ export function readLegacyDependencyConfigFromDisk(
       hooks: config.commands,
       params: config.params,
     },
+    haste: config.haste,
     commands: loadProjectCommands(rootFolder, config.plugin),
     platforms: config.platform
       ? require(path.join(rootFolder, config.platform))

--- a/types/index.js
+++ b/types/index.js
@@ -188,6 +188,12 @@ export type UserDependencyConfigT = {
   platforms: {
     [name: string]: any,
   },
+
+  // Haste config defined by legacy `rnpm`
+  haste?: {
+    platforms: string[],
+    providesModuleNodeModules: string[],
+  },
 };
 
 /**


### PR DESCRIPTION
Summary:
---------

While doing new configuration, we've decided we can actually infer `haste` config as it's just repeated information in 99,9% use-cases.

Unfortunately, `react-native-dummy` (and could be others in the future), defines just [that](https://github.com/react-native-community/react-native-dummy/blob/master/package.json). As a result, React Native tests break.

This PR uses `haste` value and when empty, it infers the values. To be changed in the future.