### PR TITLE
chore: group deprecated rnpm warnings, add migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ This CLI is intended to be used with a certain version of React Native. You'll f
 
 ## Documentation
 
+- [configuration](./docs/configuration.md)
 - [commands](./docs/commands.md)
+- [plugins](./docs/plugins.md)
 - [init](./docs/init.md)
 - [autolinking](./docs/autolinking.md)
-- [plugins](./docs/plugins.md)
 
 ## About
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,3 +14,107 @@ Check the documentation for
 - [plugins](./plugins.md)
 
 to learn more about different types of configuration and features available.
+
+## Migration guide
+
+`"rnpm"` is deprecated and support for it will be removed in next major version of the CLI.
+
+> **Important**: Proceed further only if your project uses `"rnpm"` in `package.json`.
+
+There are different kinds of React Native projects, including apps, libraries and platforms. For each we prepared a brief "before & after" of the configuration shape with legacy `"rnpm"` and current `react-native.config.js`. Please mind that all configuration entries are optional.
+
+### Apps
+
+`package.json` entry:
+
+```json
+{
+  "rnpm": {
+    "ios": {},
+    "android": {},
+    "assets": ["./path-to-assets"],
+    "plugin": "./path-to-commands.js"
+  }
+}
+```
+
+becomes `react-native.config.js`
+
+```js
+module.exports = {
+  project: {
+    ios: {},
+    android: {}, // grouped into "project"
+  },
+  assets: ['./path-to-assets'], // stays the same
+  commands: require('./path-to-commands.js'), // formerly "plugin", returns an array of commands
+};
+```
+
+### Libraries
+
+`package.json` entry:
+
+```json
+{
+  "rnpm": {
+    "ios": {},
+    "android": {},
+    "assets": ["./path-to-assets"],
+    "hooks": {
+      "prelink": "./path-to-a-prelink-hook"
+    }
+  }
+}
+```
+
+becomes `react-native.config.js`:
+
+```js
+module.exports = {
+  // config for a library is scoped under "dependency" key
+  dependency: {
+    platforms: {
+      ios: {},
+      android: {}, // projects are grouped into "platforms"
+    },
+    assets: ['./path-to-assets'], // stays the same
+    // hooks are considered anti-pattern, please avoid them
+    hooks: {
+      prelink: './path-to-a-prelink-hook',
+    },
+  },
+};
+```
+
+You'll find more details in [dependencies](./dependencies.md) docs.
+
+### Out-of-tree platforms
+
+`package.json` entry:
+
+```json
+{
+  "rnpm": {
+    "haste": {
+      "platforms": ["windows"],
+      "providesModuleNodeModules": ["react-native-windows"]
+    },
+    "platform": "./local-cli/platform.js"
+  }
+}
+```
+
+becomes `react-native.config.js`
+
+```js
+module.exports = {
+  platforms: {
+    // grouped under "platforms" entry
+    windows: require('./local-cli/platform.js').windows,
+  },
+  // "haste" is no longer needed
+};
+```
+
+You'll find more details in [platforms](./platforms.md) docs.

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -187,9 +187,7 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
       `The following packages use deprecated "rnpm" config that will stop working from next release:\n${depsWithWarnings
         .map(
           ([name, link]) =>
-            `  - ${chalk.bold(name)} ${chalk.dim(
-              `(${chalk.underline(link)})`,
-            )}`,
+            `  - ${chalk.bold(name)}: ${chalk.dim(chalk.underline(link))}`,
         )
         .join(
           '\n',

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -193,7 +193,7 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
         )
         .join(
           '\n',
-        )}\nPlease notify its maintainers about it. You can find more details at ${chalk.dim.underline(
+        )}\nPlease notify their maintainers about it. You can find more details at ${chalk.dim.underline(
         'https://react-native-community/cli/docs/configuration.md#migration-guide',
       )}.`,
     );


### PR DESCRIPTION
Summary:
---------

One warning with all deprecated packages seems nicer and less intrusive. Also added links to the packages home pages for user convenience when informing maintainers.

<img width="904" alt="Screenshot 2019-06-30 at 12 45 15" src="https://user-images.githubusercontent.com/5106466/60395522-07539180-9b35-11e9-81e2-9616d5eb874b.png">

Also added a migration guide to the configuration docs.

cc @satya164 @turnrye 	


Test Plan:
----------

Nope
