### PR TITLE
fix: fix init command to work with scoped templates without version

### DIFF
--- a/packages/cli/src/commands/init/__tests__/templateName.test.js
+++ b/packages/cli/src/commands/init/__tests__/templateName.test.js
@@ -54,6 +54,7 @@ test.each`
   templateName             | uri                      | name
   ${'react-native@0.58.0'} | ${'react-native@0.58.0'} | ${'react-native'}
   ${'some-name@latest'}    | ${'some-name@latest'}    | ${'some-name'}
+  ${'@scoped/name'}        | ${'@scoped/name'}        | ${'@scoped/name'}
   ${'@scoped/name@0.58.0'} | ${'@scoped/name@0.58.0'} | ${'@scoped/name'}
   ${'@scoped/name@tag'}    | ${'@scoped/name@tag'}    | ${'@scoped/name'}
 `(

--- a/packages/cli/src/commands/init/templateName.js
+++ b/packages/cli/src/commands/init/templateName.js
@@ -7,7 +7,7 @@ const FILE_PROTOCOL = /file:/;
 const HTTP_PROTOCOL = /https?:/;
 const TARBALL = /\.tgz$/;
 const VERSION_POSTFIX = /(.*)(-\d+\.\d+\.\d+)/;
-const VERSIONED_PACKAGE = /(@?.*)(@)(.*)/;
+const VERSIONED_PACKAGE = /(@?.+)(@)(.+)/;
 
 function handleFileProtocol(filePath: string) {
   const uri = new URL(filePath).pathname;


### PR DESCRIPTION
Summary:
---------
Fixes init command to work with scoped template names that don't have a version suffix. A regex issue was causing template names like this to return an empty string as the template name:

`@react-native-firebase/template`


<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

Added a unit test and also tried running init.
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
