### PR TITLE
feat: print web diff url when retrieving the latest release

### DIFF
--- a/packages/cli/src/tools/releaseChecker/getLatestRelease.js
+++ b/packages/cli/src/tools/releaseChecker/getLatestRelease.js
@@ -9,6 +9,7 @@ import {fetch} from '@react-native-community/cli-tools';
 export type Release = {
   version: string,
   changelogUrl: string,
+  diffUrl: string,
 };
 
 /**
@@ -52,6 +53,7 @@ export default async function getLatestRelease(
       return {
         version: latestVersion,
         changelogUrl: buildChangelogUrl(latestVersion),
+        diffUrl: buildDiffUrl(currentVersion),
       };
     }
   } catch (e) {
@@ -64,6 +66,10 @@ export default async function getLatestRelease(
 
 function buildChangelogUrl(version: string) {
   return `https://github.com/facebook/react-native/releases/tag/v${version}`;
+}
+
+function buildDiffUrl(version: string) {
+  return `https://react-native-community.github.io/upgrade-helper/?from=${version}`;
 }
 
 /**

--- a/packages/cli/src/tools/releaseChecker/printNewRelease.js
+++ b/packages/cli/src/tools/releaseChecker/printNewRelease.js
@@ -20,6 +20,7 @@ export default function printNewRelease(
     } is now available (your project is running on v${currentVersion}).`,
   );
   logger.info(`Changelog: ${chalk.dim.underline(latestRelease.changelogUrl)}.`);
+  logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}.`);
   logger.info(`To upgrade, run "${chalk.bold('react-native upgrade')}".`);
 
   cacheManager.set(name, 'lastChecked', new Date().toISOString());


### PR DESCRIPTION
Summary:
---------

It would be useful to see the diff changes before committing to an upgrade.  This adds the diff url to the weekly latest version check.  It will always show the diff from the current version to whatever the latest version is.

Some discussions here: https://github.com/react-native-community/cli/issues/189

Test Plan:
----------

Use cli commands on a project that uses an old version of React-Native and you'll see the diff url.

