### PR TITLE
chore: remove unstable `init --template` shorthand support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -139,7 +139,6 @@ Uses a custom directory instead of `<projectName>`.
 Uses a custom template. Accepts following template sources:
 
 - an npm package name
-- a shorthand name for packages prefixed with `react-native-template-`
 - an absolute path to a local directory
 - an absolute path to a tarball created using `npm pack`
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -35,7 +35,6 @@ npx react-native@${VERSION} init ProjectName
 In following examples `TEMPLATE_NAME` can be either:
 
 - Full package name, eg. `react-native-template-typescript`.
-- Shorthand name of template, eg. `typescript`.
 - Absolute path to directory containing template, eg. `file:///Users/username/project/some-template`.
 - Absolute path to a tarball created using `npm pack`.
 

--- a/packages/cli/src/commands/init/__tests__/templateName.test.js
+++ b/packages/cli/src/commands/init/__tests__/templateName.test.js
@@ -21,28 +21,6 @@ test('supports file protocol with absolute path', async () => {
   });
 });
 
-test('supports shorthand templates', async () => {
-  const templateName = 'typescript';
-  (fetch: any).mockImplementationOnce(() => {
-    return Promise.resolve(`{"name": "react-native-template-${templateName}"}`);
-  });
-  expect(await processTemplateName(templateName)).toEqual({
-    uri: `react-native-template-${templateName}`,
-    name: `react-native-template-${templateName}`,
-  });
-});
-
-test('supports not-found shorthand templates', async () => {
-  const templateName = 'typescriptz';
-  (fetch: any).mockImplementationOnce(() => {
-    return Promise.resolve('Not found');
-  });
-  expect(await processTemplateName(templateName)).toEqual({
-    uri: templateName,
-    name: templateName,
-  });
-});
-
 test('supports npm packages as template names', async () => {
   expect(await processTemplateName(RN_NPM_PACKAGE)).toEqual({
     uri: RN_NPM_PACKAGE,

--- a/packages/cli/src/commands/init/templateName.js
+++ b/packages/cli/src/commands/init/templateName.js
@@ -57,35 +57,8 @@ export async function processTemplateName(templateName: string) {
     return handleVersionedPackage(templateName);
   }
 
-  const name = await tryTemplateShorthand(templateName);
-
   return {
-    uri: name,
-    name,
+    uri: templateName,
+    name: templateName,
   };
-}
-
-/**
- * `init` may be invoked with a shorthand like `--template typescript`
- * which should resolve to `react-native-template-typescript` package.
- * To support that, we query npm registry if a package like this exists, if not
- * we return the original name without a change.
- */
-async function tryTemplateShorthand(templateName: string) {
-  if (templateName.match(FILE_PROTOCOL) || templateName.match(HTTP_PROTOCOL)) {
-    return templateName;
-  }
-  try {
-    const reactNativeTemplatePackage = `react-native-template-${templateName}`;
-    const response = await fetch(
-      `https://registry.yarnpkg.com/${reactNativeTemplatePackage}/latest`,
-    );
-
-    if (JSON.parse(response).name) {
-      return reactNativeTemplatePackage;
-    }
-  } catch (e) {
-    // we expect this to fail when `file://` protocol or regular module is passed
-  }
-  return templateName;
 }


### PR DESCRIPTION
Summary:
---------

This only work with `latest` tag on packages (see more details in #483) and hence cause confusion. For now, only full npm package names are supported. We can introduce some shorthand syntax, but under different flag. Legacy `init` is not affected, users can still use shorthand (and only that) notation there.

Test Plan:
----------

Updated tests.
