### PR TITLE
feat: allow `dependencyConfig` to override `podspec` name

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -56,6 +56,7 @@ The following settings are available on iOS and Android:
 ```ts
 type DependencyParamsIOST = {
   project?: string,
+  podspec?: string,
   sharedLibraries?: string[],
 };
 
@@ -70,6 +71,10 @@ type DependencyParamsAndroidT = {
 #### platforms.ios.project
 
 Custom path to `.xcodeproj`
+
+#### platforms.ios.podspec
+
+Custom `podspec` name to use when auto-linking (without the file extension). Your `podspec` file must be located in the root of the dependency package.
 
 #### platforms.ios.sharedLibraries
 

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -49,6 +49,7 @@ export const dependencyConfig = t
             ios: t
               .object({
                 project: t.string(),
+                podspec: t.string(),
                 sharedLibraries: t.array().items(t.string()),
                 libraryFolder: t.string(),
               })

--- a/packages/platform-ios/src/config/index.js
+++ b/packages/platform-ios/src/config/index.js
@@ -53,7 +53,7 @@ export function projectConfig(
     folder,
     pbxprojPath: path.join(projectPath, 'project.pbxproj'),
     podfile: findPodfilePath(projectPath),
-    podspec: findPodspecName(folder),
+    podspec: userConfig.podspec || findPodspecName(folder),
     projectPath,
     projectName: path.basename(projectPath),
     libraryFolder: userConfig.libraryFolder || 'Libraries',

--- a/types/index.js
+++ b/types/index.js
@@ -66,6 +66,7 @@ type ProjectParamsAndroidT = {
  */
 type ProjectParamsIOST = {
   project?: string,
+  podspec?: string,
   sharedLibraries?: string[],
   libraryFolder?: string,
   plist: any[],
@@ -221,7 +222,7 @@ type ProjectConfigIOST = {
   folder: string,
   pbxprojPath: string,
   podfile: null,
-  podspec: null,
+  podspec: null | string,
   projectPath: string,
   projectName: string,
   libraryFolder: string,


### PR DESCRIPTION
Summary:
---------

This change allows dependencies to specify a custom name of the podspec to use when linking / auto-linking ([used here in auto-linking](https://github.com/react-native-community/cli/blob/master/packages/platform-ios/native_modules.rb#L44))


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
