### PR TITLE
feat: improve `run-android` error messages; rename "installDebug" -> "task"

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -310,7 +310,7 @@ Do not launch packager while building.
 
 Launches the Metro Bundler in a new window using the specified terminal path.
 
-#### `--task [list]`
+#### `--tasks [list]`
 
 > default: 'installDebug'
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -270,6 +270,8 @@ Override the root directory for the Android build (which contains the android di
 
 > default: 'debug'
 
+Specify your app's build variant.
+
 #### `--appFolder [string]`
 
 > default: 'app'
@@ -310,7 +312,9 @@ Launches the Metro Bundler in a new window using the specified terminal path.
 
 #### `--task [string]`
 
-Run custom Gradle task instead of default "installDebug" where "debug" is default variant.
+> default: 'installDebug'
+
+Run custom Gradle task.
 
 ### `run-ios`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -262,8 +262,6 @@ Builds your app and starts it on a connected Android emulator or device.
 
 #### Options
 
-#### `--install-debug`
-
 #### `--root [string]`
 
 Override the root directory for the Android build (which contains the android directory)'.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -310,11 +310,12 @@ Do not launch packager while building.
 
 Launches the Metro Bundler in a new window using the specified terminal path.
 
-#### `--task [string]`
+#### `--task [list]`
 
 > default: 'installDebug'
 
-Run custom Gradle task.
+Run custom gradle tasks. If this argument is provided, then `--variant` option is ignored.
+Example: `yarn react-native run-android --tasks clean,installDebug`.
 
 ### `run-ios`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -300,13 +300,17 @@ Do not launch packager while building.
 
 #### `--port [number]`
 
-> default: process.env.RCT_METRO_PORT || 8081,
+> default: process.env.RCT_METRO_PORT || 8081
 
 #### `--terminal [string]`
 
 > default: process.env.REACT_TERMINAL || process.env.TERM_PROGRAM
 
 Launches the Metro Bundler in a new window using the specified terminal path.
+
+#### `--task [string]`
+
+Run custom Gradle task instead of default "installDebug" where "debug" is default variant.
 
 ### `run-ios`
 

--- a/packages/cli/src/tools/copyFiles.js
+++ b/packages/cli/src/tools/copyFiles.js
@@ -53,7 +53,7 @@ function copyFile(srcPath: string, destPath: string) {
  */
 function copyBinaryFile(srcPath, destPath, cb) {
   let cbCalled = false;
-  // const {mode} = fs.statSync(srcPath);
+  const {mode} = fs.statSync(srcPath);
   const readStream = fs.createReadStream(srcPath);
   const writeStream = fs.createWriteStream(destPath);
   readStream.on('error', err => {
@@ -64,10 +64,7 @@ function copyBinaryFile(srcPath, destPath, cb) {
   });
   readStream.on('close', () => {
     done();
-    // We may revisit setting mode to original later, however this fn is used
-    // before "replace placeholder in template" step, which expects files to be
-    // writable.
-    // fs.chmodSync(destPath, mode);
+    fs.chmodSync(destPath, mode);
   });
   readStream.pipe(writeStream);
   function done(err) {

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
@@ -51,7 +51,7 @@ describe('--appFolder', () => {
 
   it('uses only task argument', () => {
     runOnAllDevices({
-      task: ['someTask'],
+      tasks: ['someTask'],
       variant: 'debug',
     });
 
@@ -61,7 +61,7 @@ describe('--appFolder', () => {
   it('uses appFolder and custom task argument', () => {
     runOnAllDevices({
       appFolder: 'anotherApp',
-      task: ['someTask'],
+      tasks: ['someTask'],
       variant: 'debug',
     });
 
@@ -71,7 +71,7 @@ describe('--appFolder', () => {
   it('uses multiple tasks', () => {
     runOnAllDevices({
       appFolder: 'app',
-      task: ['clean', 'someTask'],
+      tasks: ['clean', 'someTask'],
     });
 
     expect(execFileSync.mock.calls[0][1]).toContain(

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
@@ -22,7 +22,9 @@ describe('--appFolder', () => {
   });
 
   it('uses installDebug as default if no arguments', () => {
-    runOnAllDevices({});
+    runOnAllDevices({
+      variant: 'debug',
+    });
 
     expect(execFileSync.mock.calls[0][1]).toContain('installDebug');
   });
@@ -30,59 +32,39 @@ describe('--appFolder', () => {
   it('uses appFolder and default variant', () => {
     runOnAllDevices({
       appFolder: 'someApp',
+      variant: 'debug',
     });
 
     expect(execFileSync.mock.calls[0][1]).toContain('someApp:installDebug');
   });
 
-  it('uses appFolder and variant', () => {
-    runOnAllDevices({
-      appFolder: 'app',
-      variant: 'debug',
-    });
-
-    expect(execFileSync.mock.calls[0][1]).toContain('app:installDebug');
-
-    runOnAllDevices({
-      appFolder: 'anotherApp',
-      variant: 'debug',
-    });
-
-    expect(execFileSync.mock.calls[1][1]).toContain('anotherApp:installDebug');
-
+  it('uses appFolder and custom variant', () => {
     runOnAllDevices({
       appFolder: 'anotherApp',
       variant: 'staging',
     });
 
-    expect(execFileSync.mock.calls[2][1]).toContain(
+    expect(execFileSync.mock.calls[0][1]).toContain(
       'anotherApp:installStaging',
     );
   });
 
-  it('uses appFolder and flavor', () => {
+  it('uses only task argument', () => {
     runOnAllDevices({
-      appFolder: 'app',
-      flavor: 'someFlavor',
+      task: 'someTask',
+      variant: 'debug',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('app:installSomeFlavor');
+    expect(execFileSync.mock.calls[0][1]).toContain('someTask');
   });
 
-  it('uses only installDebug argument', () => {
-    runOnAllDevices({
-      installDebug: 'someCommand',
-    });
-
-    expect(execFileSync.mock.calls[0][1]).toContain('someCommand');
-  });
-
-  it('uses appFolder and custom installDebug argument', () => {
+  it('uses appFolder and custom task argument', () => {
     runOnAllDevices({
       appFolder: 'anotherApp',
-      installDebug: 'someCommand',
+      task: 'someTask',
+      variant: 'debug',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('anotherApp:someCommand');
+    expect(execFileSync.mock.calls[0][1]).toContain('anotherApp:someTask');
   });
 });

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
@@ -21,7 +21,7 @@ describe('--appFolder', () => {
     jest.clearAllMocks();
   });
 
-  it('uses installDebug as default if no arguments', () => {
+  it('uses task "install[Variant]" as default task', () => {
     runOnAllDevices({
       variant: 'debug',
     });

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.js
@@ -51,7 +51,7 @@ describe('--appFolder', () => {
 
   it('uses only task argument', () => {
     runOnAllDevices({
-      task: 'someTask',
+      task: ['someTask'],
       variant: 'debug',
     });
 
@@ -61,10 +61,22 @@ describe('--appFolder', () => {
   it('uses appFolder and custom task argument', () => {
     runOnAllDevices({
       appFolder: 'anotherApp',
-      task: 'someTask',
+      task: ['someTask'],
       variant: 'debug',
     });
 
     expect(execFileSync.mock.calls[0][1]).toContain('anotherApp:someTask');
+  });
+
+  it('uses multiple tasks', () => {
+    runOnAllDevices({
+      appFolder: 'app',
+      task: ['clean', 'someTask'],
+    });
+
+    expect(execFileSync.mock.calls[0][1]).toContain(
+      'app:clean',
+      'app:someTask',
+    );
   });
 });

--- a/packages/platform-android/src/commands/runAndroid/adb.js
+++ b/packages/platform-android/src/commands/runAndroid/adb.js
@@ -70,7 +70,6 @@ function getAvailableCPUs(adbPath: string, device: string): Array<string> {
 }
 
 export default {
-  parseDevicesResult,
   getDevices,
   getAvailableCPUs,
 };

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -158,11 +158,9 @@ function buildApk(gradlew) {
     const gradleArgs = ['build', '-x', 'lint'];
     logger.info('Building the app...');
     logger.debug(`Running command "${gradlew} ${gradleArgs.join(' ')}"`);
-    execFileSync(gradlew, gradleArgs, {
-      stdio: [process.stdin, process.stdout, process.stderr],
-    });
+    execFileSync(gradlew, gradleArgs, {stdio: 'inherit'});
   } catch (error) {
-    throw new CLIError(`Failed to build the app: ${error.message}`, error);
+    throw new CLIError('Failed to build the app.', error);
   }
 }
 
@@ -188,10 +186,7 @@ function tryInstallAppOnDevice(args, adbPath, device) {
     );
     execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
   } catch (error) {
-    throw new CLIError(
-      `Failed to install the app on the device: ${error.message}`,
-      error,
-    );
+    throw new CLIError('Failed to install the app on the device.', error);
   }
 }
 

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -31,7 +31,7 @@ function checkAndroid(root) {
 }
 
 export type FlagsT = {|
-  task?: Array<string>,
+  tasks?: Array<string>,
   root: string,
   variant: string,
   appFolder: string,
@@ -360,8 +360,8 @@ export default {
       default: getDefaultUserTerminal,
     },
     {
-      name: '--task [list]',
-      description: 'Run custom Gradle task. By default it\'s "installDebug"',
+      name: '--tasks [list]',
+      description: 'Run custom Gradle tasks. By default it\'s "installDebug"',
       parse: (val: string) => val.split(','),
     },
   ],

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -31,7 +31,7 @@ function checkAndroid(root) {
 }
 
 export type FlagsT = {|
-  task?: string,
+  task?: Array<string>,
   root: string,
   variant: string,
   appFolder: string,
@@ -360,8 +360,9 @@ export default {
       default: getDefaultUserTerminal,
     },
     {
-      name: '--task [string]',
+      name: '--task [list]',
       description: 'Run custom Gradle task. By default it\'s "installDebug"',
+      parse: (val: string) => val.split(','),
     },
   ],
 };

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -31,6 +31,7 @@ function checkAndroid(root) {
 }
 
 export type FlagsT = {|
+  task?: string,
   root: string,
   variant: string,
   appFolder: string,
@@ -362,6 +363,11 @@ export default {
       description:
         'Launches the Metro Bundler in a new window using the specified terminal path.',
       default: getDefaultUserTerminal,
+    },
+    {
+      name: '--task [string]',
+      description:
+        'Run custom Gradle task instead of default "installDebug" where "debug" is default variant',
     },
   ],
 };

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -56,7 +56,7 @@ function runAndroid(argv: Array<string>, config: ConfigT, args: FlagsT) {
   }
 
   if (!args.packager) {
-    return buildAndRun(args, config);
+    return buildAndRun(args);
   }
 
   return isPackagerRunning(args.port).then(result => {
@@ -69,7 +69,7 @@ function runAndroid(argv: Array<string>, config: ConfigT, args: FlagsT) {
       logger.info('Starting JS server...');
       startServerInNewWindow(args.port, args.terminal, config.reactNativePath);
     }
-    return buildAndRun(args, config);
+    return buildAndRun(args);
   });
 }
 
@@ -85,7 +85,7 @@ function getPackageNameWithSuffix(appId, appIdSuffix, packageName) {
 }
 
 // Builds the app and runs it on a connected emulator / device.
-function buildAndRun(args, config) {
+function buildAndRun(args) {
   process.chdir(path.join(args.root, 'android'));
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
@@ -118,7 +118,6 @@ function buildAndRun(args, config) {
       packageNameWithSuffix,
       packageName,
       adbPath,
-      config,
     );
   }
 }

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -314,6 +314,7 @@ export default {
     },
     {
       name: '--variant [string]',
+      description: "Specify your app's build variant",
       default: 'debug',
     },
     {
@@ -360,8 +361,7 @@ export default {
     },
     {
       name: '--task [string]',
-      description:
-        'Run custom Gradle task instead of default "installDebug" where "debug" is default variant',
+      description: 'Run custom Gradle task. By default it\'s "installDebug"',
     },
   ],
 };

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -7,103 +7,60 @@
  * @flow
  */
 
-import {spawnSync, execFileSync} from 'child_process';
-import {logger} from '@react-native-community/cli-tools';
+import chalk from 'chalk';
+import {execFileSync} from 'child_process';
+import {logger, CLIError} from '@react-native-community/cli-tools';
 import adb from './adb';
 import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
+import type {FlagsT} from '.';
 
 function getCommand(appFolder, command) {
   return appFolder ? `${appFolder}:${command}` : command;
 }
 
+function toPascalCase(value: string) {
+  return value[0].toUpperCase() + value.slice(1);
+}
+
 function runOnAllDevices(
-  args: Object,
+  args: FlagsT,
   cmd: string,
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
 ) {
   try {
-    const gradleArgs = [];
+    const gradleArgs = [
+      getCommand(args.appFolder, 'install' + toPascalCase(args.variant)),
+    ];
 
-    if (args.installDebug) {
-      gradleArgs.push(getCommand(args.appFolder, args.installDebug));
-    } else if (args.variant) {
-      gradleArgs.push(
-        `${getCommand(
-          args.appFolder,
-          'install',
-        )}${args.variant[0].toUpperCase()}${args.variant.slice(1)}`,
-      );
-    } else if (args.flavor) {
-      logger.warn('--flavor has been deprecated. Use --variant instead');
-      gradleArgs.push(
-        `${getCommand(
-          args.appFolder,
-          'install',
-        )}${args.flavor[0].toUpperCase()}${args.flavor.slice(1)}`,
-      );
-    } else {
-      gradleArgs.push(getCommand(args.appFolder, 'installDebug'));
-    }
-
-    logger.info(
-      `Building and installing the app on the device (cd android && ${cmd} ${gradleArgs.join(
-        ' ',
-      )})...`,
+    logger.info('Installing the app...');
+    logger.debug(
+      `Running command "cd android && ${cmd} ${gradleArgs.join(' ')}"`,
     );
 
-    execFileSync(cmd, gradleArgs, {
-      stdio: [process.stdin, process.stdout, process.stderr],
-    });
+    execFileSync(cmd, gradleArgs, {stdio: 'inherit'});
   } catch (e) {
-    logger.error(
-      'Could not install the app on the device, read the error above for details.\n' +
-        'Make sure you have an Android emulator running or a device connected and have\n' +
-        'set up your Android development environment:\n' +
-        'https://facebook.github.io/react-native/docs/getting-started.html',
+    throw new CLIError(
+      `Failed to install the app. Make sure you have an Android emulator running or a device connected and the Android development environment set up: ${chalk.underline.dim(
+        'https://facebook.github.io/react-native/docs/getting-started.html#android-development-environment',
+      )}`,
+      e,
     );
-    // stderr is automatically piped from the gradle process, so the user
-    // should see the error already, there is no need to do
-    // `logger.info(e.stderr)`
-    return Promise.reject(e);
   }
   const devices = adb.getDevices(adbPath);
-  if (devices && devices.length > 0) {
-    devices.forEach(device => {
-      tryRunAdbReverse(args.port, device);
-      tryLaunchAppOnDevice(
-        device,
-        packageNameWithSuffix,
-        packageName,
-        adbPath,
-        args.mainActivity,
-      );
-    });
-  } else {
-    try {
-      // If we cannot execute based on adb devices output, fall back to
-      // shell am start
-      const fallbackAdbArgs = [
-        'shell',
-        'am',
-        'start',
-        '-n',
-        `${packageNameWithSuffix}/${packageName}.MainActivity`,
-      ];
-      logger.info(
-        `Starting the app (${adbPath} ${fallbackAdbArgs.join(' ')}...`,
-      );
-      spawnSync(adbPath, fallbackAdbArgs, {stdio: 'inherit'});
-    } catch (e) {
-      logger.error('adb invocation failed. Do you have adb in your PATH?');
-      // stderr is automatically piped from the gradle process, so the user
-      // should see the error already, there is no need to do
-      // `logger.info(e.stderr)`
-      return Promise.reject(e);
-    }
-  }
+
+  (devices.length > 0 ? devices : [undefined]).forEach(device => {
+    tryRunAdbReverse(args.port, device);
+    tryLaunchAppOnDevice(
+      device,
+      packageNameWithSuffix,
+      packageName,
+      adbPath,
+      args.mainActivity,
+    );
+  });
 }
 
 export default runOnAllDevices;

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -16,7 +16,7 @@ import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import type {FlagsT} from '.';
 import type {ConfigT} from 'types';
 
-function getCommand(appFolder, command) {
+function getTaskName(appFolder, command) {
   return appFolder ? `${appFolder}:${command}` : command;
 }
 
@@ -24,7 +24,7 @@ function toPascalCase(value: string) {
   return value[0].toUpperCase() + value.slice(1);
 }
 
-async function runOnAllDevices(
+function runOnAllDevices(
   args: FlagsT,
   cmd: string,
   packageNameWithSuffix: string,
@@ -34,7 +34,9 @@ async function runOnAllDevices(
 ) {
   try {
     const gradleArgs = [
-      getCommand(args.appFolder, 'install' + toPascalCase(args.variant)),
+      args.task
+        ? getTaskName(args.appFolder, args.task)
+        : getTaskName(args.appFolder, 'install' + toPascalCase(args.variant)),
     ];
 
     logger.info('Installing the app...');

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -14,7 +14,6 @@ import adb from './adb';
 import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import type {FlagsT} from '.';
-import type {ConfigT} from 'types';
 
 function getTaskName(appFolder, command) {
   return appFolder ? `${appFolder}:${command}` : command;
@@ -30,7 +29,6 @@ function runOnAllDevices(
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
-  config: ConfigT,
 ) {
   try {
     const gradleArgs = [

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -31,11 +31,8 @@ function runOnAllDevices(
   adbPath: string,
 ) {
   try {
-    const gradleArgs = [
-      args.task
-        ? getTaskName(args.appFolder, args.task)
-        : getTaskName(args.appFolder, 'install' + toPascalCase(args.variant)),
-    ];
+    const task = args.task || 'install' + toPascalCase(args.variant);
+    const gradleArgs = [getTaskName(args.appFolder, task)];
 
     logger.info('Installing the app...');
     logger.debug(

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -15,7 +15,7 @@ import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import type {FlagsT} from '.';
 
-function getTaskName(
+function getTaskNames(
   appFolder: string,
   commands: Array<string>,
 ): Array<string> {
@@ -37,7 +37,7 @@ function runOnAllDevices(
 ) {
   try {
     const task = args.task || ['install' + toPascalCase(args.variant)];
-    const gradleArgs = getTaskName(args.appFolder, task);
+    const gradleArgs = getTaskNames(args.appFolder, task);
 
     logger.info('Installing the app...');
     logger.debug(

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -15,8 +15,13 @@ import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import type {FlagsT} from '.';
 
-function getTaskName(appFolder, command) {
-  return appFolder ? `${appFolder}:${command}` : command;
+function getTaskName(
+  appFolder: string,
+  commands: Array<string>,
+): Array<string> {
+  return appFolder
+    ? commands.map(command => `${appFolder}:${command}`)
+    : commands;
 }
 
 function toPascalCase(value: string) {
@@ -31,8 +36,8 @@ function runOnAllDevices(
   adbPath: string,
 ) {
   try {
-    const task = args.task || 'install' + toPascalCase(args.variant);
-    const gradleArgs = [getTaskName(args.appFolder, task)];
+    const task = args.task || ['install' + toPascalCase(args.variant)];
+    const gradleArgs = getTaskName(args.appFolder, task);
 
     logger.info('Installing the app...');
     logger.debug(

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -67,7 +67,7 @@ function createInstallError(error) {
 
   // Pass the error message from the command to stdout because we pipe it to
   // parent process so it's not visible
-  console.log(stderr);
+  logger.log(stderr);
 
   // Handle some common failures and make the errors more helpful
   if (stderr.includes('No connected devices')) {

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -36,8 +36,8 @@ function runOnAllDevices(
   adbPath: string,
 ) {
   try {
-    const task = args.task || ['install' + toPascalCase(args.variant)];
-    const gradleArgs = getTaskNames(args.appFolder, task);
+    const tasks = args.tasks || ['install' + toPascalCase(args.variant)];
+    const gradleArgs = getTaskNames(args.appFolder, tasks);
 
     logger.info('Installing the app...');
     logger.debug(

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.js
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.js
@@ -8,10 +8,10 @@
  */
 
 import {spawnSync} from 'child_process';
-import {logger} from '@react-native-community/cli-tools';
+import {logger, CLIError} from '@react-native-community/cli-tools';
 
 function tryLaunchAppOnDevice(
-  device: string,
+  device?: string,
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
@@ -19,20 +19,22 @@ function tryLaunchAppOnDevice(
 ) {
   try {
     const adbArgs = [
-      '-s',
-      device,
       'shell',
       'am',
       'start',
       '-n',
       `${packageNameWithSuffix}/${packageName}.${mainActivity}`,
     ];
-    logger.info(
-      `Starting the app on ${device} (${adbPath} ${adbArgs.join(' ')})...`,
-    );
+    if (device) {
+      adbArgs.unshift('-s', device);
+      logger.info(`Starting the app on "${device}"...`);
+    } else {
+      logger.info('Starting the app...');
+    }
+    logger.debug(`Running command "${adbPath} ${adbArgs.join(' ')}"`);
     spawnSync(adbPath, adbArgs, {stdio: 'inherit'});
-  } catch (e) {
-    logger.error('adb invocation failed. Do you have adb in your PATH?');
+  } catch (error) {
+    throw new CLIError('Failed to start the app.', error);
   }
 }
 

--- a/packages/platform-android/src/commands/runAndroid/tryRunAdbReverse.js
+++ b/packages/platform-android/src/commands/runAndroid/tryRunAdbReverse.js
@@ -12,7 +12,7 @@ import {logger} from '@react-native-community/cli-tools';
 import getAdbPath from './getAdbPath';
 
 // Runs ADB reverse tcp:8081 tcp:8081 to allow loading the jsbundle from the packager
-function tryRunAdbReverse(packagerPort: number | string, device: string) {
+function tryRunAdbReverse(packagerPort: number | string, device?: string) {
   try {
     const adbPath = getAdbPath();
     const adbArgs = ['reverse', `tcp:${packagerPort}`, `tcp:${packagerPort}`];
@@ -22,13 +22,16 @@ function tryRunAdbReverse(packagerPort: number | string, device: string) {
       adbArgs.unshift('-s', device);
     }
 
-    logger.info(`Running ${adbPath} ${adbArgs.join(' ')}`);
+    logger.info('Connecting to the development server...');
+    logger.debug(`Running command "${adbPath} ${adbArgs.join(' ')}"`);
 
-    execFileSync(adbPath, adbArgs, {
-      stdio: [process.stdin, process.stdout, process.stderr],
-    });
+    execFileSync(adbPath, adbArgs, {stdio: 'inherit'});
   } catch (e) {
-    logger.info(`Could not run adb reverse: ${e.message}`);
+    logger.warn(
+      `Failed to connect to development server using "adb reverse": ${
+        e.message
+      }`,
+    );
   }
 }
 


### PR DESCRIPTION
Summary:
---------

- cleanup run-android implementation to remove duplication
- unify and simplify error messages, put details into verbose mode
- provide more helpful messages for common cases when installing with Gradle
- rename flag `installDebug` -> `task`

Fixes #251

Example messages:

<img width="839" alt="Screenshot 2019-05-07 at 10 31 09" src="https://user-images.githubusercontent.com/5106466/57288231-5e9b2f80-70b9-11e9-9f31-fbbc934a27d9.png">
<img width="534" alt="Screenshot 2019-05-07 at 11 12 51" src="https://user-images.githubusercontent.com/5106466/57288232-5e9b2f80-70b9-11e9-949e-fc247f7c812c.png">
<img width="824" alt="Screenshot 2019-05-07 at 11 13 20" src="https://user-images.githubusercontent.com/5106466/57288234-5f33c600-70b9-11e9-8c71-829bf9fd7d50.png">
<img width="233" alt="Screenshot 2019-05-07 at 11 13 27" src="https://user-images.githubusercontent.com/5106466/57288235-5f33c600-70b9-11e9-83eb-147823132b96.png">
<img width="426" alt="Screenshot 2019-05-07 at 11 14 34" src="https://user-images.githubusercontent.com/5106466/57288236-5f33c600-70b9-11e9-8079-8e10c7de8f70.png">


Test Plan:
----------

Adjusted tests accordingly.
