### PR TITLE
fix: run "config" from react-native binary in autolinking scripts

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -54,7 +54,8 @@ class ReactNativeModules {
   private ArrayList<HashMap<String, String>> reactNativeModules
 
   private static String LOG_PREFIX = ":ReactNative:"
-  private static String REACT_NATIVE_CONFIG_CMD = "node ./node_modules/.bin/react-native config"
+  private static String REACT_NATIVE_CONFIG_CMD = "yarn run react-native config"
+  private static String REACT_NATIVE_CONFIG_CMD_FALLBACK = "node ./node_modules/.bin/react-native config"
 
   ReactNativeModules(Logger logger) {
     this.logger = logger
@@ -172,9 +173,17 @@ class ReactNativeModules {
     ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
 
     def cmdProcess
+    def root = getReactNativeProjectRoot()
+    def command = REACT_NATIVE_CONFIG_CMD_FALLBACK
 
     try {
-      cmdProcess = Runtime.getRuntime().exec(REACT_NATIVE_CONFIG_CMD, null, getReactNativeProjectRoot())
+      try {
+        // Check if project uses Yarn
+        def isYarnProject = Runtime.getRuntime().exec("node -e console.log(require.resolve('./yarn.lock'))", null, root)
+        isYarnProject.waitFor()
+        command = REACT_NATIVE_CONFIG_CMD
+      } catch(Exception exception) {}
+      cmdProcess = Runtime.getRuntime().exec(command, null, root)
       cmdProcess.waitFor()
     } catch (Exception exception) {
       this.logger.warn("${LOG_PREFIX}${exception.message}")
@@ -183,6 +192,7 @@ class ReactNativeModules {
     }
 
     def reactNativeConfigOutput = cmdProcess.in.text
+    // TODO: filter out "warn ...", "yarn run ..." "$ ..." "Done in ..." from reactNativeConfigOutput that are output by Yarn
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
     def dependencies = json["dependencies"]
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -54,8 +54,7 @@ class ReactNativeModules {
   private ArrayList<HashMap<String, String>> reactNativeModules
 
   private static String LOG_PREFIX = ":ReactNative:"
-  private static String REACT_NATIVE_CLI_BIN = "node_modules${File.separator}@react-native-community${File.separator}cli${File.separator}build${File.separator}index.js"
-  private static String REACT_NATIVE_CONFIG_CMD = "node ${REACT_NATIVE_CLI_BIN} config"
+  private static String REACT_NATIVE_CONFIG_CMD = "node ./node_modules/.bin/react-native config"
 
   ReactNativeModules(Logger logger) {
     this.logger = logger

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -164,6 +164,23 @@ class ReactNativeModules {
   }
 
   /**
+   * Given a command string output, filter out non-json parts that may
+   * come from the package manager running the command.
+   *
+   * @param commandOutput
+   * @return string
+   */
+  String getCommandJsonOutput(String commandOutput) {
+    def output = []
+    commandOutput.readLines().forEach { line ->
+        if (line.startsWith("{") || line.startsWith("}") || line.startsWith(" ")) {
+            output.add(line)
+        }
+    }
+    return String.join("\n", output)
+  }
+
+  /**
    * Runs a process to call the React Native CLI Config command and parses the output
    *
    * @return ArrayList < HashMap < String , String > >
@@ -191,8 +208,7 @@ class ReactNativeModules {
       return reactNativeModules
     }
 
-    def reactNativeConfigOutput = cmdProcess.in.text
-    // TODO: filter out "warn ...", "yarn run ..." "$ ..." "Done in ..." from reactNativeConfigOutput that are output by Yarn
+    def reactNativeConfigOutput = getCommandJsonOutput(cmdProcess.in.text)
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
     def dependencies = json["dependencies"]
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -54,7 +54,7 @@ class ReactNativeModules {
   private ArrayList<HashMap<String, String>> reactNativeModules
 
   private static String LOG_PREFIX = ":ReactNative:"
-  private static String REACT_NATIVE_CONFIG_CMD = "yarn run react-native config"
+  private static String REACT_NATIVE_CONFIG_CMD = "yarn run --silent react-native config"
   private static String REACT_NATIVE_CONFIG_CMD_FALLBACK = "node ./node_modules/.bin/react-native config"
 
   ReactNativeModules(Logger logger) {
@@ -164,23 +164,6 @@ class ReactNativeModules {
   }
 
   /**
-   * Given a command string output, filter out non-json parts that may
-   * come from the package manager running the command.
-   *
-   * @param commandOutput
-   * @return string
-   */
-  String getCommandJsonOutput(String commandOutput) {
-    def output = []
-    commandOutput.readLines().forEach { line ->
-        if (line.startsWith("{") || line.startsWith("}") || line.startsWith(" ")) {
-            output.add(line)
-        }
-    }
-    return String.join("\n", output)
-  }
-
-  /**
    * Runs a process to call the React Native CLI Config command and parses the output
    *
    * @return ArrayList < HashMap < String , String > >
@@ -208,7 +191,7 @@ class ReactNativeModules {
       return reactNativeModules
     }
 
-    def reactNativeConfigOutput = getCommandJsonOutput(cmdProcess.in.text)
+    def reactNativeConfigOutput = cmdProcess.in.text
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
     def dependencies = json["dependencies"]
 

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -5,12 +5,10 @@
 #
 def use_native_modules!(root = "..", packages = nil)
   if (!packages)
-    # Resolve the CLI's main index file
-    cli_bin = Pod::Executable.execute_command("node", ["-e", "console.log(require.resolve('@react-native-community/cli/build/index.js'))"], true).strip
     output = ""
     # Make sure `react-native config` is ran from your project root
     Dir.chdir(root) do
-      output = Pod::Executable.execute_command("node", [cli_bin, "config"], true)
+      output = Pod::Executable.execute_command("node", ["./node_modules/.bin/react-native", "config"], true)
     end
 
     json = []

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -5,15 +5,28 @@
 #
 def use_native_modules!(root = "..", packages = nil)
   if (!packages)
+    command = "node"
+    args = ["./node_modules/.bin/react-native", "config"]
+    begin
+      # Check if project uses Yarn
+      Pod::Executable.execute_command("node", ["-e", "console.log(require.resolve('#{root}/yarn.lock'))"], true)
+      command = "yarn"
+      args = ["run", "react-native", "config"]
+    rescue
+    end
+
     output = ""
     # Make sure `react-native config` is ran from your project root
     Dir.chdir(root) do
-      output = Pod::Executable.execute_command("node", ["./node_modules/.bin/react-native", "config"], true)
+      output = Pod::Executable.execute_command(command, args, true)
     end
 
     json = []
     output.each_line do |line|
       case line
+      when /^yarn run/
+      when /^\$/
+      when /^Done/
       when /^warn\s(.+)/
         Pod::UI.warn($1)
       when /^(success|info|error|debug)\s(.+)/

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -11,7 +11,7 @@ def use_native_modules!(root = "..", packages = nil)
       # Check if project uses Yarn
       Pod::Executable.execute_command("node", ["-e", "console.log(require.resolve('#{root}/yarn.lock'))"], true)
       command = "yarn"
-      args = ["run", "react-native", "config"]
+      args = ["run", "--silent", "react-native", "config"]
     rescue
     end
 
@@ -24,9 +24,6 @@ def use_native_modules!(root = "..", packages = nil)
     json = []
     output.each_line do |line|
       case line
-      when /^yarn run/
-      when /^\$/
-      when /^Done/
       when /^warn\s(.+)/
         Pod::UI.warn($1)
       when /^(success|info|error|debug)\s(.+)/


### PR DESCRIPTION
Summary:
---------

Since `@react-native-community/cli` is not declared as template dependency, there is a possibility for Node to not be able to resolve it. It may happen because package managers can put the package inside `react-native/node_modules/` behind a symlink (like `npm` does in some scenarios) which is invisible to `require.resolve`. 

This diff changes autolinking scripts to use `config` command directly from `react-native` binary instead, as `react-native` is a direct dependency of any template.

Because running node binaries differs between package managers (e.g. Yarn in PnP mode doesn't have `node_modules/` so no `node_modules/.bin/` as well), the best thing we can do is to directly run the command through a package manager. For now Yarn and npm are supported, I'm happy to extend support for pnpm as well in the future if requested.

What happens now:
1) if the project root has Yarn lockfile, use `yarn run react-native config`
2) if not, fallback to `node ./node_modules/.bin/react-native config` (could be replaced with less safe `npx` later)

Test Plan:
----------

Try init with tarball RN master.