### PR TITLE
fix: don't set `projetRoot` for Metro

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -48,7 +48,6 @@ async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {
     port: args.port,
     resetCache: args.resetCache,
     watchFolders: args.watchFolders,
-    projectRoot: ctx.root,
     sourceExts: args.sourceExts,
     reporter,
   });

--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -71,7 +71,6 @@ export const getDefaultConfig = (ctx: ConfigT) => {
 export type ConfigOptionsT = {|
   maxWorkers?: number,
   port?: number,
-  projectRoot?: string,
   resetCache?: boolean,
   watchFolders?: string[],
   sourceExts?: string[],


### PR DESCRIPTION
Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/492 by not overriding user's `metro.config.js`. The `ctx.root` is always set to `process.cwd()` currently, so it didn't make sense anyway.

cc @janicduplessis 	

Test Plan:
----------

Verified on a sample project.
