### PR TITLE
fix: add chalk as dependency of cli-platform-android

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,7 @@
     "@react-native-community/cli-platform-android": "^2.1.1",
     "@react-native-community/cli-platform-ios": "^2.2.0",
     "@react-native-community/cli-tools": "^2.0.2",
-    "chalk": "^1.1.1",
+    "chalk": "^2.4.2",
     "commander": "^2.19.0",
     "compression": "^1.7.1",
     "connect": "^3.6.5",

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@react-native-community/cli-platform-android",
   "version": "2.1.1",
+  "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
     "@react-native-community/cli-tools": "^2.0.2",
+    "chalk": "^2.4.2",
     "logkitty": "^0.5.0",
     "slash": "^2.0.0",
     "xmldoc": "^0.4.0"

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@react-native-community/cli-platform-ios",
   "version": "2.2.0",
+  "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
     "@react-native-community/cli-tools": "^2.0.2",
-    "chalk": "^1.1.1",
+    "chalk": "^2.4.2",
     "xcode": "^2.0.0"
   },
   "files": [

--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -91,7 +91,7 @@ function runIOS(_: Array<string>, ctx: ConfigT, args: FlagsT) {
   if (device) {
     return logger.error(
       `Could not find a device named: "${chalk.bold(
-        device,
+        String(device),
       )}". ${printFoundDevices(devices)}`,
     );
   }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@react-native-community/cli-tools",
   "version": "2.0.2",
+  "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "chalk": "^1.1.1",
+    "chalk": "^2.4.2",
     "lodash": "^4.17.5",
     "mime": "^2.4.1",
     "node-fetch": "^2.5.0"


### PR DESCRIPTION
Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/516
Additionally:
- bumps chalk to latest for all packages
- Adds missing license fields to all packages.


Test Plan:
----------

CI
