### PR TITLE
feat: support `unlink --platforms` 

### DIFF
--- a/packages/cli/src/commands/install/uninstall.js
+++ b/packages/cli/src/commands/install/uninstall.js
@@ -10,13 +10,13 @@
 import type {ConfigT} from 'types';
 import {logger} from '@react-native-community/cli-tools';
 import * as PackageManager from '../../tools/packageManager';
-import link from '../link/unlink';
+import unlink from '../link/unlink';
 
 async function uninstall(args: Array<string>, ctx: ConfigT) {
   const name = args[0];
 
   logger.info(`Unlinking "${name}"...`);
-  await link.func([name], ctx);
+  await unlink.func([name], ctx, {});
 
   logger.info(`Uninstalling "${name}"...`);
   await PackageManager.uninstall([name]);


### PR DESCRIPTION
Summary:
---------

Add support for `--platforms` flag to `unlink`, same as in `link`.
This is helpful when a package can't support autolinking on a single platform. With `unlink --platforms android` we can only unlink Android if that's not supported. 

Related issue: https://github.com/kmagiera/react-native-gesture-handler/issues/671#issuecomment-509110370


Test Plan:
----------

No tests added. Verified this on a sample project, existing e2e tests should cover regressions.
