### PR TITLE
fix: modify wrong install arguments

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -173,9 +173,9 @@ function tryInstallAppOnDevice(args, adbPath, device) {
     );
 
     const pathToApk = `${buildDirectory}/${apkFile}`;
-    const adbArgs = ['-s', device, 'install', '-rd', pathToApk];
+    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
     logger.info(
-      `Installing the app on the device (cd android && adb -s ${device} install -rd ${pathToApk}`,
+      `Installing the app on the device (cd android && adb -s ${device} install -r -d ${pathToApk}`,
     );
     execFileSync(adbPath, adbArgs, {
       stdio: [process.stdin, process.stdout, process.stderr],


### PR DESCRIPTION
Summary:
---------

In the previous PR(#323), the code was modified with the following comment.

```
@Krizzu
You can also combine arguments -rd, but it's up to you
```

But, I realized that this arguments does not work.

```bash
adb -s ce021712cad7e8990c install -rd test.apk
adb: failed to install test.apk:
Exception occurred while dumping:
java.lang.IllegalArgumentException: No argument expected after "-rd"
```

So, I modified it to divide the arguments.

Test Plan:
----------

Not required.