### PR TITLE
fix: run `pod repo update` after installing CocoaPods

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,6 @@
     "@react-native-community/cli-platform-ios": "^2.2.0",
     "@react-native-community/cli-tools": "^2.0.2",
     "chalk": "^1.1.1",
-    "command-exists": "^1.2.8",
     "commander": "^2.19.0",
     "compression": "^1.7.1",
     "connect": "^3.6.5",

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -154,7 +154,7 @@ async function installDependencies({
   npm?: boolean,
   loader: typeof Ora,
 }) {
-  loader.start('Installing all required dependencies');
+  loader.start('Installing dependencies');
 
   await PackageManager.installAll({
     preferYarn: !npm,

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -48,7 +48,11 @@ async function installPods({
 
       if (shouldInstallCocoaPods) {
         if (loader) {
-          loader.start('Installing CocoaPods');
+          loader.start(
+            `Installing CocoaPods ${chalk.dim(
+              '(this make take a few minutes)',
+            )}`,
+          );
         }
 
         try {

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -100,16 +100,18 @@ async function installPods({
             loader.succeed();
           }
         }
-
-        // This only shows when `CocoaPods` is automatically installed,
-        // if it's already installed then we just show the `Installing dependencies` step
-        if (loader) {
-          loader.start('Installing CocoaPods dependencies');
-        }
       }
     }
 
     try {
+      if (loader) {
+        loader.succeed();
+        loader.start(
+          `Installing CocoaPods dependencies ${chalk.dim(
+            '(this make take a few minutes)',
+          )}`,
+        );
+      }
       await execa('pod', ['install']);
     } catch (error) {
       // "pod" command outputs errors to stdout (at least some of them)

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -32,7 +32,7 @@ async function installPods({
       // Check if "pod" is available and usable. It happens that there are
       // multiple versions of "pod" command and even though it's there, it exits
       // with a failure
-      await execa('pod');
+      await execa('pod', ['--version']);
     } catch (e) {
       loader.info();
 
@@ -83,7 +83,6 @@ async function installPods({
             )}`,
           );
           await execa('pod', ['repo', 'update']);
-          loader.succeed();
         } catch (error) {
           // "pod" command outputs errors to stdout (at least some of them)
           logger.log(error.stderr || error.stdout);
@@ -99,6 +98,7 @@ async function installPods({
     }
 
     try {
+      loader.succeed();
       loader.start(
         `Installing CocoaPods dependencies ${chalk.dim(
           '(this make take a few minutes)',

--- a/packages/cli/src/tools/loader.js
+++ b/packages/cli/src/tools/loader.js
@@ -2,14 +2,15 @@
 import Ora from 'ora';
 import logger from './logger';
 
-class OraMock {
+class OraNoop {
   succeed() {}
   fail() {}
-  start() {}
+  start(message?: string) {}
+  info(message?: string) {}
 }
 
-function getLoader(): typeof Ora {
-  return logger.isVerbose() ? OraMock : Ora;
+export function getLoader(): typeof Ora {
+  return logger.isVerbose() ? OraNoop : Ora;
 }
 
-export {getLoader};
+export const NoopLoader = OraNoop;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2948,11 +2948,6 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-command-exists@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.8.tgz#715acefdd1223b9c9b37110a149c6392c2852291"
-  integrity sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==
-
 commander@^2.19.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Added `pod repo update` command call after CocoaPods installation to
avoid issues with pod command being unable to find specification for
dependency (as per #487 ).
Added loader to CocoaPods installation step for consistency with other
steps of init and better DX, removed logger info after 30s timeout
because of redundancy with loader.
Changed loader method before prompt for CocoaPods installation from
`stop` to `info` for better prompt visibility.

Resolves #487 


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Tested manually by uninstalling cocoapods gem, removing `~/.cocoapods` and running init command.