### PR TITLE
Fix Metro Bundler crashing on run-android on Windows

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -252,7 +252,8 @@ function startServerInNewWindow(port, terminal, reactNativePath) {
 
   /**
    * Quick & temporary fix for packager crashing on Windows due to using removed --projectRoot flag
-   * in script. So we just replace the contents of the script with the fixed version.
+   * in script. So we just replace the contents of the script with the fixed version. This should be
+   * removed when PR #25517 on RN Repo gets approved and a new RN version is released.
    */
   const launchPackagerScriptContent = `:: Copyright (c) Facebook, Inc. and its affiliates.
   ::


### PR DESCRIPTION
Summary:
---------
This is a temporary fix for #484 until [this PR](https://github.com/facebook/react-native/pull/25517) get approved in RN repo and a new RN version is released. It should be removed afterwards.

I basically replace the content of `launchPackager.bat` to its fixed version. Everything runs smoothly afterwards.

Test Plan:
----------
Tested this on a new project created using `react-native init` and manually editing the appropriate files to implement the fix. It seems to be working on my Windows machine. Should be tested before merge though.