### PR TITLE
feat: support `init` with custom project directory

### DIFF
--- a/__e2e__/__snapshots__/init.test.js.snap
+++ b/__e2e__/__snapshots__/init.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`init --template with custom project path: package.json contains necessary configuration 1`] = `
+Object {
+  "dependencies": Object {
+    "react": "16.8.1",
+    "react-native": "0.59.0-rc.1",
+  },
+  "devDependencies": Object {
+    "@babel/core": "^7.3.3",
+    "@babel/runtime": "^7.3.1",
+    "@react-native-community/eslint-config": "^0.0.3",
+    "babel-jest": "^24.1.0",
+    "jest": "^24.1.0",
+    "metro-react-native-babel-preset": "^0.51.1",
+    "react-test-renderer": "16.8.1",
+  },
+  "jest": Object {
+    "preset": "react-native",
+  },
+  "name": "TestInit",
+  "private": true,
+  "scripts": Object {
+    "start": "node node_modules/react-native/local-cli/cli.js start",
+    "test": "jest",
+  },
+  "version": "0.0.1",
+}
+`;
+
 exports[`init --template: package.json contains necessary configuration 1`] = `
 Object {
   "dependencies": Object {

--- a/__e2e__/__snapshots__/init.test.js.snap
+++ b/__e2e__/__snapshots__/init.test.js.snap
@@ -1,33 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`init --template with custom project path: package.json contains necessary configuration 1`] = `
-Object {
-  "dependencies": Object {
-    "react": "16.8.1",
-    "react-native": "0.59.0-rc.1",
-  },
-  "devDependencies": Object {
-    "@babel/core": "^7.3.3",
-    "@babel/runtime": "^7.3.1",
-    "@react-native-community/eslint-config": "^0.0.3",
-    "babel-jest": "^24.1.0",
-    "jest": "^24.1.0",
-    "metro-react-native-babel-preset": "^0.51.1",
-    "react-test-renderer": "16.8.1",
-  },
-  "jest": Object {
-    "preset": "react-native",
-  },
-  "name": "TestInit",
-  "private": true,
-  "scripts": Object {
-    "start": "node node_modules/react-native/local-cli/cli.js start",
-    "test": "jest",
-  },
-  "version": "0.0.1",
-}
-`;
-
 exports[`init --template: package.json contains necessary configuration 1`] = `
 Object {
   "dependencies": Object {

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -22,27 +22,27 @@ test('init --template fails without package name', () => {
   expect(stderr).toContain('missing required argument');
 });
 
-test('init --template', () => {
-  const templateFiles = [
-    '.buckconfig',
-    '.eslintrc.js',
-    '.flowconfig',
-    '.gitattributes',
-    // should be here, but it's not published yet
-    // '.gitignore',
-    '.watchmanconfig',
-    'App.js',
-    '__tests__',
-    'android',
-    'babel.config.js',
-    'index.js',
-    'ios',
-    'metro.config.js',
-    'node_modules',
-    'package.json',
-    'yarn.lock',
-  ];
+const templateFiles = [
+  '.buckconfig',
+  '.eslintrc.js',
+  '.flowconfig',
+  '.gitattributes',
+  // should be here, but it's not published yet
+  // '.gitignore',
+  '.watchmanconfig',
+  'App.js',
+  '__tests__',
+  'android',
+  'babel.config.js',
+  'index.js',
+  'ios',
+  'metro.config.js',
+  'node_modules',
+  'package.json',
+  'yarn.lock',
+];
 
+test('init --template', () => {
   const {stdout} = run(DIR, [
     'init',
     '--template',
@@ -83,4 +83,30 @@ test('init --template file:/tmp/custom/template', () => {
   ]);
 
   expect(stdout).toContain('Run instructions');
+});
+
+test('init --template with custom project path', () => {
+  const projectName = 'TestInit';
+  const customProjectPath = './random/path';
+
+  run(DIR, [
+    'init',
+    '--template',
+    'react-native-new-template',
+    'TestInit',
+    customProjectPath,
+  ]);
+
+  const projectPath = path.join(DIR, customProjectPath);
+
+  // make sure we don't leave garbage
+  expect(fs.readdirSync(projectPath)).toEqual(['TestInit']);
+  expect(fs.readdirSync(path.join(projectPath, projectName))).toEqual(
+    templateFiles,
+  );
+
+  const pkgJson = require(path.join(projectPath, 'TestInit', 'package.json'));
+  expect(pkgJson).toMatchSnapshot(
+    'package.json contains necessary configuration',
+  );
 });

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -1,6 +1,7 @@
 // @flow
 import fs from 'fs';
 import path from 'path';
+import inquirer from 'inquirer';
 import {run, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-init');
@@ -87,35 +88,24 @@ test('init --template file:/tmp/custom/template', () => {
 
 test('init --template with custom project path', () => {
   const projectName = 'TestInit';
-  const customProjectPath = getTempDirectory('command-init-custom-path');
-
-  // Create directory
-  writeFiles(customProjectPath, {});
+  const customPath = 'custom-path';
 
   run(DIR, [
     'init',
     '--template',
     'react-native-new-template',
     projectName,
-    customProjectPath,
+    '--directory',
+    'custom-path',
   ]);
 
   // make sure we don't leave garbage
-  expect(fs.readdirSync(customProjectPath)).toEqual([projectName]);
-  expect(fs.readdirSync(path.join(customProjectPath, projectName))).toEqual(
-    templateFiles,
-  );
+  expect(fs.readdirSync(DIR)).toEqual([customPath]);
+  expect(fs.readdirSync(path.join(DIR, customPath))).toEqual(templateFiles);
 
-  const pkgJson = require(path.join(
-    customProjectPath,
-    projectName,
-    'package.json',
-  ));
+  const pkgJson = require(path.join(DIR, customPath, 'package.json'));
 
   expect(pkgJson).toMatchSnapshot(
     'package.json contains necessary configuration',
   );
-
-  // Remove custom project path
-  cleanup(customProjectPath);
 });

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -101,10 +101,4 @@ test('init --template with custom project path', () => {
   // make sure we don't leave garbage
   expect(fs.readdirSync(DIR)).toEqual([customPath]);
   expect(fs.readdirSync(path.join(DIR, customPath))).toEqual(templateFiles);
-
-  const pkgJson = require(path.join(DIR, customPath, 'package.json'));
-
-  expect(pkgJson).toMatchSnapshot(
-    'package.json contains necessary configuration',
-  );
 });

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -87,26 +87,35 @@ test('init --template file:/tmp/custom/template', () => {
 
 test('init --template with custom project path', () => {
   const projectName = 'TestInit';
-  const customProjectPath = './random/path';
+  const customProjectPath = getTempDirectory('command-init-custom-path');
+
+  // Create directory
+  writeFiles(customProjectPath, {});
 
   run(DIR, [
     'init',
     '--template',
     'react-native-new-template',
-    'TestInit',
+    projectName,
     customProjectPath,
   ]);
 
-  const projectPath = path.join(DIR, customProjectPath);
-
   // make sure we don't leave garbage
-  expect(fs.readdirSync(projectPath)).toEqual(['TestInit']);
-  expect(fs.readdirSync(path.join(projectPath, projectName))).toEqual(
+  expect(fs.readdirSync(customProjectPath)).toEqual([projectName]);
+  expect(fs.readdirSync(path.join(customProjectPath, projectName))).toEqual(
     templateFiles,
   );
 
-  const pkgJson = require(path.join(projectPath, 'TestInit', 'package.json'));
+  const pkgJson = require(path.join(
+    customProjectPath,
+    projectName,
+    'package.json',
+  ));
+
   expect(pkgJson).toMatchSnapshot(
     'package.json contains necessary configuration',
   );
+
+  // Remove custom project path
+  cleanup(customProjectPath);
 });

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -1,7 +1,6 @@
 // @flow
 import fs from 'fs';
 import path from 'path';
-import inquirer from 'inquirer';
 import {run, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-init');

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -94,7 +94,6 @@ test('init --template with custom project path', () => {
     '--template',
     'react-native-new-template',
     projectName,
-    '--directory',
     'custom-path',
   ]);
 

--- a/__e2e__/init.test.js
+++ b/__e2e__/init.test.js
@@ -94,6 +94,7 @@ test('init --template with custom project path', () => {
     '--template',
     'react-native-new-template',
     projectName,
+    '--directory',
     'custom-path',
   ]);
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -114,13 +114,15 @@ Output project and dependencies configuration in JSON format to stdout. Used by 
 
 > Available since 0.60.0
 
-Usage:
+> **IMPORTANT**: Please note that this command is not available through `react-native-cli`, hence you need to either invoke it directly from `@react-native-community/cli` or `react-native` package which proxies binary to this CLI since 0.60.0, so it's possible to use it with e.g. `npx`.
+
+Usage (with `npx`):
 
 ```sh
-react-native init <projectName> [options]
+npx react-native init <projectName> [directory] [options]
 ```
 
-Initialize new React Native project. You can find out more use cases in [init docs](./init.md).
+Initialize a new React Native project named `<projectName>` in a directory of the same name or specified by an optional `[directory]` argument. You can find out more use cases in [init docs](./init.md).
 
 #### Options
 
@@ -140,10 +142,11 @@ Uses a custom template. Accepts following template sources:
 Example:
 
 ```sh
-react-native init MyApp --template react-native-custom-template
-react-native init MyApp --template typescript
-react-native init MyApp --template file:///Users/name/template-path
-react-native init MyApp --template file:///Users/name/template-name-1.0.0.tgz
+npx react-native init MyApp CustomDirectory
+npx react-native init MyApp --template react-native-custom-template
+npx react-native init MyApp --template typescript
+npx react-native init MyApp --template file:///Users/name/template-path
+npx react-native init MyApp --template file:///Users/name/template-name-1.0.0.tgz
 ```
 
 A template is any directory or npm package that contains a `template.config.js` file in the root with following of the following type:
@@ -164,9 +167,9 @@ Example `template.config.js`:
 
 ```js
 module.exports = {
-  placeholderName: "ProjectName",
-  templateDir: "./template",
-  postInitScript: "./script.js",
+  placeholderName: 'ProjectName',
+  templateDir: './template',
+  postInitScript: './script.js',
 };
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -119,16 +119,20 @@ Output project and dependencies configuration in JSON format to stdout. Used by 
 Usage (with `npx`):
 
 ```sh
-npx react-native init <projectName> [directory] [options]
+npx react-native init <projectName> [options]
 ```
 
-Initialize a new React Native project named `<projectName>` in a directory of the same name or specified by an optional `[directory]` argument. You can find out more use cases in [init docs](./init.md).
+Initialize a new React Native project named <projectName> in a directory of the same name. You can find out more use cases in [init docs](./init.md).
 
 #### Options
 
 #### `--version [string]`
 
 Uses a valid semver version of React Native as a template.
+
+#### `--directory [string]`
+
+Uses a custom directory instead of `<projectName>`.
 
 #### `--template [string]`
 
@@ -142,7 +146,6 @@ Uses a custom template. Accepts following template sources:
 Example:
 
 ```sh
-npx react-native init MyApp CustomDirectory
 npx react-native init MyApp --template react-native-custom-template
 npx react-native init MyApp --template typescript
 npx react-native init MyApp --template file:///Users/name/template-path

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -55,6 +55,10 @@ const handleError = err => {
 // one modified to suit our needs
 function printHelpInformation(examples, pkg) {
   let cmdName = this._name;
+  const argsList = this._args
+    .map(arg => (arg.required ? `<${arg.name}>` : `[${arg.name}]`))
+    .join(' ');
+
   if (this._alias) {
     cmdName = `${cmdName}|${this._alias}`;
   }
@@ -64,7 +68,7 @@ function printHelpInformation(examples, pkg) {
     : [];
 
   let output = [
-    chalk.bold(`react-native ${cmdName}`),
+    chalk.bold(`react-native ${cmdName} ${argsList}`),
     this._description ? `\n${this._description}\n` : '',
     ...sourceInformation,
     `${chalk.bold('Options:')}`,

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -3,8 +3,9 @@ import init from './init';
 
 export default {
   func: init,
-  name: 'init <projectName>',
-  description: 'initialize new React Native project',
+  name: 'init <projectName> [directory]',
+  description:
+    'Initialize a new React Native project named <projectName> in a directory of the same name or specified by an optional [directory] argument.',
   options: [
     {
       name: '--version [string]',
@@ -17,10 +18,6 @@ export default {
     {
       name: '--npm',
       description: 'Force use of npm during initialization',
-    },
-    {
-      name: '--directory [string]',
-      description: 'Custom directory for your app',
     },
   ],
 };

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -9,11 +9,12 @@ export default {
   options: [
     {
       name: '--version [string]',
-      description: 'Version of React Native',
+      description: 'Uses a valid semver version of React Native as a template',
     },
     {
       name: '--template [string]',
-      description: 'Custom template',
+      description:
+        'Uses a custom template. Valid arguments are: npm package, absolute directory prefixed with `file://`, Git repository or a tarball',
     },
     {
       name: '--npm',

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -3,7 +3,7 @@ import init from './init';
 
 export default {
   func: init,
-  name: 'init <packageName>',
+  name: 'init <projectName> [projectPath]',
   description: 'initialize new React Native project',
   options: [
     {

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -3,9 +3,9 @@ import init from './init';
 
 export default {
   func: init,
-  name: 'init <projectName> [directory]',
+  name: 'init <projectName>',
   description:
-    'Initialize a new React Native project named <projectName> in a directory of the same name or specified by an optional [directory] argument.',
+    'Initialize a new React Native project named <projectName> in a directory of the same name.',
   options: [
     {
       name: '--version [string]',
@@ -18,7 +18,11 @@ export default {
     },
     {
       name: '--npm',
-      description: 'Force use of npm during initialization',
+      description: 'Forces using npm for initialization',
+    },
+    {
+      name: '--directory [string]',
+      description: 'Uses a custom directory instead of `<projectName>`.',
     },
   ],
 };

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -3,12 +3,12 @@ import init from './init';
 
 export default {
   func: init,
-  name: 'init <projectName> [projectPath]',
+  name: 'init <projectName>',
   description: 'initialize new React Native project',
   options: [
     {
       name: '--version [string]',
-      description: 'Version of RN',
+      description: 'Version of React Native',
     },
     {
       name: '--template [string]',
@@ -17,6 +17,10 @@ export default {
     {
       name: '--npm',
       description: 'Force use of npm during initialization',
+    },
+    {
+      name: '--directory [string]',
+      description: 'Custom directory for your app',
     },
   ],
 };

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -29,6 +29,7 @@ import {CLIError} from '@react-native-community/cli-tools';
 type Options = {|
   template?: string,
   npm?: boolean,
+  directory?: string,
 |};
 
 function doesDirectoryExist(dir: string) {
@@ -194,7 +195,7 @@ async function createProject(
 }
 
 export default (async function initialize(
-  [projectName, directory]: Array<string>,
+  [projectName]: Array<string>,
   _context: ConfigT,
   options: Options,
 ) {
@@ -210,7 +211,7 @@ export default (async function initialize(
 
   const directoryName = getProjectDirectory({
     projectName,
-    directory: directory || projectName,
+    directory: options.directory || projectName,
   });
   const directoryExists = doesDirectoryExist(directoryName);
 

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -29,6 +29,7 @@ import {CLIError} from '@react-native-community/cli-tools';
 type Options = {|
   template?: string,
   npm?: boolean,
+  directory?: string,
 |};
 
 async function setProjectDirectory({projectName, directory}) {

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -50,6 +50,7 @@ async function setProjectDirectory(directory) {
         type: 'confirm',
         name: 'shouldReplaceprojectDirectory',
         message: `Directory "${directory}" already exists, do you want to replace it?`,
+        default: false,
       },
     ]);
 

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -143,7 +143,7 @@ function createProject(
   options: Options,
   version: string,
 ) {
-  fs.mkdirSync(projectPath);
+  fs.mkdirSync(projectPath, {recursive: true});
   process.chdir(projectPath);
 
   if (options.template) {

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -33,7 +33,7 @@ function getProjectPath({
   customProjectPath = '',
 }: {
   projectName: string,
-  customProjectPath: ?string,
+  customProjectPath: string,
 }) {
   return path.join(customProjectPath, projectName);
 }

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -143,8 +143,14 @@ function createProject(
   options: Options,
   version: string,
 ) {
-  fs.mkdirSync(projectPath, {recursive: true});
-  process.chdir(projectPath);
+  try {
+    fs.mkdirSync(projectPath, {recursive: true});
+    process.chdir(projectPath);
+  } catch (err) {
+    throw new Error(
+      'Cannot initialize new project because custom project directory does not exist.',
+    );
+  }
 
   if (options.template) {
     return createFromTemplate({

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -17,6 +17,10 @@ async function installPods({
   loader?: typeof Ora,
 }) {
   try {
+    if (!(await fs.pathExists('ios'))) {
+      return;
+    }
+
     process.chdir('ios');
 
     const hasPods = await fs.pathExists('Podfile');

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -1,5 +1,5 @@
 // @flow
-import fs from 'fs-extra';
+import fs from 'fs';
 import execa from 'execa';
 import chalk from 'chalk';
 import Ora from 'ora';
@@ -17,13 +17,13 @@ async function installPods({
   loader?: typeof Ora,
 }) {
   try {
-    if (!(await fs.pathExists('ios'))) {
+    if (!fs.existsSync('ios')) {
       return;
     }
 
     process.chdir('ios');
 
-    const hasPods = await fs.pathExists('Podfile');
+    const hasPods = fs.existsSync('Podfile');
 
     if (!hasPods) {
       return;


### PR DESCRIPTION
Summary:
---------

This PR fixes #110 by adding the possibility of specifying the folder path of the project when running the `init` command.

This changes the `fs.mkdirSync` to run with `recursive: true` which is only available on Node.js > 10, I'm open for opinions on how to throw a nice error to the user if the path doesn't exist yet and is not possible to create without `recursive`.

Test Plan:
----------

```sh
npx react-native init AwesomeApp --directory ../
npx react-native init AwesomeApp --directory path/that/does/not/exist/yet
```

I also added a test for this on `init.test.js` that I would love some feedback on!

cc @thymikee maybe you can review this :)

---

### Directory exists and user chooses to replace it
![image](https://user-images.githubusercontent.com/6207220/57866851-53a27680-7800-11e9-8197-283f2ec5de80.png)

### Directory exists and user chooses to not replace it
![Screenshot 2019-05-16 at 15 56 01](https://user-images.githubusercontent.com/6207220/57866867-5ac98480-7800-11e9-98af-0ea3e113d8b2.png)

---

- [x] Prompt the user to replace the project directory after the `init` intro (React logo) shows up;
- [x] Fix test for `init` failing because of `inquirer`.