### PR TITLE
fix: stop resolving "react-native" from package.json as a config 

### DIFF
--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -23,7 +23,7 @@ import {logger} from '@react-native-community/cli-tools';
 /**
  * Places to look for the new configuration
  */
-const searchPlaces = ['react-native.config.js', 'package.json'];
+const searchPlaces = ['react-native.config.js'];
 
 /**
  * Reads a project configuration as defined by the user in the current


### PR DESCRIPTION
Summary:
---------

`"react-native"` key already exists in userspace and is used by Metro to resolve source files of published React Native modules. That's why we cannot use it to store config values insead of `"rnpm"`. I'm not a fan of having configs in package.json, so I got rid of that entirely and rely only on `react-native.config.js` file from now on. 

Test Plan:
----------

Added a test and updated existing ones.