### PR TITLE
[android] Optionally support an Application instance in PackageList constructor

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -17,9 +17,15 @@ import java.util.ArrayList;
 {{ packageImports }}
 
 public class PackageList {
+  private Application application;
   private ReactNativeHost reactNativeHost;
   public PackageList(ReactNativeHost reactNativeHost) {
     this.reactNativeHost = reactNativeHost;
+  }
+  
+  public PackageList(Application application) {
+    this.reactNativeHost = null;
+    this.application = application;
   }
 
   private ReactNativeHost getReactNativeHost() {
@@ -31,6 +37,7 @@ public class PackageList {
   }
 
   private Application getApplication() {
+    if (this.reactNativeHost == null) return this.application;
     return this.reactNativeHost.getApplication();
   }
 


### PR DESCRIPTION
Summary:
---------

Fixes #467 - confirmed working on this issue. This adds support for 'this' being an Application instance or a ReactNativeHost instance when passed to the PackageList class constructor. 

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
