### PR TITLE
feat: log error stacktrace by default

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -47,7 +47,9 @@ const handleError = err => {
       )}`,
     );
   }
-  logger.debug(chalk.dim(err.stack));
+  if (err.stack) {
+    logger.log(chalk.dim(err.stack));
+  }
   process.exit(1);
 };
 

--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -114,13 +114,13 @@ async function runOnSimulator(xcodeProject, scheme, args: FlagsT) {
         {encoding: 'utf8'},
       ),
     );
-  } catch (e) {
-    throw new CLIError('Could not parse the simulator list output');
+  } catch (error) {
+    throw new CLIError('Could not parse the simulator list output', error);
   }
 
   const selectedSimulator = findMatchingSimulator(simulators, args.simulator);
   if (!selectedSimulator) {
-    throw new CLIError(`Could not find ${args.simulator} simulator`);
+    throw new CLIError(`Could not find "${args.simulator}" simulator`);
   }
 
   /**

--- a/packages/platform-ios/src/link-pods/registerNativeModule.js
+++ b/packages/platform-ios/src/link-pods/registerNativeModule.js
@@ -7,7 +7,7 @@
  * @format
  */
 import chalk from 'chalk';
-import {CLIError, inlineString} from '@react-native-community/cli-tools';
+import {CLIError} from '@react-native-community/cli-tools';
 
 import readPodfile from './readPodfile';
 import findPodTargetLine from './findPodTargetLine';
@@ -36,20 +36,18 @@ function getLinesToAddEntry(podLines, {projectName}) {
   }
   const firstTargetLined = findPodTargetLine(podLines, projectName);
   if (firstTargetLined === null) {
-    throw new CLIError(
-      inlineString(`
-        We couldn't find a target to add a CocoaPods dependency.
-        
-        Make sure that you have a "${chalk.dim(
-          `target '${projectName.replace('.xcodeproj', '')}' do`,
-        )}" line in your Podfile.
-        
-        Alternatively, include "${chalk.dim(
-          MARKER_TEXT,
-        )}" in a Podfile where we should add
-        linked dependencies.
-    `),
-    );
+    throw new CLIError(`
+      We couldn't find a target to add a CocoaPods dependency.
+
+      Make sure that you have a "${chalk.dim(
+        `target '${projectName.replace('.xcodeproj', '')}' do`,
+      )}" line in your Podfile.
+
+      Alternatively, include "${chalk.dim(
+        MARKER_TEXT,
+      )}" in a Podfile where we should add
+      linked dependencies.
+    `);
   }
   return findLineToAddPod(podLines, firstTargetLined);
 }

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -1,28 +1,24 @@
 /**
- * @flow
- */
-
-/**
- * CLIError
- *
- * Features:
- * - uses original stack trace when error object is passed
- * - makes an inline string to match current styling inside CLI
+ * A custom Error that creates a single-lined message to match current styling inside CLI.
+ * Uses original stack trace when `originalError` is passed or erase the stack if it's not defined.
  */
 export class CLIError extends Error {
-  constructor(msg: string, originError?: Error | string) {
+  constructor(msg: string, originalError?: Error | string) {
     super(inlineString(msg));
-    if (originError) {
+    if (originalError) {
       this.stack =
-        typeof originError === 'string'
-          ? originError
-          : originError.stack ||
+        typeof originalError === 'string'
+          ? originalError
+          : originalError.stack ||
             ''
               .split('\n')
               .slice(0, 2)
               .join('\n');
     } else {
-      Error.captureStackTrace(this, CLIError);
+      // When the "originalError" is not passed, it means that we know exactly
+      // what went wrong and provide means to fix it. In such cases showing the
+      // stack is an unnecessary clutter to the CLI output, hence removing it.
+      delete this.stack;
     }
   }
 }

--- a/packages/tools/src/isPackagerRunning.ts
+++ b/packages/tools/src/isPackagerRunning.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 import fetch from 'node-fetch';


### PR DESCRIPTION
Summary:
---------

Hiding the stack trace behind `debug` log level was not a good idea, as it turned out users are not using `--verbose` flag when sending bug reports.

This PR changes the approach to always show the stack if available. The stack may not be available if it was removed, e.g. by the `CLIError` which removes it when the `originalError` parameter is not passed, since we assume that the failure is known and expected so stack trace is not necessary.


Test Plan:
----------

Dimmed stacktrace shows every time a generic, non `CLIError` happens
