### PR TITLE
Fix autolinking bug on Windows

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -167,18 +167,23 @@ class ReactNativeModules {
 
     def cmdProcess
     def root = getReactNativeProjectRoot()
-    def command = "./node_modules/.bin/react-native config"
-
+    def command = "node ./node_modules/react-native/cli.js config"
+    def reactNativeConfigOutput = ""
+    
     try {
       cmdProcess = Runtime.getRuntime().exec(command, null, root)
-      cmdProcess.waitFor()
+      def inputStreamReader = new InputStreamReader(cmdProcess.getInputStream())
+      def bufferedReader = new BufferedReader(inputStreamReader)
+      def line = null
+      while ((line = bufferedReader.readLine()) != null){
+          reactNativeConfigOutput += line
+      }
     } catch (Exception exception) {
       this.logger.warn("${LOG_PREFIX}${exception.message}")
       this.logger.warn("${LOG_PREFIX}Automatic import of native modules failed.")
       return reactNativeModules
     }
 
-    def reactNativeConfigOutput = cmdProcess.in.text
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
     this.packageName = json["project"]["android"]["packageName"]
     def dependencies = json["dependencies"]


### PR DESCRIPTION
Summary:
---------
This fixes #470. 

I changed the `config` command to one that works on Windows and replaced `cmdProcess.waitFor` with directly reading from the processes `InputStream` so the `buffer` is continuously cleared preventing a deadlock.

Test Plan:
----------
I tested this on a new project created using `react-native init` and making necessary edits to `native_modules.gradle` This works on Windows without a hitch. I did not test it on Linux or macOS but it _should_ work.
