### PR TITLE
fix: reporter config option

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -170,10 +170,12 @@ success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the
 `);
 });
 
-test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
-  (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
-  await upgrade.func([newVersion], ctx, opts);
-  expect(flushOutput()).toMatchInlineSnapshot(`
+test(
+  'fetches regular patch, adds remote, applies patch, installs deps, removes remote,',
+  async () => {
+    (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
+    await upgrade.func([newVersion], ctx, opts);
+    expect(flushOutput()).toMatchInlineSnapshot(`
 "info Fetching diff between v0.57.8 and v0.58.4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -192,18 +194,22 @@ info Running \\"git status\\" to check what changed...
 $ execa git status
 success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
 `);
-  expect(
-    snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
-      contextLines: 1,
-    }),
-  ).toMatchSnapshot('RnDiffApp is replaced with app name (TestApp)');
-}, 60000);
-test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
-  (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
-  (execa: any).mockImplementation(mockExecaNested);
-  const config = {...ctx, root: '/project/root/NestedApp'};
-  await upgrade.func([newVersion], config, opts);
-  expect(flushOutput()).toMatchInlineSnapshot(`
+    expect(
+      snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
+        contextLines: 1,
+      }),
+    ).toMatchSnapshot('RnDiffApp is replaced with app name (TestApp)');
+  },
+  60000,
+);
+test(
+  'fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory',
+  async () => {
+    (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
+    (execa: any).mockImplementation(mockExecaNested);
+    const config = {...ctx, root: '/project/root/NestedApp'};
+    await upgrade.func([newVersion], config, opts);
+    expect(flushOutput()).toMatchInlineSnapshot(`
 "info Fetching diff between v0.57.8 and v0.58.4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -222,7 +228,9 @@ info Running \\"git status\\" to check what changed...
 $ execa git status
 success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
 `);
-}, 60000);
+  },
+  60000,
+);
 test('cleans up if patching fails,', async () => {
   (fetch: any).mockImplementation(() => Promise.resolve(samplePatch));
   (execa: any).mockImplementation((command, args) => {

--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -88,6 +88,8 @@ export type ConfigOptionsT = {|
  */
 export default function load(ctx: ContextT, options?: ConfigOptionsT) {
   const defaultConfig = getDefaultConfig(ctx);
-
-  return loadConfig({cwd: ctx.root, ...options}, defaultConfig);
+  return loadConfig(
+    {cwd: ctx.root, ...options},
+    {...defaultConfig, reporter: options && options.reporter},
+  );
 }


### PR DESCRIPTION
*This PR backports the fix from https://github.com/react-native-community/cli/pull/370 to the 1.x branch. I cherry picked 809aef93f20b6 to 1.x.*

Summary:
---------

The `loadConfig` function in `metro-config` reads the `reporter` option
from the second argument (`defaultConfigOverrides`) instead of the
first argument (`argv`), so we need to pass it in that object to
make the `customLogReporterPath` CLI option work.

Test Plan:
----------

1. Created a file `reporter.js` with the following contents:
```js
class JsonReporter {
  update(event) {
    console.log(JSON.stringify(event));
  }
}

module.exports = JsonReporter;
```
2. Ran this command and inspected that the output was JSON:
```
node ~/Projects/react-native-cli/packages/cli/build/index.js start --customLogReporterPath ~/Projects/react-native-cli/reporter.js
```