### PR TITLE
fix: use_native_modules! warns and skips dependencies without a podspec

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -27,6 +27,17 @@ def use_native_modules!(root = "..", packages = nil)
     next unless package_config = package["platforms"]["ios"]
 
     podspec_path = package_config["podspecPath"]
+
+    # Add a warning to the queue and continue to the next dependency if the podspec_path is nil/empty
+    if podspec_path.nil? || podspec_path.empty?
+      Pod::UI.warn("use_native_modules! skipped the react-native dependency '#{package["name"]}'. No podspec file was found.",
+        [
+          "Check to see if there is an updated version that contains the necessary podspec file",
+          "Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a package.json driven podspec. See https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec"
+        ])
+    end
+    next if podspec_path.nil? || podspec_path.empty?
+
     spec = Pod::Specification.from_file(podspec_path)
 
     # We want to do a look up inside the current CocoaPods target

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -33,7 +33,8 @@ def use_native_modules!(root = "..", packages = nil)
       Pod::UI.warn("use_native_modules! skipped the react-native dependency '#{package["name"]}'. No podspec file was found.",
         [
           "Check to see if there is an updated version that contains the necessary podspec file",
-          "Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a package.json driven podspec. See https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec"
+          "Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a package.json driven podspec. See https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec",
+          "If necessary, you can disable autolinking for the dependency and link it manually. See https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library"
         ])
     end
     next if podspec_path.nil? || podspec_path.empty?


### PR DESCRIPTION
Summary:
---------
fix: use_native_modules! displays a descriptive warning and then skips any dependency packages without a podspec (#506)


Test Plan:
----------
1. Create a new react-native project using react-native v0.60.0
2. Install a dependency into `node_modules/` which the `react-native config` command will return a `platform.ios.podspecPath` value of `null/empty`. (e.g. `react-native-text-input-mask` https://github.com/react-native-community/react-native-text-input-mask).
3. Run the `pod install` command from the `ios/` folder.

**Expected Behavior:** The `use_native_modules!` function no longer attempts to load a podspec file using the `nil` `podspec_path` value causing the error message described in #506. The `use_native_modules!` function now skips the dependency without a podspec and continues. At completion, the `pod install` command prints a warning and suggested actions for any/each dependency encountered that did not have the required `podspec` file.

![image](https://user-images.githubusercontent.com/9260799/60842354-8da54e80-a199-11e9-9dde-e2716ae74428.png)


