### PR TITLE
fix: cache lazy project getter for perf when accessed repeatedly

### DIFF
--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -64,6 +64,7 @@ function getDependencyConfig(
  * Loads CLI configuration
  */
 function loadConfig(projectRoot: string = process.cwd()): ConfigT {
+  let lazyProject;
   const userConfig = readConfigFromDisk(projectRoot);
 
   const initialConfig: ConfigT = {
@@ -84,14 +85,19 @@ function loadConfig(projectRoot: string = process.cwd()): ConfigT {
       platforms: Object.keys(userConfig.platforms),
     },
     get project() {
-      const project = {};
+      if (lazyProject) {
+        return lazyProject;
+      }
+
+      lazyProject = {};
       for (const platform in finalConfig.platforms) {
-        project[platform] = finalConfig.platforms[platform].projectConfig(
+        lazyProject[platform] = finalConfig.platforms[platform].projectConfig(
           projectRoot,
           userConfig.project[platform] || {},
         );
       }
-      return project;
+
+      return lazyProject;
     },
   };
 


### PR DESCRIPTION
Summary:
---------

When accessing `config.project` multiple times, there's no need to recalculate the `projectConfig()`, hence caching it. Dramatically improves performance of `warnAboutManuallyLinkedLibs` when running RNTester in `react-native` repo.


Test Plan:
----------

Nope
