### PR TITLE
feat: simplify passing root to gradle autolinking

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -34,16 +34,55 @@ The implementation ensures that a library is imported only once. If you need to 
 
 See the implementation of [native_modules.rb](https://github.com/react-native-community/cli/blob/master/packages/platform-ios/native_modules.rb).
 
-> Autolinking assumes your Podfile is in a sub-folder from your `package.json`. If this is not the case, use the first parameter to tell the linker where to find the `package.json` e.g. `use_native_modules!("../../")`.
+### Custom root (monorepos)
+
+The project root is where `node_modules` with `react-native` is. Autolinking script assume your project root to be `".."`, relative to `ios` directory. If you're in a project with custom structure, like this:
+
+```
+root/
+  node_modules
+  example/
+    ios/
+```
+
+you'll need to set a custom root. Pass it as an argument to `use_native_modules!`:
+
+```rb
+# example/ios/Podfile
+use_native_modules!("../..")
+```
 
 ## Platform Android
 
 1. At build time, before the build script is run:
-   1. A first Gradle plugin (in `settings.gradle`) runs. It uses the package metadata from `react-native config` to add Android projects.
-   1. A second Gradle plugin (in `build.gradle`) runs. It creates a list of React Native packages to include in the generated `/android/build/generated/rn/src/main/java/com/facebook/react/PackageList.java` file.
+   1. A first Gradle plugin (in `settings.gradle`) runs `applyNativeModulesSettingsGradle` method. It uses the package metadata from `react-native config` to add Android projects.
+   1. A second Gradle plugin (in `app/build.gradle`) runs `applyNativeModulesAppBuildGradle` method. It creates a list of React Native packages to include in the generated `/android/build/generated/rn/src/main/java/com/facebook/react/PackageList.java` file.
 1. At runtime, the list of React Native packages, generated in step 1.2, is passed to React Native host.
 
 See the implementation of [native_modules.gradle](https://github.com/react-native-community/cli/blob/master/packages/platform-android/native_modules.gradle).
+
+### Custom root (monorepos)
+
+The project root is where `node_modules` with `react-native` is. Autolinking scripts assume your project root to be `".."`, relative to `android` directory. If you're in a project with custom structure, like this:
+
+```
+root/
+  node_modules
+  example/
+    android/
+```
+
+you'll need to set a custom root. Pass it as a second argument to `applyNativeModulesSettingsGradle` and `applyNativeModulesAppBuildGradle` methods:
+
+```groovy
+// example/android/settings.gradle
+applyNativeModulesSettingsGradle(settings, "../..")
+```
+
+```groovy
+// example/android/app/build.gradle
+applyNativeModulesAppBuildGradle(project, "../..")
+```
 
 ## What do I need to have in my package to make it work?
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -51,7 +51,7 @@ class ReactNativeModules {
   private Project project
   private String packageName
   private DefaultSettings defaultSettings
-  private ExtraPropertiesExtension extension
+  private String root
   private ArrayList<HashMap<String, String>> reactNativeModules
 
   private static String LOG_PREFIX = ":ReactNative:"
@@ -60,17 +60,17 @@ class ReactNativeModules {
     this.logger = logger
   }
 
-  void applySettingsGradle(DefaultSettings defaultSettings, ExtraPropertiesExtension extraPropertiesExtension) {
+  void applySettingsGradle(DefaultSettings defaultSettings, String root) {
     this.defaultSettings = defaultSettings
-    this.extension = extraPropertiesExtension
+    this.root = root
     this.reactNativeModules = this.getReactNativeConfig()
 
     addReactNativeModuleProjects()
   }
 
-  void applyBuildGradle(Project project, ExtraPropertiesExtension extraPropertiesExtension) {
+  void applyBuildGradle(Project project, String root) {
     this.project = project
-    this.extension = extraPropertiesExtension
+    this.root = root
     this.reactNativeModules = this.getReactNativeConfig()
 
     addReactNativeModuleDependencies()
@@ -110,13 +110,6 @@ class ReactNativeModules {
    * @return
    */
   File getReactNativeProjectRoot() {
-    if (this.extension.has("reactNativeProjectRoot")) {
-      File rnRoot = File(this.extension.get("reactNativeProjectRoot"))
-      // allow custom React Native project roots for non-standard directory structures
-      this.logger.debug("${LOG_PREFIX}Using custom React Native project root path '${rnRoot.toString()}'")
-      return rnRoot
-    }
-
     File androidRoot
 
     if (this.project) {
@@ -125,8 +118,11 @@ class ReactNativeModules {
       androidRoot = this.defaultSettings.rootProject.projectDir
     }
 
-    this.logger.debug("${LOG_PREFIX}Using default React Native project root path '${androidRoot.parentFile.toString()}'")
-    return androidRoot.parentFile
+
+    File rnRoot = new File(androidRoot, this.root)
+    // allow custom React Native project roots for non-standard directory structures
+    this.logger.debug("${LOG_PREFIX}Using React Native project root path '${rnRoot.toString()}'")
+    return rnRoot
   }
 
   /**
@@ -220,12 +216,12 @@ class ReactNativeModules {
 
 def autoModules = new ReactNativeModules(logger)
 
-ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings ->
-  autoModules.applySettingsGradle(defaultSettings, ext)
+ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String root = ".." ->
+  autoModules.applySettingsGradle(defaultSettings, root)
 }
 
-ext.applyNativeModulesAppBuildGradle = { Project project ->
-  autoModules.applyBuildGradle(project, ext)
+ext.applyNativeModulesAppBuildGradle = { Project project, String root = ".." ->
+  autoModules.applyBuildGradle(project, root)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java/com/facebook/react")
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -118,9 +118,7 @@ class ReactNativeModules {
       androidRoot = this.defaultSettings.rootProject.projectDir
     }
 
-
     File rnRoot = new File(androidRoot, this.root)
-    // allow custom React Native project roots for non-standard directory structures
     this.logger.debug("${LOG_PREFIX}Using React Native project root path '${rnRoot.toString()}'")
     return rnRoot
   }


### PR DESCRIPTION
Summary:
---------

A lot of library maintainers and some app users may find themselves in a project with custom structure, like this:

```
root/
  node_modules
  example/
    android/
    ios/
```

Setting a custom root for Gradle project kinda worked, but it was brittle and hard to set. In cooperation with @Salakar we made setting the custom root in a similar fashion to iOS code:

```groovy
// example/android/settings.gradle
applyNativeModulesSettingsGradle(settings, "../..")
```

```groovy
// example/android/app/build.gradle
applyNativeModulesAppBuildGradle(project, "../..")
```

Adjusted the iOS docs to be more descriptive as well.

Test Plan:
----------

Tested in a monorepo and default structure.
