### PR TITLE
chore: update init docs to be more descriptive

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -66,7 +66,7 @@ react-native init ProjectName
 
 # Creating custom template
 
-Every custom template needs to have configuration file called `template.config` in the root of the project:
+Every custom template needs to have configuration file called `template.config.js` in the root of the project:
 
 ```js
 module.exports = {

--- a/docs/init.md
+++ b/docs/init.md
@@ -66,7 +66,7 @@ react-native init ProjectName
 
 # Creating custom template
 
-Every custom template needs to have configuration file called `template.config.js` in the root of the project:
+Every custom template needs to have configuration file called `template.config` in the root of the project:
 
 ```js
 module.exports = {
@@ -77,7 +77,7 @@ module.exports = {
   templateDir: './template',
 
   // Path to script, which will be executed after initialization process, but before installing all the dependencies specified in the template.
-  postInitScript: './script.js',
+  postInitScript: './script.sh',
 };
 ```
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -76,8 +76,8 @@ module.exports = {
   // Directory with the template which will be copied and processed by React Native CLI. Template directory should have package.json with all dependencies specified, including `react-native`.
   templateDir: './template',
 
-  // Path to script, which will be executed after initialization process, but before installing all the dependencies specified in the template.
-  postInitScript: './script.sh',
+  // Path to script, which will be executed after initialization process, but before installing all the dependencies specified in the template. This script runs as a shell script but you can change that (e.g. to Node) by using a shebang (see example custom template).
+  postInitScript: './script.js',
 };
 ```
 


### PR DESCRIPTION
Summary:
---------

Hi everyone,

I am liking the new CLI changes a lot, really good work there, thank you all for the effort! 👍

While [refactoring the TS template to be compatible with the new CLI](https://github.com/emin93/react-native-template-typescript/issues/38), I saw there are a few things documented differently than the actual implementation.

In this PR I changed the documentation to match the current implementation. It's likely, that the implementation has to be changed as well in order to support both ways.

Test Plan:
----------

Created a new project with the template config as described in the docs. As this failed, I had a look at the current implementation and found out:

- Template config file name shouldn't have a `.js` extension: https://github.com/react-native-community/cli/blob/master/packages/cli/src/commands/init/template.js#L35
- Post install script is not a node script, therefore the sample `.js` extension is misleading as it's rather a shell script: https://github.com/react-native-community/cli/blob/master/packages/cli/src/commands/init/template.js#L74

As said above, maybe it's the implementation that needs to be fixed and not the documentation, just let me know.