### PR TITLE
[CI] Migrate to Circle 2.1, add Node LTS tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,24 @@
-version: 2
+version: 2.1
 
 defaults: &defaults
-  docker:
-    - image: circleci/node:8
   working_directory: ~/react-native-cli
 
-jobs:
-  install-dependencies:
+executors:
+  node8:
     <<: *defaults
+    docker:
+      - image: circleci/node:8
+  nodelts:
+    <<: *defaults
+    docker:
+      - image: circleci/node:lts
+  noderuby:
+    <<: *defaults
+    docker:
+      - image: circleci/ruby:2.4-node
+
+commands:
+  install-dependencies:
     steps:
       - checkout
       - attach_workspace:
@@ -25,28 +36,22 @@ jobs:
           root: .
           paths:
             - .
-  lint:
-    <<: *defaults
+  run-lint:
     steps:
       - attach_workspace:
           at: ~/react-native-cli
       - run: yarn lint
-  typecheck:
-    <<: *defaults
+  run-typecheck:
     steps:
       - attach_workspace:
           at: ~/react-native-cli
       - run: yarn flow-check
-  cocoa-pods:
-    <<: *defaults
-    docker:
-      - image: circleci/ruby:2.4-node
+  run-cocoa-pods-tests:
     steps:
       - attach_workspace:
           at: ~/react-native-cli
       - run: yarn test:ci:cocoapods
-  unit-tests:
-    <<: *defaults
+  run-unit-tests:
     steps:
       - attach_workspace:
           at: ~/react-native-cli
@@ -54,30 +59,63 @@ jobs:
       - store_artifacts:
           path: coverage
           destination: coverage
-  e2e-tests:
-    <<: *defaults
+  run-e2e-tests:
     steps:
       - attach_workspace:
           at: ~/react-native-cli
       - run: yarn test:ci:e2e
 
+jobs:
+  setup:
+    executor: node8
+    steps:
+      - install-dependencies
+  lint:
+    executor: node8
+    steps:
+      - run-lint
+  typecheck:
+    executor: node8
+    steps:
+      - run-typecheck
+  cocoa-pods:
+    executor: noderuby
+    steps:
+      - run-cocoa-pods-tests
+  unit-tests:
+    executor: node8
+    steps:
+      - run-unit-tests
+  e2e-tests:
+    executor: node8
+    steps:
+      - run-e2e-tests
+  lts-tests:
+    executor: nodelts
+    steps:
+      - install-dependencies
+      - run-lint
+      - run-typecheck
+      - run-unit-tests
+      - run-e2e-tests
+
 workflows:
-  version: 2
   build-and-test:
     jobs:
-      - install-dependencies
+      - setup
       - lint:
           requires:
-            - install-dependencies
+            - setup
       - typecheck:
           requires:
-            - install-dependencies
+            - setup
       - unit-tests:
           requires:
-            - install-dependencies
+            - setup
       - e2e-tests:
           requires:
-            - install-dependencies
+            - setup
       - cocoa-pods:
           requires:
-            - install-dependencies
+            - setup
+      - lts-tests


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

The main motivation behind this PR is to add test coverage for Node LTS (Node 10 as of today). In the interest of avoiding duplication, I migrated the existing config to Circle 2.1.

Circle's 2.1 schema allows for config reuse through the commands and executor keywords. 

The CLI's smaller scope serves as a good way to try out 2.1 before attempting to further modernize the core RN repo's Circle CI config.

Test Plan:
----------
Ran on Circle CI on my fork: https://circleci.com/workflow-run/545bcf9c-c6ee-42f6-b841-04f84ab1f47f

![Screen Shot 2019-05-24 at 12 52 31 PM](https://user-images.githubusercontent.com/165856/58353880-83ff9b80-7e24-11e9-8fd7-6d1ed109661d.png)


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->