### PR TITLE
feat: Pass along CLI port configuration for Android

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.js
@@ -39,6 +39,10 @@ function runOnAllDevices(
     const tasks = args.tasks || ['install' + toPascalCase(args.variant)];
     const gradleArgs = getTaskNames(args.appFolder, tasks);
 
+    if (args.port != null) {
+      gradleArgs.push('-PreactNativeDevServerPort=' + args.port);
+    }
+
     logger.info('Installing the app...');
     logger.debug(
       `Running command "cd android && ${cmd} ${gradleArgs.join(' ')}"`,


### PR DESCRIPTION
Hello!

Over on the RN repo, I recently merged a PR to make the dev server port configurable on Android:

https://github.com/facebook/react-native/pull/23616

A change needs to be made to the CLI in order to pass this port information over to the Android build as a gradle build argument.

This PR includes that change. Although I'm having some trouble testing it since, what looks like, changes for a 2.0 release of this project.

From what I'm seeing, the `run-android` command appears to be missing when I link this repo directly:

![image](https://user-images.githubusercontent.com/590904/59127511-b2996e00-891c-11e9-84ea-79d0f3e4d19e.png)

Would it be better to send this out against the 1.0 branch?