### PR TITLE
fix: [android][linking] Remove deprecated task syntax

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -232,8 +232,10 @@ ext.applyNativeModulesAppBuildGradle = { Project project ->
     applicationId = [variant.mergedFlavor.applicationId, variant.buildType.applicationIdSuffix].findAll().join()
   }
 
-  task generatePackageList << {
-    autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate, applicationId)
+  task generatePackageList {
+    doLast {
+      autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate, applicationId)
+    }
   }
 
   preBuild.dependsOn generatePackageList


### PR DESCRIPTION
Summary:
---------

Gradle 5 no longer supports the `<<` syntax - swapped to the non-shorthand syntax of `doLast {}`

Test Plan:
----------

Builds successfully with the updated syntax and `PackageList.java` file generated

![image](https://user-images.githubusercontent.com/5347038/56444115-57b9a200-62ef-11e9-94bc-16818c33e65e.png)

![image](https://user-images.githubusercontent.com/5347038/56444122-5f794680-62ef-11e9-962a-5beb06e90667.png)
