### PR TITLE
fix: duplicate entires in rnpm warning

### DIFF
--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -97,10 +97,12 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
 
   let depsWithWarnings = [];
 
-  const finalConfig = [
-    ...Object.keys(userConfig.dependencies),
-    ...findDependencies(projectRoot),
-  ].reduce((acc: ConfigT, dependencyName) => {
+  const finalConfig = Array.from(
+    new Set([
+      ...Object.keys(userConfig.dependencies),
+      ...findDependencies(projectRoot),
+    ]),
+  ).reduce((acc: ConfigT, dependencyName) => {
     const localDependencyRoot =
       userConfig.dependencies[dependencyName] &&
       userConfig.dependencies[dependencyName].root;


### PR DESCRIPTION
Summary:
---------

When a package config is overwritten by user's `react-native.config.js`, and it outputs the "rnpm" warning, it happens that the entries are duplicate. Let's make sure we only iterate on unique package names.

