### PR TITLE
fix: don't use yarn for spawning 'config' command

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -55,8 +55,6 @@ class ReactNativeModules {
   private ArrayList<HashMap<String, String>> reactNativeModules
 
   private static String LOG_PREFIX = ":ReactNative:"
-  private static String REACT_NATIVE_CONFIG_CMD = "yarn run --silent react-native config"
-  private static String REACT_NATIVE_CONFIG_CMD_FALLBACK = "node ./node_modules/.bin/react-native config"
 
   ReactNativeModules(Logger logger) {
     this.logger = logger
@@ -175,20 +173,14 @@ class ReactNativeModules {
 
     def cmdProcess
     def root = getReactNativeProjectRoot()
-    def command = REACT_NATIVE_CONFIG_CMD_FALLBACK
+    def command = "node ./node_modules/.bin/react-native config"
 
     try {
-      try {
-        // Check if project uses Yarn
-        def isYarnProject = Runtime.getRuntime().exec("node -e console.log(require.resolve('./yarn.lock'))", null, root)
-        isYarnProject.waitFor()
-        command = REACT_NATIVE_CONFIG_CMD
-      } catch(Exception exception) {}
       cmdProcess = Runtime.getRuntime().exec(command, null, root)
       cmdProcess.waitFor()
     } catch (Exception exception) {
       this.logger.warn("${LOG_PREFIX}${exception.message}")
-      this.logger.warn("${LOG_PREFIX}Automatic import of native modules failed. (UNKNOWN)")
+      this.logger.warn("${LOG_PREFIX}Automatic import of native modules failed.")
       return reactNativeModules
     }
 

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -7,14 +7,6 @@ def use_native_modules!(root = "..", packages = nil)
   if (!packages)
     command = "node"
     args = ["./node_modules/.bin/react-native", "config"]
-    begin
-      # Check if project uses Yarn
-      Pod::Executable.execute_command("node", ["-e", "console.log(require.resolve('#{root}/yarn.lock'))"], true)
-      command = "yarn"
-      args = ["run", "--silent", "react-native", "config"]
-    rescue
-    end
-
     output = ""
     # Make sure `react-native config` is ran from your project root
     Dir.chdir(root) do


### PR DESCRIPTION
Summary:
---------

I've added support for Yarn resolution to support PnP mode. However, RN is far from supporting PnP at the moment. It also turns out that developers use different versions of Yarn that may e.g. spawn some Node deprecation warnings on some environments. Hence removing spawning commands through Yarn, we're only using Node for now. PnP support can be added once RN core is ready.

Fixes #448 

Test Plan:
----------

Autolinking works.
