### PR TITLE
chore: get rid of link without package name message

### DIFF
--- a/packages/cli/src/commands/link/linkAll.js
+++ b/packages/cli/src/commands/link/linkAll.js
@@ -25,12 +25,6 @@ function linkAll(
   platforms: PlatformsT,
   project: ProjectConfigT,
 ) {
-  logger.warn(
-    'Running `react-native link` without package name is deprecated and will be removed ' +
-      'in next release. If you use this command to link your project assets, ' +
-      'please let us know about your use case here: https://goo.gl/RKTeoc',
-  );
-
   const projectAssets = getAssets(context.root);
   const dependencies = getProjectDependencies(context.root);
   const depenendenciesConfig = dependencies.map(dependnecy =>


### PR DESCRIPTION
Summary:
---------

_Note: this diff targets `1.x` branch_

Related: https://github.com/react-native-community/cli/issues/48

Test Plan:
----------

No warning when running `react-native link`.