### PR TITLE
Fixed iOS simulator naming problem (name with brackets) in latest Xcode update

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
@@ -676,6 +676,226 @@ describe('findMatchingSimulator', () => {
     ).toEqual(null);
   });
 
+  it('should return iPad(name with bracket) simulator if simulator name is in the list', () => {
+    expect(
+      findMatchingSimulator(
+        {
+          devices: {
+            'iOS 12.0': [
+              {
+                state: 'Shutdown',
+                availability: '(unavailable, runtime profile not found)',
+                name: 'iPhone 4s',
+                udid: 'B9B5E161-416B-43C4-A78F-729CB96CC8C6',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 5',
+                udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6',
+                udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6 (Plus)',
+                udid: '9564ABEE-9EC2-4B4A-B443-D3710929A45A',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6s',
+                udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPad Pro (9.7-inch)',
+                udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+              }
+            ],
+            'iOS 12.2': [
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6',
+                udid: '2FF48AE5-CC3B-4C80-8D25-48966A6BE2C0',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6 (Plus)',
+                udid: '841E33FE-E8A1-4B65-9FF8-6EAA6442A3FC',
+              },
+              {
+                state: 'Booted',
+                availability: '(available)',
+                name: 'iPhone 7',
+                udid: '3A409DC5-5188-42A6-8598-3AA6F34607A5',
+              },
+            ],
+          },
+        },
+        'iPad Pro (9.7-inch)',
+      ),
+    ).toEqual({
+      state: 'Shutdown',
+      availability: '(available)',
+      name: 'iPad Pro (9.7-inch)',
+      udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+    });
+  });
+
+  it('should return iPad(name with bracket) simulator if simulator name and specified iOS version is in the list', () => {
+    expect(
+      findMatchingSimulator(
+        {
+          devices: {
+            'iOS 12.0': [
+              {
+                state: 'Shutdown',
+                availability: '(unavailable, runtime profile not found)',
+                name: 'iPhone 4s',
+                udid: 'B9B5E161-416B-43C4-A78F-729CB96CC8C6',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 5',
+                udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6',
+                udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6 (Plus)',
+                udid: '9564ABEE-9EC2-4B4A-B443-D3710929A45A',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6s',
+                udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
+              },
+            ],
+            'iOS 12.2': [
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6',
+                udid: '2FF48AE5-CC3B-4C80-8D25-48966A6BE2C0',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6 (Plus)',
+                udid: '841E33FE-E8A1-4B65-9FF8-6EAA6442A3FC',
+              },
+              {
+                state: 'Booted',
+                availability: '(available)',
+                name: 'iPhone 7',
+                udid: '3A409DC5-5188-42A6-8598-3AA6F34607A5',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPad Pro (9.7-inch)',
+                udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+              }
+            ],
+          },
+        },
+        'iPad Pro (9.7-inch) (12.2)',
+      ),
+    ).toEqual({
+      state: 'Shutdown',
+      availability: '(available)',
+      name: 'iPad Pro (9.7-inch)',
+      udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+    });
+  });
+
+  it('should return null if the version is specified and no iPad device with the exact version exists', () => {
+    expect(
+      findMatchingSimulator(
+        {
+          devices: {
+            'iOS 12.0': [
+              {
+                state: 'Shutdown',
+                availability: '(unavailable, runtime profile not found)',
+                name: 'iPhone 4s',
+                udid: 'B9B5E161-416B-43C4-A78F-729CB96CC8C6',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 5',
+                udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6',
+                udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6 (Plus)',
+                udid: '9564ABEE-9EC2-4B4A-B443-D3710929A45A',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6s',
+                udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
+              },
+            ],
+            'iOS 12.2': [
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6',
+                udid: '2FF48AE5-CC3B-4C80-8D25-48966A6BE2C0',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPhone 6 (Plus)',
+                udid: '841E33FE-E8A1-4B65-9FF8-6EAA6442A3FC',
+              },
+              {
+                state: 'Booted',
+                availability: '(available)',
+                name: 'iPhone 7',
+                udid: '3A409DC5-5188-42A6-8598-3AA6F34607A5',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'iPad Pro (9.7-inch)',
+                udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+              }
+            ],
+          },
+        },
+        'iPad Pro (9.7-inch) (12.0)',
+      ),
+    ).toEqual(null);
+  });
+
   it('should return AppleTV devices if in the list', () => {
     expect(
       findMatchingSimulator(

--- a/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
@@ -676,7 +676,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual(null);
   });
 
-  it('should return iPad(name with bracket) simulator if simulator name is in the list', () => {
+  it('should return iPad(name with brackets) simulator if simulator name is in the list', () => {
     expect(
       findMatchingSimulator(
         {
@@ -751,7 +751,7 @@ describe('findMatchingSimulator', () => {
     });
   });
 
-  it('should return iPad(name with bracket) simulator if simulator name and specified iOS version is in the list', () => {
+  it('should return iPad(name with brackets) simulator if simulator name and specified iOS version is in the list', () => {
     expect(
       findMatchingSimulator(
         {

--- a/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator-test.js
@@ -717,7 +717,7 @@ describe('findMatchingSimulator', () => {
                 availability: '(available)',
                 name: 'iPad Pro (9.7-inch)',
                 udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
-              }
+              },
             ],
             'iOS 12.2': [
               {
@@ -744,10 +744,10 @@ describe('findMatchingSimulator', () => {
         'iPad Pro (9.7-inch)',
       ),
     ).toEqual({
-      state: 'Shutdown',
-      availability: '(available)',
-      name: 'iPad Pro (9.7-inch)',
       udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+      name: 'iPad Pro (9.7-inch)',
+      booted: false,
+      version: 'iOS 12.0',
     });
   });
 
@@ -812,17 +812,17 @@ describe('findMatchingSimulator', () => {
                 availability: '(available)',
                 name: 'iPad Pro (9.7-inch)',
                 udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
-              }
+              },
             ],
           },
         },
         'iPad Pro (9.7-inch) (12.2)',
       ),
     ).toEqual({
-      state: 'Shutdown',
-      availability: '(available)',
-      name: 'iPad Pro (9.7-inch)',
       udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
+      name: 'iPad Pro (9.7-inch)',
+      booted: false,
+      version: 'iOS 12.2',
     });
   });
 
@@ -887,7 +887,7 @@ describe('findMatchingSimulator', () => {
                 availability: '(available)',
                 name: 'iPad Pro (9.7-inch)',
                 udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
-              }
+              },
             ],
           },
         },

--- a/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
@@ -27,8 +27,9 @@ function findMatchingSimulator(simulators, simulatorString) {
   const devices = simulators.devices;
 
   const parsedSimulatorName = simulatorString
-    ? simulatorString.match(/(.*)? (?:\((.*)?\))?/)
+    ? simulatorString.match(/(.*)? (?:\((\d+\.\d+)?\))$/)
     : [];
+
   if (parsedSimulatorName && parsedSimulatorName[2] !== undefined) {
     var simulatorVersion = parsedSimulatorName[2];
     var simulatorName = parsedSimulatorName[1];


### PR DESCRIPTION
Summary:
---------
react-native cli --simulator option is not working with some default simulator name in Xcode 10.2.1.
(e.g. "iPad Pro (9.7-inch)" )
Changed the regex in `findMatchingSimulator.js` to parse --simulator option string to find version number only (e.g. "iPad Pro (9.7-inch) (12.2)" )

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
