### PR TITLE
docs: document how to disable autolinking for unsupported packages

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -48,3 +48,19 @@ On the iOS side, you will need to ensure you have a Podspec to the root of your 
 ## How can I customize how autolinking works for my package?
 
 A library can add a `react-native.config.js` configuration file, which will customize the defaults.
+
+## How do I disable autolinking for unsupported package?
+
+It happens, that during transition period or due to convoluted setup some packages don't support autolinking on certain platforms. To disable autolinking from running for a certain package, update your `react-native.config.js`'s `dependencies` entry to look like this:
+
+```js
+module.exports = {
+  dependencies: {
+    'some-unsupported-package': {
+      platforms: {
+        android: null, // disable Android platform, other platforms will still autolink if provided
+      },
+    },
+  },
+};
+```

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -13,32 +13,41 @@ import {
   readConfigFromDisk,
   readDependencyConfigFromDisk,
 } from './readConfigFromDisk';
-import {type ConfigT} from 'types';
+import type {
+  ConfigT,
+  UserDependencyConfigT,
+  UserConfigT,
+  DependencyConfigT,
+} from 'types';
 import assign from '../assign';
 import merge from '../merge';
 import resolveNodeModuleDir from './resolveNodeModuleDir';
 
 function getDependencyConfig(
-  root,
-  dependencyName,
-  finalConfig,
-  config,
-  userConfig,
-  isPlatform,
-) {
+  root: string,
+  dependencyName: string,
+  finalConfig: ConfigT,
+  config: UserDependencyConfigT,
+  userConfig: UserConfigT,
+  isPlatform: boolean,
+): DependencyConfigT {
   return merge(
     {
       root,
       name: dependencyName,
       platforms: Object.keys(finalConfig.platforms).reduce(
         (dependency, platform) => {
-          // Linking platforms is not supported
-          dependency[platform] = isPlatform
-            ? null
-            : finalConfig.platforms[platform].dependencyConfig(
-                root,
-                config.dependency.platforms[platform] || {},
-              );
+          const platformConfig = finalConfig.platforms[platform];
+          dependency[platform] =
+            // Linking platforms is not supported
+            isPlatform || !platformConfig
+              ? null
+              : platformConfig.dependencyConfig(
+                  root,
+                  /* $FlowFixMe - can't figure out which platform's dependency
+                   config to choose */
+                  config.dependency.platforms[platform],
+                );
           return dependency;
         },
         {},

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -150,7 +150,7 @@ class ReactNativeModules {
       packageImports = packageImports + packages.collect {
         "// ${it.name}\n${it.packageImportPath}"
       }.join('\n')
-      packageClassInstances = ",\n      " + packages.collect { it.packageInstance }.join(',')
+      packageClassInstances = ",\n      " + packages.collect { it.packageInstance }.join(",\n      ")
     }
 
     String generatedFileContents = generatedFileContentsTemplate

--- a/types/index.js
+++ b/types/index.js
@@ -72,9 +72,14 @@ type ProjectParamsIOST = {
   plist: any[],
 };
 
-type PlatformConfig<ProjectParams, ProjectConfig, DependencyConfig> = {
-  projectConfig: (string, ProjectParams) => ?ProjectConfig,
-  dependencyConfig: (string, ProjectParams) => ?DependencyConfig,
+type PlatformConfig<
+  ProjectParams,
+  DependencyParams,
+  ProjectConfig,
+  DependencyConfig,
+> = {
+  projectConfig: (string, ?ProjectParams) => ?ProjectConfig,
+  dependencyConfig: (string, ?DependencyParams) => ?DependencyConfig,
   linkConfig: () => {
     isInstalled: (ProjectConfig, string, DependencyConfig) => boolean,
     register: (string, DependencyConfig, Object, ProjectConfig) => void,
@@ -131,14 +136,16 @@ export type ConfigT = {|
 
   // Map of available platforms (built-ins and dynamically loaded)
   platforms: {
-    [name: string]: PlatformConfig<Object, Object, Object>,
+    [name: string]: PlatformConfig<any, any, any, any>,
     ios?: PlatformConfig<
       ProjectParamsIOST,
+      ProjectParamsIOST, // DependencyParams are the same as ProjectParams on iOS
       ProjectConfigIOST,
       DependencyConfigIOST,
     >,
     android?: PlatformConfig<
       ProjectParamsAndroidT,
+      DependencyParamsAndroidT,
       ProjectConfigAndroidT,
       DependencyConfigAndroidT,
     >,


### PR DESCRIPTION
Summary:
---------

There are packages (like [appcenter](https://github.com/microsoft/appcenter-sdk-react-native/) or [react-native-fbsdk](https://github.com/facebook/react-native-fbsdk#usage)) that are not able to support autolinking on Android just yet, because of too complicated setup. This diff documents how we can disable certain platform of a package to not be autolinked.

By the way I've adjusted some types (please double check). The types naming is pretty confusing even after all this time :|


Test Plan:
----------

Tested on `appcenter` and `react-native-fbsdk`.

Related issue in appcenter: https://github.com/microsoft/appcenter-sdk-react-native/issues/613
