### PR TITLE
feat: automatically run `pod install` when running `init` command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "@react-native-community/cli-platform-ios": "^2.0.0-alpha.17",
     "@react-native-community/cli-tools": "^2.0.0-alpha.17",
     "chalk": "^1.1.1",
+    "command-exists": "^1.2.8",
     "commander": "^2.19.0",
     "compression": "^1.7.1",
     "connect": "^3.6.5",

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -272,7 +272,7 @@ export default (async function initialize(
   try {
     await createProject(projectName, options, version);
 
-    printRunInstructions(process.cwd(), projectName);
+    await printRunInstructions(process.cwd(), projectName);
   } catch (e) {
     logger.error(e.message);
     fs.removeSync(projectName);

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -127,14 +127,7 @@ async function installPods(loader: typeof Ora) {
         );
       }
 
-      try {
-        loader.start('Installing pods');
-      } catch (err) {
-        throw new CLIError(
-          'Failed to run "pod install", please try to run it manually.',
-          err,
-        );
-      }
+      loader.start('Installing pods');
     }
   }
 

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -164,7 +164,15 @@ async function installDependencies({
     silent: true,
   });
 
-  await installPods(loader);
+  try {
+    await installPods(loader);
+
+    process.chdir('..');
+  } catch (err) {
+    process.chdir('..');
+
+    throw err;
+  }
 
   loader.succeed();
 }

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -130,7 +130,6 @@ async function installPods(loader: typeof Ora) {
       try {
         loader.start('Installing pods');
       } catch (err) {
-        console.log(err);
         throw new CLIError(
           'Failed to run "pod install", please try to run it manually.',
           err,

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -117,14 +117,22 @@ async function installPods(loader: typeof Ora) {
 
     if (shouldInstallCocoaPods) {
       try {
-        await execa('sudo', ['gem', 'install', 'cocoapods'], {
+        // First attempt to install `cocoapods`
+        await execa('gem', ['install', 'cocoapods'], {
           stdio: 'pipe',
         });
       } catch (err) {
-        throw new CLIError(
-          'Error occurred while trying to install CocoaPods, please install it manually.',
-          err,
-        );
+        try {
+          // If that doesn't work then try with sudo
+          await execa('sudo', ['gem', 'install', 'cocoapods'], {
+            stdio: 'pipe',
+          });
+        } catch (err) {
+          throw new CLIError(
+            'Error occurred while trying to install CocoaPods, please run this command again.',
+            err,
+          );
+        }
       }
 
       loader.start('Installing pods');

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -74,7 +74,7 @@ async function createFromExternalTemplate(
     const {postInitScript} = templateConfig;
     if (postInitScript) {
       // Leaving trailing space because there may be stdout from the script
-      loader.start('Executing post init script ');
+      loader.start('Executing post init script');
       await executePostInitScript(name, postInitScript, templateSourceDir);
       loader.succeed();
     }

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -165,14 +165,10 @@ async function installDependencies({
     silent: true,
   });
 
-  try {
+  if (process.platform === 'darwin') {
     await installPods(loader);
 
     process.chdir('..');
-  } catch (err) {
-    process.chdir('..');
-
-    throw err;
   }
 
   loader.succeed();

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -228,7 +228,7 @@ export default (async function initialize(
   try {
     await createProject(projectName, options, version);
 
-    await printRunInstructions(process.cwd(), projectName);
+    printRunInstructions(process.cwd(), projectName);
   } catch (e) {
     logger.error(e.message);
     fs.removeSync(projectName);

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -79,7 +79,7 @@ async function createFromExternalTemplate(
     const {postInitScript} = templateConfig;
     if (postInitScript) {
       // Leaving trailing space because there may be stdout from the script
-      loader.start('Executing post init script');
+      loader.start('Executing post init script ');
       await executePostInitScript(name, postInitScript, templateSourceDir);
       loader.succeed();
     }

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -111,7 +111,7 @@ async function installPods(loader: typeof Ora) {
       {
         type: 'confirm',
         name: 'shouldInstallCocoaPods',
-        message: 'CocoaPods is not installed, Do you want to install it?',
+        message: 'CocoaPods is not installed, do you want to install it?',
       },
     ]);
 

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -121,7 +121,7 @@ async function installPods(loader: typeof Ora) {
           stdio: 'pipe',
         });
       } catch (err) {
-        throw new Error(
+        throw new CLIError(
           'Error occurred while trying to install CocoaPods, please install it manually.',
           err,
         );

--- a/packages/cli/src/commands/init/printRunInstructions.js
+++ b/packages/cli/src/commands/init/printRunInstructions.js
@@ -9,19 +9,22 @@
  */
 
 import path from 'path';
+import fs from 'fs-extra';
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 
-function printRunInstructions(projectDir: string, projectName: string) {
+async function printRunInstructions(projectDir: string, projectName: string) {
   const absoluteProjectDir = path.resolve(projectDir);
-  const xcodeProjectPath = `${path.resolve(
-    projectDir,
-    'ios',
-    projectName,
-  )}.xcworkspace`;
+  const iosProjectDir = path.resolve(projectDir, 'ios');
+
+  const iosPodsFile = path.resolve(iosProjectDir, `${projectName}.xcworkspace`);
+  const isUsingPods = await fs.pathExists(iosPodsFile);
+
   const relativeXcodeProjectPath = path.relative(
     process.cwd(),
-    xcodeProjectPath,
+    isUsingPods
+      ? iosPodsFile
+      : path.resolve(iosProjectDir, `${projectName}.xcodeproj`),
   );
 
   logger.log(`

--- a/packages/cli/src/commands/init/printRunInstructions.js
+++ b/packages/cli/src/commands/init/printRunInstructions.js
@@ -18,7 +18,7 @@ function printRunInstructions(projectDir: string, projectName: string) {
     projectDir,
     'ios',
     projectName,
-  )}.xcodeproj`;
+  )}.xcworkspace`;
   const relativeXcodeProjectPath = path.relative(
     process.cwd(),
     xcodeProjectPath,

--- a/packages/cli/src/commands/init/printRunInstructions.js
+++ b/packages/cli/src/commands/init/printRunInstructions.js
@@ -9,16 +9,16 @@
  */
 
 import path from 'path';
-import fs from 'fs-extra';
+import fs from 'fs';
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 
-async function printRunInstructions(projectDir: string, projectName: string) {
+function printRunInstructions(projectDir: string, projectName: string) {
   const absoluteProjectDir = path.resolve(projectDir);
   const iosProjectDir = path.resolve(projectDir, 'ios');
 
   const iosPodsFile = path.resolve(iosProjectDir, `${projectName}.xcworkspace`);
-  const isUsingPods = await fs.pathExists(iosPodsFile);
+  const isUsingPods = fs.existsSync(iosPodsFile);
 
   const relativeXcodeProjectPath = path.relative(
     process.cwd(),

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -3,6 +3,7 @@ import execa from 'execa';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
 import commandExists from 'command-exists';
+import {logger} from '@react-native-community/cli-tools';
 
 async function installPods({
   projectName,

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -1,6 +1,8 @@
+// @flow
 import fs from 'fs-extra';
 import execa from 'execa';
 import chalk from 'chalk';
+import Ora from 'ora';
 import inquirer from 'inquirer';
 import commandExists from 'command-exists';
 import {logger} from '@react-native-community/cli-tools';
@@ -38,11 +40,13 @@ async function installPods({
         try {
           // First attempt to install `cocoapods`
           await execa('gem', ['install', 'cocoapods']);
-        } catch (err) {
+        } catch (_error) {
           try {
             // If that doesn't work then try with sudo
             await execa('sudo', ['gem', 'install', 'cocoapods']);
           } catch (error) {
+            logger.log(error.stderr);
+
             throw new Error(
               `Error occured while trying to install CocoaPods, which is required by this template.\nPlease try again manually: "sudo gem install cocoapods".\nCocoaPods documentation: ${chalk.dim.underline(
                 'https://cocoapods.org/',
@@ -59,8 +63,9 @@ async function installPods({
 
     try {
       await execa('pod', ['install']);
-    } catch (err) {
-      logger.log(err.stderr || err.stdout);
+    } catch (error) {
+      // "pod" command outputs errors to stdout (at least some of them)
+      logger.log(error.stderr || error.stdout);
 
       throw new Error(
         `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${projectName}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
@@ -68,8 +73,8 @@ async function installPods({
         )}`,
       );
     }
-  } catch (err) {
-    throw err;
+  } catch (error) {
+    throw error;
   } finally {
     process.chdir('..');
   }

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -1,0 +1,77 @@
+import fs from 'fs-extra';
+import execa from 'execa';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import commandExists from 'command-exists';
+
+async function installPods({
+  projectName,
+  loader,
+}: {
+  projectName: string,
+  loader: typeof Ora,
+}) {
+  try {
+    process.chdir('ios');
+
+    const hasPods = await fs.pathExists('Podfile');
+
+    if (!hasPods) {
+      return;
+    }
+
+    try {
+      await commandExists('pod');
+    } catch (err) {
+      loader.stop();
+
+      const {shouldInstallCocoaPods} = await inquirer.prompt([
+        {
+          type: 'confirm',
+          name: 'shouldInstallCocoaPods',
+          message: 'CocoaPods is not installed, do you want to install it?',
+        },
+      ]);
+
+      if (shouldInstallCocoaPods) {
+        try {
+          // First attempt to install `cocoapods`
+          await execa('gem', ['install', 'cocoapods']);
+        } catch (err) {
+          try {
+            // If that doesn't work then try with sudo
+            await execa('sudo', ['gem', 'install', 'cocoapods']);
+          } catch (err) {
+            throw new Error(
+              `Error occured while trying to install CocoaPods, which is required by this template.\nPlease try again manually: "sudo gem install cocoapods".\nCocoaPods documentation: ${chalk.dim.underline(
+                'https://cocoapods.org/',
+              )}`,
+            );
+          }
+        }
+
+        // This only shows when `CocoaPods` is automatically installed,
+        // if it's already installed then we just show the `Installing dependencies` step
+        loader.start('Installing CocoaPods dependencies');
+      }
+    }
+
+    try {
+      await execa('pod', ['install']);
+    } catch (err) {
+      logger.log(err.stderr || err.stdout);
+
+      throw new Error(
+        `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${projectName}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
+          'https://cocoapods.org/',
+        )}`,
+      );
+    }
+  } catch (err) {
+    throw err;
+  } finally {
+    process.chdir('..');
+  }
+}
+
+export default installPods;

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -23,7 +23,7 @@ async function installPods({
 
     try {
       await commandExists('pod');
-    } catch (err) {
+    } catch (e) {
       loader.stop();
 
       const {shouldInstallCocoaPods} = await inquirer.prompt([
@@ -42,7 +42,7 @@ async function installPods({
           try {
             // If that doesn't work then try with sudo
             await execa('sudo', ['gem', 'install', 'cocoapods']);
-          } catch (err) {
+          } catch (error) {
             throw new Error(
               `Error occured while trying to install CocoaPods, which is required by this template.\nPlease try again manually: "sudo gem install cocoapods".\nCocoaPods documentation: ${chalk.dim.underline(
                 'https://cocoapods.org/',

--- a/packages/cli/src/tools/packageManager.js
+++ b/packages/cli/src/tools/packageManager.js
@@ -1,5 +1,6 @@
 // @flow
 import execa from 'execa';
+import commandExists from 'command-exists';
 import logger from './logger';
 import {getYarnVersionIfAvailable, isProjectUsingYarn} from './yarn';
 
@@ -11,7 +12,12 @@ type Options = {|
 
 let projectDir;
 
-function executeCommand(
+export const ERRORS = {
+  noCocoaPods: 'noCocoaPods',
+  failedToRunPodInstall: 'failedToRunPodInstall',
+};
+
+export function executeCommand(
   command: string,
   args: Array<string>,
   options?: Options,
@@ -61,8 +67,34 @@ export function uninstall(packageNames: Array<string>, options?: Options) {
     : executeCommand('npm', ['uninstall', ...packageNames, '--save'], options);
 }
 
-export function installAll(options?: Options) {
-  return shouldUseYarn(options)
-    ? executeCommand('yarn', ['install'], options)
-    : executeCommand('npm', ['install'], options);
+export function installCocoaPods() {
+  return executeCommand('sudo', ['gem', 'install', 'cocoapods'], {
+    silent: false,
+  });
+}
+
+export async function installPods(options?: Options) {
+  try {
+    await commandExists('pod');
+  } catch (err) {
+    return {error: ERRORS.noCocoaPods};
+  }
+
+  process.chdir('ios');
+
+  try {
+    return await executeCommand('pod', ['install'], options);
+  } catch (err) {
+    return {error: ERRORS.failedToRunPodInstall};
+  }
+}
+
+export async function installAll(options?: Options) {
+  shouldUseYarn(options)
+    ? await executeCommand('yarn', ['install'], options)
+    : await executeCommand('npm', ['install'], options);
+
+  // TODO: only do this on macOS
+
+  return installPods(options);
 }

--- a/packages/cli/src/tools/packageManager.js
+++ b/packages/cli/src/tools/packageManager.js
@@ -1,6 +1,5 @@
 // @flow
 import execa from 'execa';
-import commandExists from 'command-exists';
 import logger from './logger';
 import {getYarnVersionIfAvailable, isProjectUsingYarn} from './yarn';
 
@@ -17,7 +16,7 @@ export const ERRORS = {
   failedToRunPodInstall: 'failedToRunPodInstall',
 };
 
-export function executeCommand(
+function executeCommand(
   command: string,
   args: Array<string>,
   options?: Options,
@@ -67,34 +66,8 @@ export function uninstall(packageNames: Array<string>, options?: Options) {
     : executeCommand('npm', ['uninstall', ...packageNames, '--save'], options);
 }
 
-export function installCocoaPods() {
-  return executeCommand('sudo', ['gem', 'install', 'cocoapods'], {
-    silent: false,
-  });
-}
-
-export async function installPods(options?: Options) {
-  try {
-    await commandExists('pod');
-  } catch (err) {
-    return {error: ERRORS.noCocoaPods};
-  }
-
-  process.chdir('ios');
-
-  try {
-    return await executeCommand('pod', ['install'], options);
-  } catch (err) {
-    return {error: ERRORS.failedToRunPodInstall};
-  }
-}
-
-export async function installAll(options?: Options) {
-  shouldUseYarn(options)
-    ? await executeCommand('yarn', ['install'], options)
-    : await executeCommand('npm', ['install'], options);
-
-  // TODO: only do this on macOS
-
-  return installPods(options);
+export function installAll(options?: Options) {
+  return shouldUseYarn(options)
+    ? executeCommand('yarn', ['install'], options)
+    : executeCommand('npm', ['install'], options);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,6 +2787,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-exists@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
+  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
+
 commander@^2.19.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"


### PR DESCRIPTION
Summary:
---------

This PR fixes #368 of which checks if CocoaPods is installed and runs `pod install`.

Test Plan:
----------

Run `node /path/to/cli/packages/cli/build/index.js init --template /path/to/react-native AwesomeProject`

Looks like this now when user doesn't have CocoaPods installed:

![Screenshot 2019-05-07 at 11 15 35](https://user-images.githubusercontent.com/6207220/57288858-9656a700-70ba-11e9-8602-81bd1b3f8151.png)

With CocoaPods installed:

![Screenshot 2019-05-07 at 11 19 08](https://user-images.githubusercontent.com/6207220/57288868-9ce51e80-70ba-11e9-9ed2-763707ba999c.png)

---

#### TODOs

- [x] Verify if `Podfile` exists before trying to install and/or check if `cocoapods` is installed;
- [x] Don't do this for non-mac machines;
- [x] Install `cocoapods` without `sudo`, if that doesn't work then do it with `sudo`;
- [x] Verify that `.xcworkspace` exists before printing it out on the run instructions.