### PR TITLE
[android] Fixed a crash when adding non-autolinked custom `ReactPackages`

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -12,7 +12,7 @@ import android.content.res.Resources;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import java.util.Arrays;
-import java.util.List;
+import java.util.ArrayList;
 
 {{ packageImports }}
 
@@ -38,10 +38,10 @@ public class PackageList {
     return this.getApplication().getApplicationContext();
   }
 
-  public List<ReactPackage> getPackages() {
-    return Arrays.<ReactPackage>asList(
+  public ArrayList<ReactPackage> getPackages() {
+    return new ArrayList<>(Arrays.<ReactPackage>asList(
       new MainReactPackage(){{ packageClassInstances }}
-    );
+    ));
   }
 }
 """


### PR DESCRIPTION
Summary:
---------

This fixes a bug when trying to add additional packages that are not automatically linked, `Arrays.asList` returns a fixed size List, therefore, preventing further ReactPackages being added to it. 

Wrapping it in an `ArrayList` makes it a variable-size List and fixes the issue.


Test Plan:
----------

Created a new template project, applied the changes locally, added a custom native module:

```java
    @Override
    protected List<ReactPackage> getPackages() {
      @SuppressWarnings("UnnecessaryLocalVariable")
      List<ReactPackage> packages = new PackageList(this).getPackages();
      // additional non auto detected packages can still be added here:
      packages.add(new ReactNativeFirebaseAppPackage());
      return packages;
    }
```

App builds and starts successfully:

![image](https://user-images.githubusercontent.com/5347038/58558852-bee54300-8219-11e9-9c1b-371aec7365a5.png)

(redbox confirms additional custom package is now there (duplicated because one comes from auto-link))
![image](https://user-images.githubusercontent.com/5347038/58558865-c73d7e00-8219-11e9-9d64-bfced3d97c1d.png)




