### PR TITLE
feat: run `jetifier` before `run-android`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -326,6 +326,12 @@ Launches the Metro Bundler in a new window using the specified terminal path.
 Run custom gradle tasks. If this argument is provided, then `--variant` option is ignored.
 Example: `yarn react-native run-android --tasks clean,installDebug`.
 
+#### `--no-jetifier`
+
+> default: false
+
+Do not run [jetifier](https://www.npmjs.com/package/jetifier) – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that don't support AndroidX yet.
+
 ### `run-ios`
 
 Usage:

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@react-native-community/cli-tools": "^2.4.1",
     "chalk": "^2.4.2",
+    "jetifier": "^1.6.2",
     "logkitty": "^0.5.0",
     "slash": "^2.0.0",
     "xmldoc": "^0.4.0"

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -406,7 +406,7 @@ export default {
     {
       name: '--no-jetifier',
       description:
-        'Do not run "jetifier" – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that doesn\'t support AndroiX yet. See more at: https://www.npmjs.com/package/jetifier.',
+        'Do not run "jetifier" – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that don\'t support AndroidX yet. See more at: https://www.npmjs.com/package/jetifier.',
       default: false,
     },
   ],

--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -9,10 +9,9 @@
 
 import path from 'path';
 import {spawnSync, spawn, execFileSync} from 'child_process';
+import chalk from 'chalk';
 import fs from 'fs';
-
 import type {ConfigT} from 'types';
-
 import adb from './adb';
 import runOnAllDevices from './runOnAllDevices';
 import tryRunAdbReverse from './tryRunAdbReverse';
@@ -43,6 +42,7 @@ export type FlagsT = {|
   packager: boolean,
   port: number,
   terminal: string,
+  jetifier: boolean,
 |};
 
 /**
@@ -57,6 +57,19 @@ function runAndroid(argv: Array<string>, config: ConfigT, args: FlagsT) {
   }
 
   warnAboutManuallyLinkedLibs(config);
+
+  if (args.jetifier) {
+    logger.info(
+      `Running ${chalk.bold(
+        'jetifier',
+      )} to migrate libraries to AndroidX. ${chalk.dim(
+        'You can disable it using "--no-jetifier" flag.',
+      )}`,
+    );
+    // Jetifier is a side-effectful module without a default export. Requiring
+    // it ad-hoc.
+    require('jetifier');
+  }
 
   if (!args.packager) {
     return buildAndRun(args);
@@ -259,7 +272,7 @@ function startServerInNewWindow(port, terminal, reactNativePath) {
   ::
   :: This source code is licensed under the MIT license found in the
   :: LICENSE file in the root directory of this source tree.
-  
+
   @echo off
   title Metro Bundler
   call .packager.bat
@@ -389,6 +402,12 @@ export default {
       name: '--tasks [list]',
       description: 'Run custom Gradle tasks. By default it\'s "installDebug"',
       parse: (val: string) => val.split(','),
+    },
+    {
+      name: '--no-jetifier',
+      description:
+        'Do not run "jetifier" – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that doesn\'t support AndroiX yet. See more at: https://www.npmjs.com/package/jetifier.',
+      default: false,
     },
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5578,6 +5578,11 @@ jest@^24.6.0:
     import-local "^2.0.0"
     jest-cli "^24.7.1"
 
+jetifier@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-1.6.2.tgz#c1d8b7cc2af1d3a255963dbdaed3d56157e94712"
+  integrity sha512-KQKWmj7CNGcOztXwkWoZHoGHJqHBM2hI7YXRHv0tdSz5Gw063CU6z6o8sXaD1+ctTfYQOk+I87NPvPnX/3B3Kw==
+
 js-levenshtein@^1.1.3:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.4.tgz#3a56e3cbf589ca0081eb22cd9ba0b1290a16d26e"


### PR DESCRIPTION
Summary:
---------

Telling people to run `jetifier` seems to be less effective than just running it.

People can opt-out using `--no-jetifier` flag if needed.

cc @satya164 @mikehardy 	

Test Plan:
----------

![image](https://user-images.githubusercontent.com/5106466/61139999-decf7e00-a4ca-11e9-9595-ba04d8b7a835.png)
