### PR TITLE
docs: add `maintainers` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can also add npm scripts to call it with whichever package manager you use:
 
 ## Maintainers
 
-- Mike Pierzchała ([**@thymikee**](https://github.com/thymikee)) - [Callstack](https://callstack.com)
+- Michał Pierzchała ([**@thymikee**](https://github.com/thymikee)) - [Callstack](https://callstack.com)
 - Mike Grabowski ([**@grabbou**](https://github.com/grabbou)) - [Callstack](https://callstack.com)
 - Kacper Wiszczuk ([**@esemesek**](https://github.com/esemesek)) - [Callstack](https://callstack.com)
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ You can also add npm scripts to call it with whichever package manager you use:
 
 ## Maintainers
 
-Mike Pierzchała @thymikee - [Callstack](https://callstack.com)
-Mike Grabowski @grabbou - [Callstack](https://callstack.com)
-Kacper Wiszczuk @esemesek - [Callstack](https://callstack.com)
+- Mike Pierzchała ([**@thymikee**](https://github.com/thymikee)) - [Callstack](https://callstack.com)
+- Mike Grabowski ([**@grabbou**](https://github.com/grabbou)) - [Callstack](https://callstack.com)
+- Kacper Wiszczuk ([**@esemesek**](https://github.com/esemesek)) - [Callstack](https://callstack.com)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ You can also add npm scripts to call it with whichever package manager you use:
 }
 ```
 
+## Maintainers
+
+Mike Pierzchała @thymikee - [Callstack](https://callstack.com)
+Mike Grabowski @grabbou - [Callstack](https://callstack.com)
+Kacper Wiszczuk @esemesek - [Callstack](https://callstack.com)
+
 ## License
 
 Everything inside this repository is [MIT licensed](./LICENSE).


### PR DESCRIPTION
Adds `maintainers` section following other repositories in the RNC.
