### PR TITLE
feat: support `.prettierrc.js` dotfile in legacy `init` templates

### DIFF
--- a/packages/cli/src/commands/init/editTemplate.js
+++ b/packages/cli/src/commands/init/editTemplate.js
@@ -48,6 +48,7 @@ const UNDERSCORED_DOTFILES = [
   'flowconfig',
   'gitattributes',
   'gitignore',
+  'prettierrc.js',
   'watchmanconfig',
 ];
 


### PR DESCRIPTION
Summary:
---------

In https://github.com/facebook/react-native/commit/65eea9d1f82215f7dd10241a3cc1045b6ac3918a, the prettier config for ESLint has been extracted to a .prettierrc file.

It was however not added to the React Native `template` folder and this was causing linting issues in newly generated RN apps.

In that [PR](https://github.com/facebook/react-native/pull/25478) to `react-native`, a `_prettierrc.js` file was added to the `template` folder, however, a newly generated project would have the file still underscored (see https://github.com/facebook/react-native/pull/25478#issuecomment-511452946)

This commit addresses that issue by adding `prettierrc.js` to the list of underscored files that need to be renamed to dotfiles.



<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

Inside freshly cloned `react-native`:

#### Results of `./cli.js init --template=file:///path/to/react-native TestProject`

BEFORE patching `node_modules/@react-native-community/cli/build/commands/init/editTemplate.js`
![Screenshot 2019-07-15 at 17 35 44](https://user-images.githubusercontent.com/22741774/61228660-028f0000-a727-11e9-8efa-50a48a465ea9.png)



AFTER patching  `node_modules/@react-native-community/cli/build/commands/init/editTemplate.js` by adding `'prettierrc.js'` to the list `UNDERSCORED_DOTFILES`

![Screenshot 2019-07-15 at 17 33 57](https://user-images.githubusercontent.com/22741774/61228570-ce1b4400-a726-11e9-896f-c210ee74d467.png)


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
