### PR TITLE
[ios] Ensure that the right cwd is set up for auto-linking dependencies

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -29,6 +29,8 @@ The implementation ensures that a library is imported only once, so if you need 
 
 See implementation of [native_modules.rb](https://github.com/react-native-community/cli/blob/master/packages/platform-ios/native_modules.rb).
 
+_Notes_: Auto-linking assumes your Podfile is in a sub-folder from your `package.json` - if this is not the case, use the first parameter to tell the linker where to find the `package.json` e.g. `use_native_modules!("../../")`.
+
 ## Platform Android
 
 1. At build time, before the build script is run, a first gradle plugin (`settings.gradle`) is ran that takes the package metadata from `react-native config` to dynamically include Android library projects into the build.

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -3,15 +3,10 @@
 # which declare themselves to be iOS dependencies (via having a Podspec) and automatically
 # imports those into your current target.
 #
-def use_native_modules!(packages = nil)
+def use_native_modules!(root = "..", packages = nil)
   if (!packages)
     # Resolve the CLI's main index file
     cli_bin = Pod::Executable.execute_command("node", ["-e", "console.log(require.resolve('@react-native-community/cli/build/index.js'))"], true).strip
-    # Use the path from ^ to get the root of the node modules
-    root = cli_bin.split("node_modules/@react-native-community/cli/build/index.js").first
-
-    throw "Auto-linking could not figure out the root folder of your package" unless root
-
     output = ""
     # Make sure `react-native config` is ran from your project root
     Dir.chdir(root) do
@@ -152,8 +147,8 @@ if $0 == __FILE__
 
       spec.singleton_class.send(:define_method, :name) { "ios-dep" }
 
-      podfile.singleton_class.send(:define_method, :use_native_modules) do |config|
-        use_native_modules!(config)
+      podfile.singleton_class.send(:define_method, :use_native_modules) do |path, config|
+        use_native_modules!('..', config)
       end
 
       Pod::Specification.singleton_class.send(:define_method, :from_file) do |podspec_path|
@@ -183,7 +178,7 @@ if $0 == __FILE__
     end
 
     it "activates iOS pods" do
-      @podfile.use_native_modules(@config)
+      @podfile.use_native_modules('..', @config)
       @activated_pods.must_equal [{
         name: "ios-dep",
         options: { path: @ios_package["root"] }
@@ -194,7 +189,7 @@ if $0 == __FILE__
       activated_pod = Object.new
       activated_pod.singleton_class.send(:define_method, :name) { "ios-dep" }
       @current_target_definition_dependencies << activated_pod
-      @podfile.use_native_modules(@config)
+      @podfile.use_native_modules('..', @config)
       @activated_pods.must_equal []
     end
 
@@ -202,14 +197,14 @@ if $0 == __FILE__
       activated_pod = Object.new
       activated_pod.singleton_class.send(:define_method, :name) { "ios-dep/foo/bar" }
       @current_target_definition_dependencies << activated_pod
-      @podfile.use_native_modules(@config)
+      @podfile.use_native_modules('..', @config)
       @activated_pods.must_equal []
     end
 
     it "prints out the native module pods that were found" do
-      @podfile.use_native_modules({})
-      @podfile.use_native_modules({ "pkg-1" => @ios_package })
-      @podfile.use_native_modules({ "pkg-1" => @ios_package, "pkg-2" => @ios_package })
+      @podfile.use_native_modules('..', {})
+      @podfile.use_native_modules('..', { "pkg-1" => @ios_package })
+      @podfile.use_native_modules('..', { "pkg-1" => @ios_package, "pkg-2" => @ios_package })
       @printed_messages.must_equal [
         "Detected React Native module pod for ios-dep",
         "Detected React Native module pods for ios-dep, and ios-dep"
@@ -219,7 +214,7 @@ if $0 == __FILE__
     describe "concerning script_phases" do
       it "uses the options directly" do
         @config["ios-dep"]["platforms"]["ios"]["scriptPhases"] = [@script_phase]
-        @podfile.use_native_modules(@config)
+        @podfile.use_native_modules('..', @config)
         @added_scripts.must_equal [{
           "script" => "123",
           "name" => "My Name",
@@ -237,7 +232,7 @@ if $0 == __FILE__
         file_read_mock.expect(:call, "contents from file", [File.join(@ios_package["root"], "some_shell_script.sh")])
 
         File.stub(:read, file_read_mock) do
-          @podfile.use_native_modules(@config)
+          @podfile.use_native_modules('..', @config)
         end
 
         @added_scripts.must_equal [{


### PR DESCRIPTION
Summary:
---------

```sh
# from inside my iOS folder

▲ ios  $ yarn react-native config

yarn run v1.12.3
$ /Users/ortatherox/Downloads/Autolinking/node_modules/.bin/react-native config
{
  "root": "/Users/ortatherox/Downloads/Autolinking",
  "reactNativePath": "/Users/ortatherox/Downloads/Autolinking/node_modules/react-native",
  "dependencies": {
    "@react-native-community/cli": {
      "root": "/Users/ortatherox/Downloads/Autolinking/node_modules/@react-native-community/cli",
      "name": "@react-native-community/cli",
      "platforms": {
        "ios": null,
        "android": null
      },
      "assets": [],
      "hooks": {},
      "params": []
    },
  },
  // [snip]
  "project": {
    "ios": {
      "sourceDir": "/Users/ortatherox/Downloads/Autolinking/ios",
      "folder": "/Users/ortatherox/Downloads/Autolinking",
      "pbxprojPath": "/Users/ortatherox/Downloads/Autolinking/ios/Autolinking.xcodeproj/project.pbxproj",
      "podfile": "/Users/ortatherox/Downloads/Autolinking/ios/Podfile",
      "podspec": null,
      "projectPath": "/Users/ortatherox/Downloads/Autolinking/ios/Autolinking.xcodeproj",
      "projectName": "Autolinking.xcodeproj",
      "libraryFolder": "Libraries",
      "sharedLibraries": [],
      "plist": []
    },
    "android": {
      "sourceDir": "/Users/ortatherox/Downloads/Autolinking/android/app",
      "isFlat": false,
      "folder": "/Users/ortatherox/Downloads/Autolinking",
      "stringsPath": "/Users/ortatherox/Downloads/Autolinking/android/app/src/main/res/values/strings.xml",
      "manifestPath": "/Users/ortatherox/Downloads/Autolinking/android/app/src/main/AndroidManifest.xml",
      "buildGradlePath": "/Users/ortatherox/Downloads/Autolinking/android/app/build.gradle",
      "settingsGradlePath": "/Users/ortatherox/Downloads/Autolinking/android/settings.gradle",
      "assetsPath": "/Users/ortatherox/Downloads/Autolinking/android/app/src/main/assets",
      "mainFilePath": "/Users/ortatherox/Downloads/Autolinking/android/app/src/main/java/com/autolinking/MainApplication.java",
      "packageName": "com.autolinking"
    }
  }
}
✨  Done in 0.37s.

# emulating how it is called inside the Podfile:

ios  $ node /Users/ortatherox/Downloads/Autolinking/node_modules/@react-native-community/cli/build/index.js config
{
  "root": "/Users/ortatherox/Downloads/Autolinking/ios",
  "reactNativePath": "/Users/ortatherox/Downloads/Autolinking/node_modules/react-native",
  "dependencies": {},
  "commands": [],
  "assets": [],
  "platforms": {},
  "haste": {
    "providesModuleNodeModules": [],
    "platforms": []
  },
  "project": {}
}
```

See how `"root"` is different? That meant that no dependencies could be found.

Test Plan:
----------

I'd want to see:

> "Detected React Native module x, y, z"

Which it does:

<img width="1192" alt="Screen Shot 2019-04-24 at 4 55 35 PM" src="https://user-images.githubusercontent.com/49038/56693177-ca40ce00-66b1-11e9-8bba-e71fad888ef1.png">
