### PR TITLE
Fixed iOS simulator naming problem

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
@@ -602,7 +602,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6s (10.0)',
+        'iPhone 6s - 10.0',
       ),
     ).toEqual({
       udid: 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22',
@@ -671,7 +671,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6s (10.0)',
+        'iPhone 6s - 10.0',
       ),
     ).toEqual(null);
   });

--- a/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
@@ -26,9 +26,21 @@ function findMatchingSimulator(simulators, simulatorString) {
   }
   const devices = simulators.devices;
 
+  // Failed to run with --simulator option in Xcode 10.2.1 update for simulator name with brackets
+  // e.g "iPad Pro (9.7-inch)"
   const parsedSimulatorName = simulatorString
     ? simulatorString.match(/(.*)? (?:\((.*)?\))?/)
     : [];
+
+  // Changed to support new Xcoce simulator name and iOS/tvOS version support
+  // e.g. --simulator='iPhone XS'
+  // e.g. --simulator='iPhone XS - 12.0'
+  // e.g. --simulator='iPad Pro (9.7-inch)'
+  // e.g. --simulator='iPad Pro (9.7-inch) - 12.2'
+  const parsedSimulatorName = simulatorString
+    ? simulatorString.match(/(.*)? - (?:(\d+\.\d+)?$)?/)
+    : [];
+
   if (parsedSimulatorName && parsedSimulatorName[2] !== undefined) {
     var simulatorVersion = parsedSimulatorName[2];
     var simulatorName = parsedSimulatorName[1];

--- a/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
@@ -32,7 +32,7 @@ function findMatchingSimulator(simulators, simulatorString) {
   //   ? simulatorString.match(/(.*)? (?:\((.*)?\))?/)
   //   : [];
 
-  // Changed to support new Xcoce simulator name and iOS/tvOS version support
+  // Changed to support new Xcode simulator name and iOS/tvOS version support
   // e.g. --simulator='iPhone XS'
   // e.g. --simulator='iPhone XS - 12.0'
   // e.g. --simulator='iPad Pro (9.7-inch)'

--- a/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
@@ -28,9 +28,9 @@ function findMatchingSimulator(simulators, simulatorString) {
 
   // Failed to run with --simulator option in Xcode 10.2.1 update for simulator name with brackets
   // e.g "iPad Pro (9.7-inch)"
-  const parsedSimulatorName = simulatorString
-    ? simulatorString.match(/(.*)? (?:\((.*)?\))?/)
-    : [];
+  // const parsedSimulatorName = simulatorString
+  //   ? simulatorString.match(/(.*)? (?:\((.*)?\))?/)
+  //   : [];
 
   // Changed to support new Xcoce simulator name and iOS/tvOS version support
   // e.g. --simulator='iPhone XS'


### PR DESCRIPTION
Summary:
---------

react-native cli --simulator option is not working with some default simulator name in Xcode 10.2.1.
(e.g. "iPad Pro (9.7-inch)" )
Changed the regex in `findMatchingSimulator.js` to parse --simulator option string to more like Xcode default simulator naming convention, `${simulatorName} - ${iosVersion}` (e.g. "iPad Pro (9.7-inch) - 12.2" )

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
