### PR TITLE
Init duplication

### DIFF
--- a/packages/cli/src/commands/init/__tests__/validate.test.js
+++ b/packages/cli/src/commands/init/__tests__/validate.test.js
@@ -23,6 +23,10 @@ test.each([
     name: 'react',
     error: ReservedNameError,
   },
+  {
+    name: 'helloworld',
+    error: ReservedNameError,
+  },
 ])("'%s' is invalid name", ({name, error}: {name: string, error: Error}) => {
   expect(() => validateProjectName(name)).toThrowError(error);
 });

--- a/packages/cli/src/commands/init/__tests__/validate.test.js
+++ b/packages/cli/src/commands/init/__tests__/validate.test.js
@@ -2,6 +2,7 @@
 import {validateProjectName} from '../validate';
 import InvalidNameError from '../errors/InvalidNameError';
 import ReservedNameError from '../errors/ReservedNameError';
+import HelloWorldError from '../errors/HelloWorldError';
 
 test.each(['projectName', 'ProjectName', 'project_name'])(
   "'%s' project name should be valid",
@@ -24,8 +25,8 @@ test.each([
     error: ReservedNameError,
   },
   {
-    name: 'helloworld',
-    error: ReservedNameError,
+    name: 'helloworld_test',
+    error: HelloWorldError,
   },
 ])("'%s' is invalid name", ({name, error}: {name: string, error: Error}) => {
   expect(() => validateProjectName(name)).toThrowError(error);

--- a/packages/cli/src/commands/init/errors/HelloWorldError.js
+++ b/packages/cli/src/commands/init/errors/HelloWorldError.js
@@ -1,0 +1,8 @@
+// @flow
+export default class HelloWorldError extends Error {
+  constructor() {
+    super(
+      'Project name shouldn\'t contain "HelloWorld" name in it, because it is CLI\'s default placeholder name. You can find more information https://github.com/react-native-community/cli/issues/441',
+    );
+  }
+}

--- a/packages/cli/src/commands/init/errors/ReservedNameError.js
+++ b/packages/cli/src/commands/init/errors/ReservedNameError.js
@@ -2,7 +2,7 @@
 export default class ReservedNameError extends Error {
   constructor() {
     super(
-      'Not a valid name for a project. Please do not use the reserved word "React".',
+      'Not a valid name for a project. Please do not use the reserved words "React" or "HelloWorld".',
     );
   }
 }

--- a/packages/cli/src/commands/init/errors/ReservedNameError.js
+++ b/packages/cli/src/commands/init/errors/ReservedNameError.js
@@ -2,7 +2,7 @@
 export default class ReservedNameError extends Error {
   constructor() {
     super(
-      'Not a valid name for a project. Please do not use the reserved words "React" or "HelloWorld".',
+      'Not a valid name for a project. Please do not use the reserved words "React".',
     );
   }
 }

--- a/packages/cli/src/commands/init/validate.js
+++ b/packages/cli/src/commands/init/validate.js
@@ -9,7 +9,7 @@ export function validateProjectName(name: string) {
     throw new InvalidNameError(name);
   }
 
-  if (name === 'React' || name === 'react') {
+  if (name.match(/helloworld|react/gi)) {
     throw new ReservedNameError();
   }
 }

--- a/packages/cli/src/commands/init/validate.js
+++ b/packages/cli/src/commands/init/validate.js
@@ -1,6 +1,7 @@
 // @flow
 import InvalidNameError from './errors/InvalidNameError';
 import ReservedNameError from './errors/ReservedNameError';
+import HelloWorldError from './errors/HelloWorldError';
 
 const NAME_REGEX = /^[$A-Z_][0-9A-Z_$]*$/i;
 
@@ -9,7 +10,11 @@ export function validateProjectName(name: string) {
     throw new InvalidNameError(name);
   }
 
-  if (name.match(/helloworld|react/gi)) {
+  if (name === 'React' || name === 'react') {
     throw new ReservedNameError();
+  }
+
+  if (name.match(/helloworld/gi)) {
+    throw new HelloWorldError();
   }
 }


### PR DESCRIPTION
Summary:
---------

Fixes #441 

This is a fix for weird duplication when initializing with the project with `helloworld` name in it. This fix is only for the `new init` because the `old init` logic for name verification exists in `global-cli` package which is no longer maintained.

Test Plan:
----------

Added UT and tested it in real life initialization.

