### PR TITLE
chore: remove special iOS and Android platform handling for react-native

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,8 +24,6 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.0.3",
-    "@react-native-community/cli-platform-android": "^2.1.1",
-    "@react-native-community/cli-platform-ios": "^2.2.0",
     "@react-native-community/cli-tools": "^2.0.2",
     "chalk": "^1.1.1",
     "command-exists": "^1.2.8",

--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -4,8 +4,6 @@
 import path from 'path';
 import chalk from 'chalk';
 import {logger, inlineString} from '@react-native-community/cli-tools';
-import * as ios from '@react-native-community/cli-platform-ios';
-import * as android from '@react-native-community/cli-platform-android';
 import findDependencies from './findDependencies';
 import resolveReactNativePath from './resolveReactNativePath';
 import findAssets from './findAssets';
@@ -131,19 +129,6 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
           Reason: ${chalk.dim(error.message)}`),
       );
       return acc;
-    }
-
-    /**
-     * @todo: remove this code once `react-native` is published with
-     * `platforms` and `commands` inside `react-native.config.js`.
-     */
-    if (dependencyName === 'react-native') {
-      if (Object.keys(config.platforms).length === 0) {
-        config.platforms = {ios, android};
-      }
-      if (config.commands.length === 0) {
-        config.commands = [...ios.commands, ...android.commands];
-      }
     }
 
     const isPlatform = Object.keys(config.platforms).length > 0;


### PR DESCRIPTION
Summary:
---------

RN 0.60.0 shipped with [`react-native.config.js`](https://github.com/facebook/react-native/blob/0.60-stable/react-native.config.js) that registers commands and `ios` and `android` platform. There's no need to special case this anymore. 

FYI, there's no need to rush in merging it. It's not breaking, unless you're on RC (which didn't publish `react-native.config.js` by mistake)


Test Plan:
----------

`yarn react-native config` in a project should return the same results as currently (with `commands` and `platforms` and `haste` entries).
