### PR TITLE
fix: no active iOS device case in `logIOS`

### DIFF
--- a/packages/platform-ios/src/commands/logIOS/index.js
+++ b/packages/platform-ios/src/commands/logIOS/index.js
@@ -36,7 +36,7 @@ async function logIOS() {
   const {devices} = JSON.parse(rawDevices);
 
   const device = findAvailableDevice(devices);
-  if (device === undefined) {
+  if (device === null) {
     logger.error('No active iOS device found');
     return;
   }


### PR DESCRIPTION
Summary:
---------

The `findAvailableDevice()` method can only return `null` or `Object`

```js
function findAvailableDevice(devices) {
  for (const key of Object.keys(devices)) {
    for (const device of devices[key]) {
      if (device.availability === '(available)' && device.state === 'Booted') {
        return device;
      }
    }
  }

  return null;
}
```

So this code
```js
if (device === undefined) {
  _cliTools().logger.error('No active iOS device found');

  return;
}
```
is useless at the moment

Test Plan:
----------

### When I have no active iOS devices
Before fix:
![Screenshot 2019-05-31 at 15 57 20](https://user-images.githubusercontent.com/42337914/58707212-e4f71880-83bc-11e9-9485-b204dd8d1215.png)

After fix:
![Screenshot 2019-05-31 at 15 58 45](https://user-images.githubusercontent.com/42337914/58707247-fdffc980-83bc-11e9-82c9-7f642b605954.png)
