### PR TITLE
feat: support local RN libraries in autolinking

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -118,23 +118,7 @@ Currently autolinking doesn't support local libraries out of the box. However, w
 module.exports = {
   dependencies: {
     'local-rn-library': {
-      platforms: {
-        ios: {
-          sourceDir: '/root/ios',
-          folder: '/root/ios',
-          pbxprojPath: 'root/ios/RNLibrary.xcodeproj/project.pbxproj',
-          podspecPath: 'root/RNLibrary.podspec',
-          projectPath: 'root/ios/RNLibrary.xcodeproj',
-          projectName: 'RNLibrary.xcodeproj',
-          libraryFolder: 'Libraries',
-        },
-        android: {
-          sourceDir: '/root/android',
-          folder: '/root/android',
-          packageImportPath: 'import com.myproject.RNLibraryPackage;',
-          packageInstance: 'new RNLibraryPackage()',
-        },
-      },
+      root: '/root/libraries',
     },
   },
 };

--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -94,7 +94,7 @@ On the iOS side, you will need to ensure you have a Podspec to the root of your 
 
 A library can add a `react-native.config.js` configuration file, which will customize the defaults.
 
-## How do I disable autolinking for unsupported package?
+## How can I disable autolinking for unsupported library?
 
 During the transition period some packages may not support autolinking on certain platforms. To disable autolinking for a package, update your `react-native.config.js`'s `dependencies` entry to look like this:
 
@@ -104,6 +104,36 @@ module.exports = {
     'some-unsupported-package': {
       platforms: {
         android: null, // disable Android platform, other platforms will still autolink if provided
+      },
+    },
+  },
+};
+```
+
+## How can I autolink a local library?
+
+Currently autolinking doesn't support local libraries out of the box. However, we can leverage CLI configuration to make it "see" the React Native libraries that are not part of our 3rd party dependencies. To make autolinking see custom libraries that are not in `node_modules`, update your `react-native.config.js`'s `dependencies` entry to look like this (adjust paths where necessary):
+
+```js
+module.exports = {
+  dependencies: {
+    'local-rn-library': {
+      platforms: {
+        ios: {
+          sourceDir: '/root/ios',
+          folder: '/root/ios',
+          pbxprojPath: 'root/ios/RNLibrary.xcodeproj/project.pbxproj',
+          podspecPath: 'root/RNLibrary.podspec',
+          projectPath: 'root/ios/RNLibrary.xcodeproj',
+          projectName: 'RNLibrary.xcodeproj',
+          libraryFolder: 'Libraries',
+        },
+        android: {
+          sourceDir: '/root/android',
+          folder: '/root/android',
+          packageImportPath: 'import com.myproject.RNLibraryPackage;',
+          packageInstance: 'new RNLibraryPackage()',
+        },
       },
     },
   },

--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -99,6 +99,7 @@ A library can add a `react-native.config.js` configuration file, which will cust
 During the transition period some packages may not support autolinking on certain platforms. To disable autolinking for a package, update your `react-native.config.js`'s `dependencies` entry to look like this:
 
 ```js
+// react-native.config.js
 module.exports = {
   dependencies: {
     'some-unsupported-package': {
@@ -112,9 +113,10 @@ module.exports = {
 
 ## How can I autolink a local library?
 
-Currently autolinking doesn't support local libraries out of the box. However, we can leverage CLI configuration to make it "see" the React Native libraries that are not part of our 3rd party dependencies. To make autolinking see custom libraries that are not in `node_modules`, update your `react-native.config.js`'s `dependencies` entry to look like this (adjust paths where necessary):
+We can leverage CLI configuration to make it "see" React Native libraries that are not part of our 3rd party dependencies. To do so, update your `react-native.config.js`'s `dependencies` entry to look like this:
 
 ```js
+// react-native.config.js
 module.exports = {
   dependencies: {
     'local-rn-library': {

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -109,7 +109,7 @@ For example, you could set:
 ```js
 module.exports = {
   dependencies: {
-    ['react-native-webview']: {
+    'react-native-webview': {
       platforms: {
         ios: null,
       },
@@ -119,6 +119,25 @@ module.exports = {
 ```
 
 in order to disable linking of React Native WebView on iOS.
+
+Another use-case would be supporting local libraries that are not discoverable for autolinking, since they're not part of your `dependencies` or `devDependencies`:
+
+```js
+module.exports = {
+  dependencies: {
+    'local-rn-library': {
+      platforms: {
+        android: {
+          sourceDir: '/root/android',
+          folder: '/root/android',
+          packageImportPath: 'import com.myproject.RNLibraryPackage;',
+          packageInstance: 'new RNLibraryPackage()',
+        },
+      },
+    },
+  },
+};
+```
 
 The object provided here is deep merged with the dependency config. Check [`projectConfig`](platforms.md#projectconfig) and [`dependencyConfig`](platforms.md#dependencyConfig) return values for a full list of properties that you can override.
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -126,14 +126,7 @@ Another use-case would be supporting local libraries that are not discoverable f
 module.exports = {
   dependencies: {
     'local-rn-library': {
-      platforms: {
-        android: {
-          sourceDir: '/root/android',
-          folder: '/root/android',
-          packageImportPath: 'import com.myproject.RNLibraryPackage;',
-          packageInstance: 'new RNLibraryPackage()',
-        },
-      },
+      root: '/root/libraries',
     },
   },
 };

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -301,7 +301,7 @@ test('does not use restricted "react-native" key to resolve config from package.
   expect(spy).not.toHaveBeenCalled();
 });
 
-test('supports default dependencies from user configuration', () => {
+test('supports dependencies from user configuration with custom root and properties', () => {
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'native-libs/local-lib/ios/LocalRNLibrary.xcodeproj/project.pbxproj': '',
@@ -309,6 +309,11 @@ test('supports default dependencies from user configuration', () => {
       dependencies: {
         'local-lib': {
           root: "${DIR}/native-libs/local-lib",
+          platforms: {
+            ios: {
+              podspecPath: "custom-path"
+            }
+          }
         },
       }
     }`,
@@ -334,7 +339,7 @@ test('supports default dependencies from user configuration', () => {
           "pbxprojPath": "<<REPLACED>>/native-libs/local-lib/ios/LocalRNLibrary.xcodeproj/project.pbxproj",
           "plist": Array [],
           "podfile": null,
-          "podspecPath": null,
+          "podspecPath": "custom-path",
           "projectName": "LocalRNLibrary.xcodeproj",
           "projectPath": "<<REPLACED>>/native-libs/local-lib/ios/LocalRNLibrary.xcodeproj",
           "sharedLibraries": Array [],

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -285,8 +285,6 @@ test.skip('should skip packages that have invalid configuration', () => {
 });
 
 test('does not use restricted "react-native" key to resolve config from package.json', () => {
-  jest.resetModules();
-
   writeFiles(DIR, {
     'node_modules/react-native-netinfo/package.json': `{
       "react-native": "src/index.js"
@@ -304,34 +302,46 @@ test('does not use restricted "react-native" key to resolve config from package.
 });
 
 test('supports default dependencies from user configuration', () => {
-  const depsWithLocalLibrary = {
-    'local-rn-library': {
-      platforms: {
-        ios: {
-          sourceDir: '/root/ios',
-          folder: '/root/ios',
-          pbxprojPath: 'root/ios/RNLibrary.xcodeproj/project.pbxproj',
-          podspecPath: 'root/RNLibrary.podspec',
-          projectPath: 'root/ios/RNLibrary.xcodeproj',
-          projectName: 'RNLibrary.xcodeproj',
-          libraryFolder: 'Libraries',
-        },
-        android: {
-          sourceDir: '/root/android',
-          folder: '/root/android',
-          packageImportPath: 'import com.myproject.RNLibraryPackage;',
-          packageInstance: 'new RNLibraryPackage()',
-        },
-      },
-    },
-  };
-
   writeFiles(DIR, {
+    'node_modules/react-native/package.json': '{}',
+    'native-libs/local-lib/ios/LocalRNLibrary.xcodeproj/project.pbxproj': '',
     'react-native.config.js': `module.exports = {
-      dependencies: ${JSON.stringify(depsWithLocalLibrary, null, 2)}
+      dependencies: {
+        'local-lib': {
+          root: "${DIR}/native-libs/local-lib",
+        },
+      }
+    }`,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1"
+      }
     }`,
   });
 
   const {dependencies} = loadConfig(DIR);
-  expect(dependencies).toMatchObject(depsWithLocalLibrary);
+  expect(removeString(dependencies['local-lib'], DIR)).toMatchInlineSnapshot(`
+    Object {
+      "assets": Array [],
+      "hooks": Object {},
+      "name": "local-lib",
+      "params": Array [],
+      "platforms": Object {
+        "android": null,
+        "ios": Object {
+          "folder": "<<REPLACED>>/native-libs/local-lib",
+          "libraryFolder": "Libraries",
+          "pbxprojPath": "<<REPLACED>>/native-libs/local-lib/ios/LocalRNLibrary.xcodeproj/project.pbxproj",
+          "plist": Array [],
+          "podfile": null,
+          "podspecPath": null,
+          "projectName": "LocalRNLibrary.xcodeproj",
+          "projectPath": "<<REPLACED>>/native-libs/local-lib/ios/LocalRNLibrary.xcodeproj",
+          "sharedLibraries": Array [],
+          "sourceDir": "<<REPLACED>>/native-libs/local-lib/ios",
+        },
+      },
+      "root": "<<REPLACED>>/native-libs/local-lib",
+    }
+  `);
 });

--- a/packages/cli/src/tools/config/__tests__/index-test.js
+++ b/packages/cli/src/tools/config/__tests__/index-test.js
@@ -302,3 +302,36 @@ test('does not use restricted "react-native" key to resolve config from package.
   expect(dependencies).toHaveProperty('react-native-netinfo');
   expect(spy).not.toHaveBeenCalled();
 });
+
+test('supports default dependencies from user configuration', () => {
+  const depsWithLocalLibrary = {
+    'local-rn-library': {
+      platforms: {
+        ios: {
+          sourceDir: '/root/ios',
+          folder: '/root/ios',
+          pbxprojPath: 'root/ios/RNLibrary.xcodeproj/project.pbxproj',
+          podspecPath: 'root/RNLibrary.podspec',
+          projectPath: 'root/ios/RNLibrary.xcodeproj',
+          projectName: 'RNLibrary.xcodeproj',
+          libraryFolder: 'Libraries',
+        },
+        android: {
+          sourceDir: '/root/android',
+          folder: '/root/android',
+          packageImportPath: 'import com.myproject.RNLibraryPackage;',
+          packageInstance: 'new RNLibraryPackage()',
+        },
+      },
+    },
+  };
+
+  writeFiles(DIR, {
+    'react-native.config.js': `module.exports = {
+      dependencies: ${JSON.stringify(depsWithLocalLibrary, null, 2)}
+    }`,
+  });
+
+  const {dependencies} = loadConfig(DIR);
+  expect(dependencies).toMatchObject(depsWithLocalLibrary);
+});

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -73,7 +73,7 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
         ? path.resolve(projectRoot, userConfig.reactNativePath)
         : resolveReactNativePath(projectRoot);
     },
-    dependencies: {},
+    dependencies: userConfig.dependencies,
     commands: userConfig.commands,
     get assets() {
       return findAssets(projectRoot, userConfig.assets);

--- a/packages/cli/src/tools/config/readConfigFromDisk.js
+++ b/packages/cli/src/tools/config/readConfigFromDisk.js
@@ -140,7 +140,24 @@ const loadProjectCommands = (
 function readLegacyDependencyConfigFromDisk(
   rootFolder: string,
 ): ?UserDependencyConfigT {
-  const {rnpm: config} = require(path.join(rootFolder, 'package.json'));
+  let config = {};
+
+  try {
+    config = require(path.join(rootFolder, 'package.json')).rnpm;
+  } catch (error) {
+    // package.json is usually missing in local libraries that are not in
+    // project "dependencies", so we just return a bare config
+    return {
+      dependency: {
+        platforms: {},
+        assets: [],
+        hooks: {},
+        params: [],
+      },
+      commands: [],
+      platforms: {},
+    };
+  }
 
   if (!config) {
     return undefined;

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -106,6 +106,7 @@ export const projectConfig = t
       t.string(),
       t
         .object({
+          root: t.string(),
           platforms: map(t.string(), t.any()).keys({
             ios: t
               .object({

--- a/types/index.js
+++ b/types/index.js
@@ -179,8 +179,8 @@ export type UserDependencyConfigT = {
   // Additional dependency settings
   dependency: {
     platforms: {
-      android: DependencyParamsAndroidT,
-      ios: ProjectParamsIOST,
+      android?: DependencyParamsAndroidT,
+      ios?: ProjectParamsIOST,
       [key: string]: any,
     },
     assets: string[],


### PR DESCRIPTION
Summary:
---------

Currently autolinking doesn't support local libraries out of the box. However, we can leverage CLI configuration to make it "see" the React Native libraries that are not part of our 3rd party dependencies. This diff turns on taking user `dependencies` config as a part of initial user config. So essentially we're able to link our local libs that are not defined in package.json, but e.g. in `/root/libraries` and `/root/some/wild-libs` in this case:

```js
module.exports = {
  dependencies: {
    'local-lib': {
      root: '/root/libraries'
    },
    'local-lib-2': {
      root: '/root/libraries'
    },
    'wild-lib': {
      root: '/root/some/wild-libs'
    },
  },
};
```

This may also handy for "example" projects in RN libraries in a monorepo setup.

Test Plan:
----------

Added a test.
