### PR TITLE
[android] remove forward slashes from package name

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -82,10 +82,10 @@ class ReactNativeModules {
    */
   void addReactNativeModuleProjects() {
     reactNativeModules.forEach { reactNativeModule ->
-      String name = reactNativeModule["name"]
+      String nameCleansed = reactNativeModule["nameCleansed"]
       String androidSourceDir = reactNativeModule["androidSourceDir"]
-      defaultSettings.include(":${name}")
-      defaultSettings.project(":${name}").projectDir = new File("${androidSourceDir}")
+      defaultSettings.include(":${nameCleansed}")
+      defaultSettings.project(":${nameCleansed}").projectDir = new File("${androidSourceDir}")
     }
   }
 
@@ -94,10 +94,10 @@ class ReactNativeModules {
    */
   void addReactNativeModuleDependencies() {
     reactNativeModules.forEach { reactNativeModule ->
-      def name = reactNativeModule["name"]
+      def nameCleansed = reactNativeModule["nameCleansed"]
       project.dependencies {
         // TODO(salakar): are other dependency scope methods such as `api` required?
-        implementation project(path: ":${name}")
+        implementation project(path: ":${nameCleansed}")
       }
     }
   }
@@ -196,6 +196,7 @@ class ReactNativeModules {
 
         HashMap reactNativeModuleConfig = new HashMap<String, String>()
         reactNativeModuleConfig.put("name", name)
+        reactNativeModuleConfig.put("nameCleansed", name.replaceAll('/', '_'))
         reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
         reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])


### PR DESCRIPTION

Summary:
---------

The previous CLI config use to return names with `/`'s replaced with `_`'s - it no longer does this so I've moved the replacing logic into the auto-linking build script so as to avoid breaking on Gradle 5+:
![image](https://user-images.githubusercontent.com/5347038/56455870-2b883a80-635c-11e9-90ef-53f00282391f.png)


Test Plan:
----------

After change build no longer fails:

![image](https://user-images.githubusercontent.com/5347038/56455888-8883f080-635c-11e9-9bda-905baf83d3bd.png)

![image](https://user-images.githubusercontent.com/5347038/56455892-98033980-635c-11e9-9cc6-8005e866bc2b.png)


