### PR TITLE
fix: make "install CocoaPods" step in `init` true by default

### DIFF
--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -45,6 +45,7 @@ async function installPods({
           )} ${chalk.reset.bold(
             "is not installed. It's necessary for iOS project to run correctly. Do you want to install it?",
           )}`,
+          default: true
         },
       ]);
 

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -45,7 +45,7 @@ async function installPods({
           )} ${chalk.reset.bold(
             "is not installed. It's necessary for iOS project to run correctly. Do you want to install it?",
           )}`,
-          default: true
+          default: true,
         },
       ]);
 


### PR DESCRIPTION
fix minor bug where shouldInstallCocoaPods is falsy by default

Summary:
---------

when i run this cli for the first time with no cocoapods, the prompt asks me to install with a "Y/n" but when i hit enter it is taken as falsy and so it shows "No". but then it goes on to install anyway. seems like a weird quirk with `inquirer`

![image](https://user-images.githubusercontent.com/6764957/61160557-d75da400-a4cd-11e9-8907-1213955c8718.png)


Test Plan:
----------

![image](https://user-images.githubusercontent.com/6764957/61160572-e5132980-a4cd-11e9-8bff-3980a1513082.png)
