### PR TITLE
fix: Add fallback path check when not found app file for iOS

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -329,7 +329,13 @@ function getBuildPath(configuration, appName, isDevice, scheme) {
     device = 'iphonesimulator';
   }
 
-  return `build/${scheme}/Build/Products/${configuration}-${device}/${appName}.app`;
+  let buildPath = `build/${scheme}/Build/Products/${configuration}-${device}/${appName}.app`;
+  // Check wether app file exist, sometimes `-derivedDataPath` option of `xcodebuild` not works as expected.
+  if (!fs.existsSync(path.join(buildPath))) {
+    return `DerivedData/Build/Products/${configuration}-${device}/${appName}.app`;
+  }
+
+  return buildPath;
 }
 
 function getProductName(buildOutput) {


### PR DESCRIPTION
Summary:
---------

I talked to @grabbou few days ago, I met a `CFBundleIdentifier problem`, I give it a look, and the reason is `-derivedDataPath` not work as expected. Leads to `app` file not found. 

I can reproduce it on latest `cli` and `react-native`, Xcode 10.2.1. I may think it's a `xcodebuild` command bug. 

Related issue: https://github.com/facebook/react-native/issues/25259


Test Plan:
----------

`react-native run-ios` can works as expected.

