### PR TITLE
feat: Show message if CocoaPods installation takes long

### DIFF
--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -40,14 +40,24 @@ async function installPods({
         },
       ]);
 
+      // This is only shown if it takes more than 30 seconds for the CocoaPods installation to finish
+      const cocoaPodsInstallationTimeMessage = setTimeout(
+        () => logger.info('Installing CocoaPods, this may take a few minutes'),
+        30000,
+      );
+
       if (shouldInstallCocoaPods) {
         try {
           // First attempt to install `cocoapods`
           await execa('gem', ['install', 'cocoapods']);
+
+          clearTimeout(cocoaPodsInstallationTimeMessage);
         } catch (_error) {
           try {
             // If that doesn't work then try with sudo
             await execa('sudo', ['gem', 'install', 'cocoapods']);
+
+            clearTimeout(cocoaPodsInstallationTimeMessage);
           } catch (error) {
             logger.log(error.stderr);
 

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -7,6 +7,8 @@ import inquirer from 'inquirer';
 import commandExists from 'command-exists';
 import {logger} from '@react-native-community/cli-tools';
 
+const COCOAPODS_INSTALLATION_TIMEOUT = 30000;
+
 async function installPods({
   projectName,
   loader,
@@ -40,24 +42,20 @@ async function installPods({
         },
       ]);
 
-      // This is only shown if it takes more than 30 seconds for the CocoaPods installation to finish
-      const cocoaPodsInstallationTimeMessage = setTimeout(
-        () => logger.info('Installing CocoaPods, this may take a few minutes'),
-        30000,
-      );
-
       if (shouldInstallCocoaPods) {
+        // Show a helpful notice when installation takes more than usually
+        const cocoaPodsInstallationTimeMessage = setTimeout(
+          () =>
+            logger.info('Installing CocoaPods, this may take a few minutes'),
+          COCOAPODS_INSTALLATION_TIMEOUT,
+        );
         try {
           // First attempt to install `cocoapods`
           await execa('gem', ['install', 'cocoapods']);
-
-          clearTimeout(cocoaPodsInstallationTimeMessage);
         } catch (_error) {
           try {
             // If that doesn't work then try with sudo
             await execa('sudo', ['gem', 'install', 'cocoapods']);
-
-            clearTimeout(cocoaPodsInstallationTimeMessage);
           } catch (error) {
             logger.log(error.stderr);
 
@@ -67,6 +65,8 @@ async function installPods({
               )}`,
             );
           }
+        } finally {
+          clearTimeout(cocoaPodsInstallationTimeMessage);
         }
 
         // This only shows when `CocoaPods` is automatically installed,


### PR DESCRIPTION
Summary:
---------

This PR shows a different message if `cocoapods` installation takes more than 30 seconds.


Test Plan:
----------

1. `sudo gem uninstall cocoapods`;
1. Put `await execa('sleep', ['30']);`[here](https://github.com/lucasbento/cli/blob/5eb25ea43788a280266f3659ce1ec11f54525168/packages/cli/src/tools/installPods.js#L59).

---

### When it takes more than 30 seconds

![Screenshot 2019-05-15 at 15 44 03](https://user-images.githubusercontent.com/6207220/57780728-246d0600-7729-11e9-8773-b8e38bcbb4c5.png)

### Less than 30 seconds

![Screenshot 2019-05-15 at 15 46 46](https://user-images.githubusercontent.com/6207220/57780742-2afb7d80-7729-11e9-9c88-8567025904bf.png)

 