### PR TITLE
fix: added an additional handling of symlink's in copyAndReplace.js for APP template

### DIFF
--- a/packages/cli/src/tools/copyAndReplace.js
+++ b/packages/cli/src/tools/copyAndReplace.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
+ * @flow
  */
 
 import fs from 'fs';
@@ -26,10 +26,10 @@ const binaryExtensions = ['.png', '.jar', '.keystore'];
  *        Function(path, 'identical' | 'changed' | 'new') => 'keep' | 'overwrite'
  */
 function copyAndReplace(
-  srcPath,
-  destPath,
-  replacements,
-  contentChangedCallback,
+  srcPath: string,
+  destPath: string,
+  replacements: {[key: string]: string},
+  contentChangedCallback: (destPath: string, contentChanged: string) => void,
 ) {
   if (isDirectory(srcPath)) {
     if (!fs.existsSync(destPath)) {
@@ -132,16 +132,16 @@ function copyBinaryFile(srcPath, destPath, cb) {
 }
 
 /**
- * extended directory expectation.
+ * Extended directory expectation.
  * npm installs the directory of a local node module as a link to the folder of origin location.
  * such the folder should be allowed to copy and replace as a template
  */
-function isDirectory(srcPath) {
+function isDirectory(srcPath: string) {
   let srcStat = fs.lstatSync(srcPath);
 
   if (srcStat.isSymbolicLink()) {
     try {
-      return fs.readDirSync(srcPath) || false;
+      return Boolean(fs.readdirSync(srcPath));
     } catch {
       return false;
     }

--- a/packages/cli/src/tools/copyAndReplace.js
+++ b/packages/cli/src/tools/copyAndReplace.js
@@ -31,7 +31,7 @@ function copyAndReplace(
   replacements,
   contentChangedCallback,
 ) {
-  if (fs.lstatSync(srcPath).isDirectory()) {
+  if (isDirectory(srcPath)) {
     if (!fs.existsSync(destPath)) {
       fs.mkdirSync(destPath);
     }
@@ -129,6 +129,25 @@ function copyBinaryFile(srcPath, destPath, cb) {
       cbCalled = true;
     }
   }
+}
+
+/**
+ * extended directory expectation.
+ * npm installs the directory of a local node module as a link to the folder of origin location.
+ * such the folder should be allowed to copy and replace as a template
+ */
+function isDirectory(srcPath) {
+  let srcStat = fs.lstatSync(srcPath);
+
+  if (srcStat.isSymbolicLink()) {
+    try {
+      return fs.readDirSync(srcPath) || false;
+    } catch {
+      return false;
+    }
+  }
+
+  return srcStat.isDirectory();
 }
 
 export default copyAndReplace;


### PR DESCRIPTION
Summary:
---------
During developing the app template for ReactNative I have faced with an issue while preparing the template after npm installed it as a dependency into the application:

(node:34062) UnhandledPromiseRejectionWarning: Error: EISDIR: illegal operation on a directory, read

After the investigation, I noticed that symlinks are handled incorrectly. isDirectory method returns false for symlink pointed to the directory.

Test Plan:
----------

Create an application with local template
