### PR TITLE
fix: run jetifier as executable to avoid race conditions

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -66,9 +66,12 @@ function runAndroid(argv: Array<string>, config: ConfigT, args: FlagsT) {
         'You can disable it using "--no-jetifier" flag.',
       )}`,
     );
-    // Jetifier is a side-effectful module without a default export. Requiring
-    // it ad-hoc.
-    require('jetifier');
+
+    try {
+      execFileSync(require.resolve('jetifier/bin/jetify'), {stdio: 'inherit'});
+    } catch (error) {
+      throw new CLIError('Failed to run jetifier.', error);
+    }
   }
 
   if (!args.packager) {


### PR DESCRIPTION
Summary:
---------

Jetifier spawns workers to parallelize computations. By requiring it, the parent process is not waiting for children to finish. We can change that using `child_process` API and run `jetifier` directly as a binary.

Fixes #534 	


Test Plan:
----------

cc @Titozzz 
