### PR TITLE
fix: run release checker only after `start` and `info` command

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -19,9 +19,6 @@ import init from './commands/init/initCompat';
 import assertRequiredOptions from './tools/assertRequiredOptions';
 import {logger} from '@react-native-community/cli-tools';
 import {setProjectDir} from './tools/packageManager';
-import resolveNodeModuleDir from './tools/config/resolveNodeModuleDir';
-import getLatestRelease from './tools/releaseChecker/getLatestRelease';
-import printNewRelease from './tools/releaseChecker/printNewRelease';
 import pkgJson from '../package.json';
 import loadConfig from './tools/config';
 
@@ -119,8 +116,6 @@ const addCommand = (command: CommandT, ctx: ConfigT) => {
         await command.func(argv, ctx, passedOptions);
       } catch (error) {
         handleError(error);
-      } finally {
-        checkForNewRelease(ctx.root);
       }
     });
 
@@ -197,29 +192,6 @@ async function setupAndRun() {
   }
 
   logger.setVerbose(commander.verbose);
-}
-
-async function checkForNewRelease(root: string) {
-  try {
-    const {version: currentVersion} = require(path.join(
-      resolveNodeModuleDir(root, 'react-native'),
-      'package.json',
-    ));
-    const {name} = require(path.join(root, 'package.json'));
-    const latestRelease = await getLatestRelease(name, currentVersion);
-
-    if (latestRelease) {
-      printNewRelease(name, latestRelease, currentVersion);
-    }
-  } catch (e) {
-    // We let the flow continue as this component is not vital for the rest of
-    // the CLI.
-    logger.debug(
-      'Cannot detect current version of React Native, ' +
-        'skipping check for a newer release',
-    );
-    logger.debug(e);
-  }
 }
 
 export default {

--- a/packages/cli/src/commands/info/__tests__/info.test.js
+++ b/packages/cli/src/commands/info/__tests__/info.test.js
@@ -3,14 +3,6 @@ import info from '../info';
 import {logger} from '@react-native-community/cli-tools';
 import loadConfig from '../../../tools/config';
 
-jest.mock('@react-native-community/cli-tools', () => ({
-  logger: {
-    info: jest.fn(),
-    error: jest.fn(),
-    log: jest.fn(),
-  },
-}));
-
 jest.mock('../../../tools/config');
 
 beforeEach(() => {

--- a/packages/cli/src/commands/info/info.js
+++ b/packages/cli/src/commands/info/info.js
@@ -10,6 +10,7 @@
 import envinfo from 'envinfo';
 import {logger} from '@react-native-community/cli-tools';
 import type {ConfigT} from 'types';
+import releaseChecker from '../../tools/releaseChecker';
 
 const info = async function getInfo(
   argv: Array<string>,
@@ -29,6 +30,8 @@ const info = async function getInfo(
     logger.log(output.trim());
   } catch (err) {
     logger.error(`Unable to print environment info.\n${err}`);
+  } finally {
+    await releaseChecker(ctx.root);
   }
 };
 

--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -17,6 +17,7 @@ import messageSocket from './messageSocket';
 import webSocketProxy from './webSocketProxy';
 import MiddlewareManager from './middleware/MiddlewareManager';
 import loadMetroConfig from '../../tools/loadMetroConfig';
+import releaseChecker from '../../tools/releaseChecker';
 
 export type Args = {|
   assetPlugins?: string[],
@@ -107,6 +108,8 @@ async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {
   // For more info: https://github.com/nodejs/node/issues/13391
   //
   serverInstance.keepAliveTimeout = 30000;
+
+  await releaseChecker(ctx.root);
 }
 
 function getReporterImpl(customLogReporterPath: ?string) {

--- a/packages/cli/src/tools/releaseChecker/index.js
+++ b/packages/cli/src/tools/releaseChecker/index.js
@@ -1,0 +1,29 @@
+// @flow
+import path from 'path';
+import {logger} from '@react-native-community/cli-tools';
+import resolveNodeModuleDir from '../config/resolveNodeModuleDir';
+import getLatestRelease from './getLatestRelease';
+import printNewRelease from './printNewRelease';
+
+export default async function releaseChecker(root: string) {
+  try {
+    const {version: currentVersion} = require(path.join(
+      resolveNodeModuleDir(root, 'react-native'),
+      'package.json',
+    ));
+    const {name} = require(path.join(root, 'package.json'));
+    const latestRelease = await getLatestRelease(name, currentVersion);
+
+    if (latestRelease) {
+      printNewRelease(name, latestRelease, currentVersion);
+    }
+  } catch (e) {
+    // We let the flow continue as this component is not vital for the rest of
+    // the CLI.
+    logger.debug(
+      'Cannot detect current version of React Native, ' +
+        'skipping check for a newer release',
+    );
+    logger.debug(e);
+  }
+}


### PR DESCRIPTION
Summary:
---------

We run release checker with every command. This is unnecessary and especially dangerous when running `config`, since we hit network and it may not resolve in time. 

Let's run it when it makes sense: 

- during development (`start` command) 
- when preparing an issue report (`info` command)

Fixes one of the issues haunting Windows: https://github.com/react-native-community/cli/issues/470

Test Plan:
----------

Run with `--verbose` and observe version check only triggers during mentioned 2 commands.
