### PR TITLE
Add `installPods` to legacy init

### DIFF
--- a/packages/cli/src/commands/init/initCompat.js
+++ b/packages/cli/src/commands/init/initCompat.js
@@ -15,6 +15,7 @@ import printRunInstructions from './printRunInstructions';
 import {createProjectFromTemplate} from '../../tools/generator/templates';
 import * as PackageManager from '../../tools/packageManager';
 import {logger} from '@react-native-community/cli-tools';
+import installPods from '../../tools/installPods';
 
 /**
  * Creates the template for a React Native project given the provided
@@ -76,6 +77,13 @@ async function generateProject(destinationRoot, newProjectName, options) {
   ]);
 
   addJestToPackageJson(destinationRoot);
+
+  if (process.platform === 'darwin') {
+    logger.info('Installing required CocoaPods dependencies');
+
+    await installPods({projectName: newProjectName});
+  }
+
   printRunInstructions(destinationRoot, newProjectName);
 }
 

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -12,7 +12,7 @@ async function installPods({
   loader,
 }: {
   projectName: string,
-  loader: typeof Ora,
+  loader?: typeof Ora,
 }) {
   try {
     process.chdir('ios');
@@ -26,7 +26,9 @@ async function installPods({
     try {
       await commandExists('pod');
     } catch (e) {
-      loader.stop();
+      if (loader) {
+        loader.stop();
+      }
 
       const {shouldInstallCocoaPods} = await inquirer.prompt([
         {
@@ -57,7 +59,9 @@ async function installPods({
 
         // This only shows when `CocoaPods` is automatically installed,
         // if it's already installed then we just show the `Installing dependencies` step
-        loader.start('Installing CocoaPods dependencies');
+        if (loader) {
+          loader.start('Installing CocoaPods dependencies');
+        }
       }
     }
 


### PR DESCRIPTION
Summary:
---------

This PR is related to #368 and adds `installPods` to the legacy init.


Test Plan:
----------

Follow https://github.com/react-native-community/cli/blob/master/CONTRIBUTING.md#testing-init-command.
