### PR TITLE
fix: reporter config option

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -82,6 +82,8 @@ export type ConfigOptionsT = {|
  */
 export default function load(ctx: ConfigT, options?: ConfigOptionsT) {
   const defaultConfig = getDefaultConfig(ctx);
-
-  return loadConfig({cwd: ctx.root, ...options}, defaultConfig);
+  return loadConfig(
+    {cwd: ctx.root, ...options},
+    {...defaultConfig, reporter: options && options.reporter},
+  );
 }


### PR DESCRIPTION
Summary:
---------

The `loadConfig` function in `metro-config` reads the `reporter` option
from the second argument (`defaultConfigOverrides`) instead of the
first argument (`argv`), so we need to pass it in that object to
make the `customLogReporterPath` CLI option work.

Test Plan:
----------

1. Created a file `reporter.js` with the following contents:
```js
class JsonReporter {
  update(event) {
    console.log(JSON.stringify(event));
  }
}

module.exports = JsonReporter;
```
2. Ran this command and inspected that the output was JSON:
```
node ~/Projects/react-native-cli/packages/cli/build/index.js start --customLogReporterPath ~/Projects/react-native-cli/reporter.js
```