### PR TITLE
chore: bump Flow to 0.101

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-import-resolver-typescript": "^1.1.1",
     "eslint-plugin-import": "^2.17.0",
     "execa": "^1.0.0",
-    "flow-bin": "^0.97.0",
+    "flow-bin": "^0.101.0",
     "flow-typed": "^2.5.1",
     "glob": "^7.1.3",
     "jest": "^24.6.0",

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -203,7 +203,7 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
     success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
   `);
   expect(
-    snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
+    snapshotDiff(samplePatch, (fs.writeFileSync: any).mock.calls[0][1], {
       contextLines: 1,
     }),
   ).toMatchSnapshot(
@@ -293,7 +293,7 @@ test('works with --name-ios and --name-android', async () => {
     opts,
   );
   expect(
-    snapshotDiff(samplePatch, fs.writeFileSync.mock.calls[0][1], {
+    snapshotDiff(samplePatch, (fs.writeFileSync: any).mock.calls[0][1], {
       contextLines: 1,
     }),
   ).toMatchSnapshot(

--- a/packages/cli/src/tools/releaseChecker/getLatestRelease.js
+++ b/packages/cli/src/tools/releaseChecker/getLatestRelease.js
@@ -110,11 +110,11 @@ async function getLatestRnDiffPurgeVersion(name: string, eTag: ?string) {
 }
 
 type Headers = {
-  'User-Agent': string,
-  [header: string]: string,
+  'User-Agent': mixed,
+  [header: string]: mixed,
 };
 
-function httpsGet(options: any) {
+function httpsGet(options) {
   return new Promise((resolve, reject) => {
     https
       .get(options, result => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4155,10 +4155,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.97.0:
-  version "0.97.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.97.0.tgz#036ffcfc27503367a9d906ec9d843a0aa6f6bb83"
-  integrity sha512-jXjD05gkatLuC4+e28frH1hZoRwr1iASP6oJr61Q64+kR4kmzaS+AdFBhYgoYS5kpoe4UzwDebWK8ETQFNh00w==
+flow-bin@^0.101.0:
+  version "0.101.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.101.0.tgz#c56fa0afb9c151eeba7954136e9066d408691063"
+  integrity sha512-2xriPEOSrGQklAArNw1ixoIUiLTWhIquYV26WqnxEu7IcXWgoZUcfJXufG9kIvrNbdwCNd5RBjTwbB0p6L6XaA==
 
 flow-typed@^2.5.1:
   version "2.5.1"


### PR DESCRIPTION
Summary:
---------

Bump Flow to [0.101](https://github.com/facebook/flow/releases/tag/v0.101.0) for latest fixes and improvements.
