### PR TITLE
WIP feat: allow dependencies to disable autolinkin

### DIFF
--- a/packages/cli/src/tools/config/index.js
+++ b/packages/cli/src/tools/config/index.js
@@ -37,10 +37,12 @@ function getDependencyConfig(
       name: dependencyName,
       platforms: Object.keys(finalConfig.platforms).reduce(
         (dependency, platform) => {
+          const isDisabled = config.dependency.platforms[platform] === null;
           const platformConfig = finalConfig.platforms[platform];
+
           dependency[platform] =
             // Linking platforms is not supported
-            isPlatform || !platformConfig
+            isDisabled || isPlatform || !platformConfig
               ? null
               : platformConfig.dependencyConfig(
                   root,

--- a/packages/cli/src/tools/config/schema.js
+++ b/packages/cli/src/tools/config/schema.js
@@ -46,22 +46,28 @@ export const dependencyConfig = t
       .object({
         platforms: map(t.string(), t.any())
           .keys({
-            ios: t
-              .object({
-                project: t.string(),
-                podspecPath: t.string(),
-                sharedLibraries: t.array().items(t.string()),
-                libraryFolder: t.string(),
-              })
-              .default({}),
-            android: t
-              .object({
-                sourceDir: t.string(),
-                manifestPath: t.string(),
-                packageImportPath: t.string(),
-                packageInstance: t.string(),
-              })
-              .default({}),
+            ios: [
+              t
+                .object({
+                  project: t.string(),
+                  podspecPath: t.string(),
+                  sharedLibraries: t.array().items(t.string()),
+                  libraryFolder: t.string(),
+                })
+                .default({}),
+              t.any().allow(null),
+            ],
+            android: [
+              t
+                .object({
+                  sourceDir: t.string(),
+                  manifestPath: t.string(),
+                  packageImportPath: t.string(),
+                  packageInstance: t.string(),
+                })
+                .default({}),
+              t.any().allow(null),
+            ],
           })
           .default(),
         assets: t

--- a/types/index.js
+++ b/types/index.js
@@ -179,8 +179,8 @@ export type UserDependencyConfigT = {
   // Additional dependency settings
   dependency: {
     platforms: {
-      android?: DependencyParamsAndroidT,
-      ios?: ProjectParamsIOST,
+      android?: DependencyParamsAndroidT | null,
+      ios?: ProjectParamsIOST | null,
       [key: string]: any,
     },
     assets: string[],


### PR DESCRIPTION
Summary:
---------

A dependency (library) that's not compatible with autolinlking can mark themselves as so using this config:

```js
module.exports = {
  dependency: {
    platforms: {
      android: null,
    },
  },
};

```

Tries to fix https://github.com/react-native-community/cli/issues/521

Test Plan:
----------

Not tested very thoroughly, need to go for now.