### PR TITLE
fix: better package class name regex on Android

### DIFF
--- a/packages/platform-android/src/config/findPackageClassName.js
+++ b/packages/platform-android/src/config/findPackageClassName.js
@@ -22,7 +22,11 @@ export default function getPackageClassName(folder) {
 
   const packages = files
     .map(filePath => fs.readFileSync(path.join(folder, filePath), 'utf8'))
-    .map(file => file.match(/class (.*) +(implements|:) ReactPackage/))
+    .map(file =>
+      file.match(
+        /class\s+(.+[^\s])(\s+implements\s+|\s*:)[\s,\w]*[^{]*ReactPackage/,
+      ),
+    )
     .filter(match => match);
 
   return packages.length ? packages[0][1] : null;


### PR DESCRIPTION
Summary:
---------
Regex that is used for finding class name of ReactPackage doesn't support custom formatting and implementation of more than one interface

Current regex doesn't work for code like this:
```kotlin
class ReactNativeSamplePackage: ReactPackage {
}
```
because there is no whitespace between `ReactNativeSamplePackage` and `:`
Module is not linked also when package class implements other interface before ReactPackage one
```kotlin
class ReactNativeSamplePackage: SomeInterface, NextInterface, ReactPackage {
}
```

Test Plan:
----------
Green tests
Try autolink module with package class like below
```kotlin
class ReactNativePackage
    : 
  ReactPackage {
    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<ViewManager<View, ReactShadowNode<*>>> {
        return Collections.emptyList()
    }

    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
        return Collections.emptyList()
    }
}
```
