### PR TITLE
fix: config on Windows & warnings breaking config JSON output on iOS

### DIFF
--- a/__e2e__/legacyInit.test.js
+++ b/__e2e__/legacyInit.test.js
@@ -17,6 +17,7 @@ afterEach(() => {
 test('legacy init through react-native-cli', () => {
   const templateFiles = [
     '.buckconfig',
+    '.eslintrc.js',
     '.flowconfig',
     '.gitattributes',
     '.gitignore',
@@ -64,7 +65,7 @@ test('legacy init through react-native-cli', () => {
     name: 'TestApp',
     private: true,
     scripts: {
-      start: 'node node_modules/react-native/local-cli/cli.js start',
+      start: 'react-native start',
       test: 'jest',
     },
   });

--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -169,7 +169,15 @@ async function setupAndRun() {
     }
   }
 
+  // when we run `config`, we don't want to output anything to the console. We
+  // expect it to return valid JSON
+  if (process.argv.includes('config')) {
+    logger.disable();
+  }
+
   const ctx = loadConfig();
+
+  logger.enable();
 
   setProjectDir(ctx.root);
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -167,7 +167,7 @@ class ReactNativeModules {
 
     def cmdProcess
     def root = getReactNativeProjectRoot()
-    def command = "node ./node_modules/.bin/react-native config"
+    def command = "./node_modules/.bin/react-native config"
 
     try {
       cmdProcess = Runtime.getRuntime().exec(command, null, root)

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -5,8 +5,8 @@
 #
 def use_native_modules!(root = "..", packages = nil)
   if (!packages)
-    command = "node"
-    args = ["./node_modules/.bin/react-native", "config"]
+    command = "./node_modules/.bin/react-native"
+    args = ["config"]
     output = ""
     # Make sure `react-native config` is ran from your project root
     Dir.chdir(root) do
@@ -15,14 +15,7 @@ def use_native_modules!(root = "..", packages = nil)
 
     json = []
     output.each_line do |line|
-      case line
-      when /^warn\s(.+)/
-        Pod::UI.warn($1)
-      when /^(success|info|error|debug)\s(.+)/
-        Pod::UI.message($1)
-      else
-        json << line
-      end
+      json << line
     end
     config = JSON.parse(json.join("\n"))
     packages = config["dependencies"]

--- a/packages/tools/src/logger.ts
+++ b/packages/tools/src/logger.ts
@@ -3,34 +3,45 @@ import chalk from 'chalk';
 const SEPARATOR = ', ';
 
 let verbose = false;
+let disabled = false;
 
 const formatMessages = (messages: Array<string>) =>
   chalk.reset(messages.join(SEPARATOR));
 
 const success = (...messages: Array<string>) => {
-  console.log(`${chalk.green.bold('success')} ${formatMessages(messages)}`);
+  if (!disabled) {
+    console.log(`${chalk.green.bold('success')} ${formatMessages(messages)}`);
+  }
 };
 
 const info = (...messages: Array<string>) => {
-  console.log(`${chalk.cyan.bold('info')} ${formatMessages(messages)}`);
+  if (!disabled) {
+    console.log(`${chalk.cyan.bold('info')} ${formatMessages(messages)}`);
+  }
 };
 
 const warn = (...messages: Array<string>) => {
-  console.warn(`${chalk.yellow.bold('warn')} ${formatMessages(messages)}`);
+  if (!disabled) {
+    console.warn(`${chalk.yellow.bold('warn')} ${formatMessages(messages)}`);
+  }
 };
 
 const error = (...messages: Array<string>) => {
-  console.error(`${chalk.red.bold('error')} ${formatMessages(messages)}`);
+  if (!disabled) {
+    console.error(`${chalk.red.bold('error')} ${formatMessages(messages)}`);
+  }
 };
 
 const debug = (...messages: Array<string>) => {
-  if (verbose) {
+  if (verbose && !disabled) {
     console.log(`${chalk.gray.bold('debug')} ${formatMessages(messages)}`);
   }
 };
 
 const log = (...messages: Array<string>) => {
-  console.log(`${formatMessages(messages)}`);
+  if (!disabled) {
+    console.log(`${formatMessages(messages)}`);
+  }
 };
 
 const setVerbose = (level: boolean) => {
@@ -38,6 +49,14 @@ const setVerbose = (level: boolean) => {
 };
 
 const isVerbose = () => verbose;
+
+const disable = () => {
+  disabled = true;
+};
+
+const enable = () => {
+  disabled = false;
+};
 
 export default {
   success,
@@ -48,4 +67,6 @@ export default {
   log,
   setVerbose,
   isVerbose,
+  disable,
+  enable,
 };


### PR DESCRIPTION
Summary:
---------

This PR introduces `enable` and `disable` methods to logger, so that we can disable logging when calling `config`, which should only output valid JSON.

Fixes:
- fixes https://github.com/react-native-community/cli/issues/465 (running config on Windows)
- multi-line warnings breaking config JSON output on iOS 


Test Plan:
----------

Tested on a local project
