### PR TITLE
fix: allow upgrading with binary files in the diff

### DIFF
--- a/jest/setupUnitTests.js
+++ b/jest/setupUnitTests.js
@@ -2,18 +2,6 @@
  * @flow
  */
 
-jest.mock('@react-native-community/cli-tools', () => ({
-  ...jest.requireActual('@react-native-community/cli-tools'),
-  logger: {
-    success: jest.fn(),
-    info: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
-    debug: jest.fn(),
-    log: jest.fn(),
-    setVerbose: jest.fn(),
-    isVerbose: jest.fn(),
-  },
-}));
+jest.mock('@react-native-community/cli-tools');
 
 jest.setTimeout(20000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -47,6 +47,7 @@ jest.mock('../../../tools/fetch', () => ({
   fetch: jest.fn(() => Promise.resolve('patch')),
 }));
 jest.mock('@react-native-community/cli-tools', () => ({
+  ...jest.requireActual('@react-native-community/cli-tools'),
   logger: {
     info: jest.fn((...args) => mockPushLog('info', args)),
     error: jest.fn((...args) => mockPushLog('error', args)),
@@ -187,7 +188,7 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
     "info Fetching diff between v0.57.8 and v0.58.4...
     [fs] write tmp-upgrade-rn.patch
     $ execa git rev-parse --show-prefix
-    $ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
     info Applying diff...
     $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
     [fs] unlink tmp-upgrade-rn.patch
@@ -219,7 +220,7 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
     "info Fetching diff between v0.57.8 and v0.58.4...
     [fs] write tmp-upgrade-rn.patch
     $ execa git rev-parse --show-prefix
-    $ execa git apply --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
     info Applying diff...
     $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
     [fs] unlink tmp-upgrade-rn.patch
@@ -266,7 +267,7 @@ test('cleans up if patching fails,', async () => {
     "info Fetching diff between v0.57.8 and v0.58.4...
     [fs] write tmp-upgrade-rn.patch
     $ execa git rev-parse --show-prefix
-    $ execa git apply --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
     info Applying diff (excluding: package.json, .flowconfig)...
     $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig -p2 --3way --directory=
     error: .flowconfig: does not exist in index

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import semver from 'semver';
 import execa from 'execa';
 import type {ConfigT} from 'types';
-import {logger} from '@react-native-community/cli-tools';
+import {logger, CLIError} from '@react-native-community/cli-tools';
 import * as PackageManager from '../../tools/packageManager';
 import {fetch} from '../../tools/fetch';
 import legacyUpgrade from './legacyUpgrade';
@@ -179,6 +179,10 @@ const applyPatch = async (
       );
       await execa('git', [
         'apply',
+        // According to git documentation, `--binary` flag is turned on by
+        // default. However it's necessary when running `git apply --check` to
+        // actually accept binary files, maybe a bug in git?
+        '--binary',
         '--check',
         tmpPatchFile,
         ...excludes,
@@ -307,7 +311,7 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
         `${rnDiffPurgeRawDiffsUrl}/${currentVersion}..${newVersion}.diff`,
       )}`);
 
-      throw new Error(
+      throw new CLIError(
         'Upgrade failed. Please see the messages above for details',
       );
     }


### PR DESCRIPTION
Summary:
---------

From the git manual:

```
--allow-binary-replacement, --binary
Historically we did not allow binary patch applied without an explicit permission from the user, and this flag was the way to do so. Currently we always allow binary patch application, so this is a no-op.
```

However it's necessary when running `git apply --check` to actually accept binary files. Maybe a bug in git? 

Fixes #422 	


Test Plan:
----------

Upgrade to RN 0.59.9 works with minor conflicts (`git apply` succeeds)
