### PR TITLE
fix: make sure the port passed to Metro is a number

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -53,7 +53,7 @@ export const getDefaultConfig = (ctx: ConfigT) => {
         require(path.join(ctx.reactNativePath, 'rn-get-polyfills'))(),
     },
     server: {
-      port: process.env.RCT_METRO_PORT || 8081,
+      port: Number(process.env.RCT_METRO_PORT) || 8081,
     },
     transformer: {
       babelTransformerPath: require.resolve(


### PR DESCRIPTION
Summary:
---------

That should fix a validation error coming from Metro.

```
error ● Validation Error:

  Option "server.port" must be of type:
    number
  but instead received:
    string

  Example:
  {
    "port": 8080
  }
```


Test Plan:
----------

cc @kelset 	
