### PR TITLE
Use `packageName` instead of `applicationId` in gradle script

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -137,7 +137,6 @@ class ReactNativeModules {
    * @param outputDir
    * @param generatedFileName
    * @param generatedFileContentsTemplate
-   * @param packageName
    */
   void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
     ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -136,16 +136,16 @@ class ReactNativeModules {
    * @param outputDir
    * @param generatedFileName
    * @param generatedFileContentsTemplate
-   * @param applicationId
+   * @param packageName
    */
-  void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate, String applicationId) {
+  void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate, String packageName) {
     ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules
 
     String packageImports = ""
     String packageClassInstances = ""
 
     if (packages.size() > 0) {
-      packageImports = "import ${applicationId}.BuildConfig;\nimport ${applicationId}.R;\n\n"
+      packageImports = "import ${packageName}.BuildConfig;\nimport ${packageName}.R;\n\n"
       packageImports = packageImports + packages.collect {
         "// ${it.name}\n${it.packageImportPath}"
       }.join('\n')
@@ -233,17 +233,14 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings ->
 ext.applyNativeModulesAppBuildGradle = { Project project ->
   autoModules.applyBuildGradle(project, ext)
 
-  def applicationId
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java/com/facebook/react")
 
-  // TODO(salakar): not sure if this is the best way of getting the package name (used to import BuildConfig)
-  project.android.applicationVariants.all { variant ->
-    applicationId = [variant.mergedFlavor.applicationId, variant.buildType.applicationIdSuffix].findAll().join()
-  }
+  def manifest = new XmlSlurper().parse(android.sourceSets.main.manifest.srcFile)
+  def packageName = manifest.@package.text()
 
   task generatePackageList {
     doLast {
-      autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate, applicationId)
+      autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate, packageName)
     }
   }
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -49,6 +49,7 @@ public class PackageList {
 class ReactNativeModules {
   private Logger logger
   private Project project
+  private String packageName
   private DefaultSettings defaultSettings
   private ExtraPropertiesExtension extension
   private ArrayList<HashMap<String, String>> reactNativeModules
@@ -138,8 +139,9 @@ class ReactNativeModules {
    * @param generatedFileContentsTemplate
    * @param packageName
    */
-  void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate, String packageName) {
+  void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
     ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules
+    String packageName = this.packageName
 
     String packageImports = ""
     String packageClassInstances = ""
@@ -193,6 +195,7 @@ class ReactNativeModules {
 
     def reactNativeConfigOutput = cmdProcess.in.text
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
+    this.packageName = json["project"]["android"]["packageName"]
     def dependencies = json["dependencies"]
 
     dependencies.each { name, value ->
@@ -235,12 +238,9 @@ ext.applyNativeModulesAppBuildGradle = { Project project ->
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java/com/facebook/react")
 
-  def manifest = new XmlSlurper().parse(android.sourceSets.main.manifest.srcFile)
-  def packageName = manifest.@package.text()
-
   task generatePackageList {
     doLast {
-      autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate, packageName)
+      autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate)
     }
   }
 


### PR DESCRIPTION
Summary:
---------

As the issue #438 suggested, `R` and `BuildConfig` are located using `packageName` rather than `applicationId`.

I figured out a way to get `packageName` from `AndroidManifest.xml` and use it to replace `applicationId`.

- This pull request will close #438

Test Plan:
----------

### How it previously failed

Change your `applicationId` in `app/build.gradle` different from `packageName` in `app/src/main/AndroidManifest.xml` and build failed due to `R` and `BuildConfig` not found.

### Now it works

Even if you change `applicationId` in `app/build.gradle` to be whatever, generated `PackageList.java` always `import packageName.R`.