### PR TITLE
Improve CocoaPods prompt question when running  `init`

### DIFF
--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -32,7 +32,11 @@ async function installPods({
         {
           type: 'confirm',
           name: 'shouldInstallCocoaPods',
-          message: 'CocoaPods is not installed, do you want to install it?',
+          message: `CocoaPods ${chalk.dim.underline(
+            '(https://cocoapods.org/)',
+          )} ${chalk.reset.bold(
+            "is not installed. It's necessary for iOS project to run correctly. Do you want to install it?",
+          )}`,
         },
       ]);
 


### PR DESCRIPTION
Summary:
---------

This PR adds the CocoaPods documentation link to the prompt question when running `init`.

Test Plan:
----------

1. Run `sudo gem uninstall cocoapods` (or without sudo);
1. Run `react-native init`.
