### PR TITLE
fix: log-android not working. update logkitty.

### DIFF
--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -4,7 +4,7 @@
   "main": "build/index.js",
   "dependencies": {
     "@react-native-community/cli-tools": "^2.0.2",
-    "logkitty": "^0.4.0",
+    "logkitty": "^0.5.0",
     "slash": "^2.0.0",
     "xmldoc": "^0.4.0"
   },

--- a/packages/platform-android/src/commands/logAndroid/index.js
+++ b/packages/platform-android/src/commands/logAndroid/index.js
@@ -10,7 +10,7 @@ import {
   makeTagsFilter,
   formatEntry,
   formatError,
-  Priority,
+  AndroidPriority,
 } from 'logkitty';
 import {logger} from '@react-native-community/cli-tools';
 
@@ -19,7 +19,7 @@ async function logAndroid() {
 
   const emitter = logkitty({
     platform: 'android',
-    minPriority: Priority.VERBOSE,
+    minPriority: AndroidPriority.VERBOSE,
     filter: makeTagsFilter('ReactNative', 'ReactNativeJS'),
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5971,10 +5971,10 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-logkitty@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/logkitty/-/logkitty-0.4.0.tgz#4a534bb4fb2b27f0120ed7b9fc62b8aa3ba6bb43"
-  integrity sha512-IKuHwaXYDpbEzC9EfsrmvwdS80b4Lv+W4n7g6GG0gBHt5kXzQEvew46E0omrSD3ycEpTOtAX7BXGWnOUFEksYA==
+logkitty@^0.5.0:
+  version "0.5.0"
+  resolved "http://localhost:4873/logkitty/-/logkitty-0.5.0.tgz#5a348c2049551aa02da69543c3b5c44e28c7c24f"
+  integrity sha512-UA06TmPaSPiHxMBlo5uxL3ZvjJ2Gx/rEECrqowHsIsNoAoSB8aBSP553Fr2FJhOp3it2ulLsd520DZWS1IaYOw==
   dependencies:
     ansi-fragments "^0.2.1"
     yargs "^12.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5973,7 +5973,7 @@ log-symbols@^2.2.0:
 
 logkitty@^0.5.0:
   version "0.5.0"
-  resolved "http://localhost:4873/logkitty/-/logkitty-0.5.0.tgz#5a348c2049551aa02da69543c3b5c44e28c7c24f"
+  resolved "https://registry.yarnpkg.com/logkitty/-/logkitty-0.5.0.tgz#5a348c2049551aa02da69543c3b5c44e28c7c24f"
   integrity sha512-UA06TmPaSPiHxMBlo5uxL3ZvjJ2Gx/rEECrqowHsIsNoAoSB8aBSP553Fr2FJhOp3it2ulLsd520DZWS1IaYOw==
   dependencies:
     ansi-fragments "^0.2.1"


### PR DESCRIPTION
Summary:
---------

This PR was actually trying to fix #459 for logkitty@0.4.1 but since 0.4.2 is out (to revert back) and release 0.5.0 (for the new breaking change), this PR is more to update to the latest one.

Test Plan:
----------

Follow [testing-init-command](https://github.com/react-native-community/cli/blob/master/CONTRIBUTING.md#testing-init-command) locally and use the new [init](https://github.com/react-native-community/cli/blob/master/docs/init.md):

```sh
mkdir testlog && cd testlog
yarn init && yarn add react-native@${RN_VERSION} && yarn react-native init testlog
react-native log-android
```
