### PR TITLE
fix: incorrect condition for upgrade newer version check

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -147,6 +147,10 @@ test('errors when older version passed', async () => {
   expect(logger.error).toBeCalledWith(
     `Trying to upgrade from newer version "${currentVersion}" to older "${olderVersion}"`,
   );
+  await upgrade.func(['0.57.10'], ctx, opts);
+  expect(logger.error).not.toBeCalledWith(
+    `Trying to upgrade from newer version "${currentVersion}" to older "0.57.10"`,
+  );
 }, 60000);
 
 test('warns when dependency upgrade version is in semver range', async () => {

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -110,13 +110,13 @@ const getVersionToUpgradeTo = async (argv, currentVersion, projectDir) => {
     return null;
   }
 
-  if (currentVersion > newVersion) {
+  if (semver.gt(currentVersion, newVersion)) {
     logger.error(
       `Trying to upgrade from newer version "${currentVersion}" to older "${newVersion}"`,
     );
     return null;
   }
-  if (currentVersion === newVersion) {
+  if (semver.eq(currentVersion, newVersion)) {
     const {
       dependencies: {'react-native': version},
     } = require(path.join(projectDir, 'package.json'));


### PR DESCRIPTION
Summary:
---------

Fixes 
```
error Trying to upgrade from newer version "0.59.9" to older "0.59.10"
```

🤦‍♂ Spotted while upgrading to `0.59.10`

Test Plan:
----------

Added a test case