### PR TITLE
feat: Only pass `hasteImplModulePath` if the `hasteImpl` file is available in RN

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -5,6 +5,7 @@
 import path from 'path';
 import {createBlacklist} from 'metro';
 import {loadConfig} from 'metro-config';
+import {existsSync} from 'fs';
 import {type ConfigT} from 'types';
 import findSymlinkedModules from './findSymlinkedModules';
 
@@ -31,13 +32,16 @@ const getBlacklistRE = () => createBlacklist([/.*\/__fixtures__\/.*/]);
  * Otherwise, a.native.js will not load on Windows or other platforms
  */
 export const getDefaultConfig = (ctx: ConfigT) => {
+  const hasteImplPath = path.join(ctx.reactNativePath, 'jest/hasteImpl');
   return {
     resolver: {
       resolverMainFields: ['react-native', 'browser', 'main'],
       blacklistRE: getBlacklistRE(),
       platforms: [...ctx.haste.platforms, 'native'],
       providesModuleNodeModules: ctx.haste.providesModuleNodeModules,
-      hasteImplModulePath: path.join(ctx.reactNativePath, 'jest/hasteImpl'),
+      hasteImplModulePath: existsSync(hasteImplPath)
+        ? hasteImplPath
+        : undefined,
     },
     serializer: {
       getModulesRunBeforeMainModule: () => [


### PR DESCRIPTION
Summary:
---------
We are removing `hasteImpl` related stuff in https://github.com/facebook/react-native/pull/24811. However, the cli always passes a hasteImpl on to Metro and on to `jest-haste-map`. If a path to file that doesn't exist is passed, Metro will fail.

This changes the default config to detect whether there is a `hasteImpl.js` file available inside of RN and to only pass it when it is. This makes the cli compatible both with RN <0.60 and >0.61.


Test Plan:
----------

I patched the cli locally and it seemed to work when `hasteImpl` was removed.
