### PR TITLE
chore: change `upgrade` to use new diff files approach

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -159,16 +159,16 @@ test('fetches empty patch and installs deps', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(''));
   await upgrade.func([newVersion], ctx, opts);
   expect(flushOutput()).toMatchInlineSnapshot(`
-"info Fetching diff between v0.57.8 and v0.58.4...
-info Diff has no changes to apply, proceeding further
-info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-$ execa npm info react-native@0.58.4 peerDependencies --json
-$ yarn add react-native@0.58.4 react@16.6.3
-$ execa git add package.json
-$ execa git add yarn.lock
-$ execa git add package-lock.json
-success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-`);
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    info Diff has no changes to apply, proceeding further
+    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+    $ execa npm info react-native@0.58.4 peerDependencies --json
+    $ yarn add react-native@0.58.4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+  `);
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
@@ -184,24 +184,24 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
     opts,
   );
   expect(flushOutput()).toMatchInlineSnapshot(`
-"info Fetching diff between v0.57.8 and v0.58.4...
-[fs] write tmp-upgrade-rn.patch
-$ execa git rev-parse --show-prefix
-$ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-info Applying diff...
-$ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-[fs] unlink tmp-upgrade-rn.patch
-$ execa git status -s
-info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-$ execa npm info react-native@0.58.4 peerDependencies --json
-$ yarn add react-native@0.58.4 react@16.6.3
-$ execa git add package.json
-$ execa git add yarn.lock
-$ execa git add package-lock.json
-info Running \\"git status\\" to check what changed...
-$ execa git status
-success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-`);
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    info Applying diff...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+    $ execa npm info react-native@0.58.4 peerDependencies --json
+    $ yarn add react-native@0.58.4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Running \\"git status\\" to check what changed...
+    $ execa git status
+    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+  `);
   expect(
     snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
       contextLines: 1,
@@ -216,24 +216,24 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
   const config = {...ctx, root: '/project/root/NestedApp'};
   await upgrade.func([newVersion], config, opts);
   expect(flushOutput()).toMatchInlineSnapshot(`
-"info Fetching diff between v0.57.8 and v0.58.4...
-[fs] write tmp-upgrade-rn.patch
-$ execa git rev-parse --show-prefix
-$ execa git apply --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-info Applying diff...
-$ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-[fs] unlink tmp-upgrade-rn.patch
-$ execa git status -s
-info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-$ execa npm info react-native@0.58.4 peerDependencies --json
-$ yarn add react-native@0.58.4 react@16.6.3
-$ execa git add package.json
-$ execa git add yarn.lock
-$ execa git add package-lock.json
-info Running \\"git status\\" to check what changed...
-$ execa git status
-success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-`);
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    info Applying diff...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+    $ execa npm info react-native@0.58.4 peerDependencies --json
+    $ yarn add react-native@0.58.4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Running \\"git status\\" to check what changed...
+    $ execa git status
+    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+  `);
 }, 60000);
 test('cleans up if patching fails,', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
@@ -263,22 +263,22 @@ test('cleans up if patching fails,', async () => {
     );
   }
   expect(flushOutput()).toMatchInlineSnapshot(`
-"info Fetching diff between v0.57.8 and v0.58.4...
-[fs] write tmp-upgrade-rn.patch
-$ execa git rev-parse --show-prefix
-$ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-info Applying diff (excluding: package.json, .flowconfig)...
-$ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig -p2 --3way --directory=
-error: .flowconfig: does not exist in index
-error Automatically applying diff failed
-[fs] unlink tmp-upgrade-rn.patch
-$ execa git status -s
-error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
-info You may find these resources helpful:
-• Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
-• Comparison between versions: https://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8..version/0.58.4
-• Git diff: https://github.com/react-native-community/rn-diff-purge/compare/version/0.57.8..version/0.58.4.diff"
-`);
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    info Applying diff (excluding: package.json, .flowconfig)...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig -p2 --3way --directory=
+    error: .flowconfig: does not exist in index
+    error Automatically applying diff failed
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
+    info You may find these resources helpful:
+    • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
+    • Comparison between versions: https://github.com/react-native-community/rn-diff-purge/compare/release/0.57.8..release/0.58.4
+    • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
+  `);
 }, 60000);
 test('works with --name-ios and --name-android', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -14,8 +14,9 @@ type FlagsT = {
   legacy: boolean | void,
 };
 
-const rnDiffPurgeUrl =
-  'https://github.com/react-native-community/rn-diff-purge';
+const rnDiffPurgeUrl = 'https://github.com/react-native-community/rn-diff-purge';
+const rnDiffPurgeRawDiffsUrl =
+  'https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs';
 
 const getLatestRNVersion = async (): Promise<string> => {
   logger.info('No version passed. Fetching latest...');
@@ -45,7 +46,7 @@ const getPatch = async (currentVersion, newVersion, config) => {
 
   try {
     patch = await fetch(
-      `${rnDiffPurgeUrl}/compare/version/${currentVersion}...version/${newVersion}.diff`,
+      `${rnDiffPurgeRawDiffsUrl}/${currentVersion}..${newVersion}.diff`,
     );
   } catch (error) {
     logger.error(
@@ -297,10 +298,10 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
         `https://github.com/facebook/react-native/releases/tag/v${newVersion}`,
       )}
 • Comparison between versions: ${chalk.underline.dim(
-        `${rnDiffPurgeUrl}/compare/version/${currentVersion}..version/${newVersion}`,
+        `${rnDiffPurgeUrl}/compare/release/${currentVersion}..release/${newVersion}`,
       )}
 • Git diff: ${chalk.underline.dim(
-        `${rnDiffPurgeUrl}/compare/version/${currentVersion}..version/${newVersion}.diff`,
+        `${rnDiffPurgeRawDiffsUrl}/${currentVersion}..${newVersion}.diff`,
       )}`);
 
       throw new Error(

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -14,7 +14,8 @@ type FlagsT = {
   legacy: boolean | void,
 };
 
-const rnDiffPurgeUrl = 'https://github.com/react-native-community/rn-diff-purge';
+const rnDiffPurgeUrl =
+  'https://github.com/react-native-community/rn-diff-purge';
 const rnDiffPurgeRawDiffsUrl =
   'https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs';
 

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -54,7 +54,9 @@ const getPatch = async (currentVersion, newVersion, config) => {
       `Failed to fetch diff for react-native@${newVersion}. Maybe it's not released yet?`,
     );
     logger.info(
-      'For available releases to diff see: https://github.com/react-native-community/rn-diff-purge#version-changes',
+      `For available releases to diff see: ${chalk.underline.dim(
+        'https://github.com/react-native-community/rn-diff-purge#diff-table-full-table-here',
+      )}`,
     );
     return null;
   }


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

We were relying on github to generate diffs and patches for us. This worked fine when we had one branch for all the releases, but this is not enough anymore with a branch per release. We still use github's compare view, but for patches we grab the ones we generate on the [purge repo](https://github.com/react-native-community/rn-diff-purge).

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

More or less the same as https://github.com/react-native-community/react-native-cli/pull/176.
Create a RN project, and try upgrading like so.
<img width="615" alt="Screen Shot 2019-04-23 at 20 21 29" src="https://user-images.githubusercontent.com/100233/56611445-1a685380-6612-11e9-93b2-0833d379e38d.png">

Having conflicts still causes the upgrade to not leave files for the user to resolve.