### PR TITLE
fix: remove reliance on `node_modules` in paths to podspecs

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -56,11 +56,9 @@ def use_native_modules!(root = "..", config = nil)
       existing_dep.name.split('/').first == spec.name
     end
 
-    # Use relative path
-    folder = File.dirname(podspec_path)
-    path = folder.split(project_root).last
+    relative_path = File.dirname(podspec_path).split(project_root).last || ""
 
-    pod spec.name, :path => File.join(root, path)
+    pod spec.name, :path => File.join(root, relative_path)
 
     if package_config["scriptPhases"]
       # Can be either an object, or an array of objects

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -58,7 +58,7 @@ def use_native_modules!(root = "..", config = nil)
 
     # Use relative path
     folder = File.dirname(podspec_path)
-    path = folder.partition(project_root).last()
+    path = folder.split(project_root).last
 
     pod spec.name, :path => File.join(root, path)
 

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -19,6 +19,7 @@ def use_native_modules!(root = "..", packages = nil)
     end
     config = JSON.parse(json.join("\n"))
     packages = config["dependencies"]
+    project_root = config["root"]
   end
 
   found_pods = []
@@ -55,10 +56,10 @@ def use_native_modules!(root = "..", packages = nil)
     end
 
     # Use relative path
-    absolute_podspec_path = File.dirname(podspec_path)
-    relative_podspec_path = File.join(root, absolute_podspec_path.partition('node_modules').last(2).join())
+    folder = package_config["folder"]
+    path = folder.partition(project_root).last()
 
-    pod spec.name, :path => relative_podspec_path
+    pod spec.name, :path => File.join(root, path)
 
     if package_config["scriptPhases"]
       # Can be either an object, or an array of objects

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -56,7 +56,7 @@ def use_native_modules!(root = "..", packages = nil)
     end
 
     # Use relative path
-    folder = package_config["folder"]
+    folder = File.dirname(podspec_path)
     path = folder.partition(project_root).last()
 
     pod spec.name, :path => File.join(root, path)


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Previous implementation assumed `node_modules` being somewhere in the
path to podspec file and relied on it to create relative path, which
broke monorepos (since `config` lists real filepaths instead of, as
I assumed previously, symlinks). New implementation subtracts project
root path from absolute path to podspec file for the purpose of generating
relative path.

Resolves #537


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Tested changes manually to verify correct paths in `Podfile.lock`, adjusted existing tests
