### PR TITLE
feat: use relative paths in podfile lock

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -43,10 +43,10 @@ def use_native_modules!(root = "..", packages = nil)
     end
 
     # Use relative path
-    absolute_path = File.dirname(podspec_path)
-    relative_path = '../' + absolute_path.partition('node_modules').last(2).join()
+    absolute_podspec_path = File.dirname(podspec_path)
+    relative_podspec_path = File.join(root, absolute_podspec_path.partition('node_modules').last(2).join())
 
-    pod spec.name, :path => relative_path
+    pod spec.name, :path => relative_podspec_path
 
     if package_config["scriptPhases"]
       # Can be either an object, or an array of objects

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -42,7 +42,11 @@ def use_native_modules!(root = "..", packages = nil)
       existing_dep.name.split('/').first == spec.name
     end
 
-    pod spec.name, :path => File.dirname(podspec_path)
+    # Use relative path
+    absolute_path = File.dirname(podspec_path)
+    relative_path = '../' + absolute_path.partition('node_modules').last(2).join()
+
+    pod spec.name, :path => relative_path
 
     if package_config["scriptPhases"]
       # Can be either an object, or an array of objects
@@ -174,7 +178,7 @@ if $0 == __FILE__
       @podfile.use_native_modules('..', @config)
       @activated_pods.must_equal [{
         name: "ios-dep",
-        options: { path: @ios_package["root"] }
+        options: { path: "../node_modules/react" }
       }]
     end
 


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

I've changed `native_modules.rb` to use relative path to package instead of absolute one. Fixes #488 


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I've tested the changes manually by adding `react-native-community/@geolocation` via yarn to local project and running `pod install` to generate `Podfile.lock`. I've also changed one of the tests to take into account new path.