### PR TITLE
Add import for `applicationId.R` class in generated `PackageList.java`

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -145,7 +145,7 @@ class ReactNativeModules {
     String packageClassInstances = ""
 
     if (packages.size() > 0) {
-      packageImports = "import ${applicationId}.BuildConfig;\n\n"
+      packageImports = "import ${applicationId}.BuildConfig;\nimport ${applicationId}.R;\n\n"
       packageImports = packageImports + packages.collect {
         "// ${it.name}\n${it.packageImportPath}"
       }.join(';\n')

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -148,7 +148,7 @@ class ReactNativeModules {
       packageImports = "import ${applicationId}.BuildConfig;\nimport ${applicationId}.R;\n\n"
       packageImports = packageImports + packages.collect {
         "// ${it.name}\n${it.packageImportPath}"
-      }.join(';\n')
+      }.join('\n')
       packageClassInstances = ",\n      " + packages.collect { it.packageInstance }.join(',')
     }
 


### PR DESCRIPTION
Summary:
---------

- Fix https://github.com/react-native-community/cli/issues/434
- Also remove the redundant semicolon after package imports

Test Plan:
----------

It fixes #434.

Try to modify `node_modules/@react-native-community/cli-platform-android/native_modules.gradle` in https://github.com/robertying/autolink-issue-example and it can build succesfully now!