### PR TITLE
fix: Package class name regex tweaks on Android

### DIFF
--- a/packages/platform-android/src/config/__fixtures__/android.js
+++ b/packages/platform-android/src/config/__fixtures__/android.js
@@ -91,3 +91,145 @@ exports.noPackage = {
     },
   },
 };
+
+exports.findPackagesClassNameKotlinValid = [
+  `
+  class SomeExampleKotlinPackage() : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage : ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage:ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage
+    :
+  ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage() : SomeDelegate, OtherDelegate, ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage(val name: String) : SomeDelegate, OtherDelegate, ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage : SomeSuper(), ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+];
+
+exports.findPackagesClassNameKotlinNotValid = [
+  `
+  class SomeExampleKotlinPackage() {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+  `
+  class SomeExampleKotlinPackage {
+    val package: ReactPackage = ReactPackage()
+  }`,
+  `
+  class ReactPackage {
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
+        return Collections.emptyList()
+    }
+    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
+       return Collections.emptyList()
+    }
+  }`,
+];
+
+exports.findPackagesClassNameJavaValid = [
+  `
+  class SomeExampleKotlinPackage implements ReactPackage {
+    
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage implements SomePackage, ReactPackage {
+    
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage extends SomeSuper implements SomePackage, ReactPackage {
+    
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage
+    implements
+    SomePackage,
+    ReactPackage {
+    
+  }
+  `,
+];
+
+exports.findPackagesClassNameJavaNotValid = [
+  `
+  class SomeExampleKotlinPackage implements SomePackage {
+    
+  }
+  `,
+  `
+  class ReactPackage {
+    
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage extends ReactPackage {
+    
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage {
+    
+  }
+  `,
+];

--- a/packages/platform-android/src/config/__tests__/findPackageClassName-test.js
+++ b/packages/platform-android/src/config/__tests__/findPackageClassName-test.js
@@ -9,7 +9,7 @@
  */
 
 import mocks from '../__fixtures__/android';
-import findPackageClassName from '../findPackageClassName';
+import findPackageClassName, {matchClassName} from '../findPackageClassName';
 
 jest.mock('path');
 jest.mock('fs');
@@ -52,6 +52,32 @@ const fs = require('fs');
 
     it('returns `null` if there are no matches', () => {
       expect(findPackageClassName(`${root}empty`)).toBeNull();
+    });
+  });
+});
+
+describe('android:FindPackageClassNameRegex', () => {
+  it('returns the name of the kotlin class implementing ReactPackage', () => {
+    mocks.findPackagesClassNameKotlinValid.forEach(file => {
+      expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
+    });
+  });
+
+  it('returns `null` if there are no matches for kotlin classes', () => {
+    mocks.findPackagesClassNameKotlinNotValid.forEach(file => {
+      expect(matchClassName(file)).toBeNull();
+    });
+  });
+
+  it('returns the name of the java class implementing ReactPackage', () => {
+    mocks.findPackagesClassNameJavaValid.forEach(file => {
+      expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
+    });
+  });
+
+  it('returns `null` if there are no matches for java classes', () => {
+    mocks.findPackagesClassNameJavaNotValid.forEach(file => {
+      expect(matchClassName(file)).toBeNull();
     });
   });
 });

--- a/packages/platform-android/src/config/__tests__/findPackageClassName-test.js
+++ b/packages/platform-android/src/config/__tests__/findPackageClassName-test.js
@@ -57,27 +57,25 @@ const fs = require('fs');
 });
 
 describe('android:FindPackageClassNameRegex', () => {
-  it('returns the name of the kotlin class implementing ReactPackage', () => {
-    mocks.findPackagesClassNameKotlinValid.forEach(file => {
-      expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
+  [
+    mocks.findPackagesClassNameKotlinValid,
+    mocks.findPackagesClassNameJavaValid,
+  ].forEach(files => {
+    it('returns the name of the kotlin/java class implementing ReactPackage', () => {
+      files.forEach(file => {
+        expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
+      });
     });
   });
 
-  it('returns `null` if there are no matches for kotlin classes', () => {
-    mocks.findPackagesClassNameKotlinNotValid.forEach(file => {
-      expect(matchClassName(file)).toBeNull();
-    });
-  });
-
-  it('returns the name of the java class implementing ReactPackage', () => {
-    mocks.findPackagesClassNameJavaValid.forEach(file => {
-      expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
-    });
-  });
-
-  it('returns `null` if there are no matches for java classes', () => {
-    mocks.findPackagesClassNameJavaNotValid.forEach(file => {
-      expect(matchClassName(file)).toBeNull();
+  [
+    mocks.findPackagesClassNameKotlinNotValid,
+    mocks.findPackagesClassNameJavaNotValid,
+  ].forEach(files => {
+    it('returns `null` if there are no matches for kotlin/java classes', () => {
+      files.forEach(file => {
+        expect(matchClassName(file)).toBeNull();
+      });
     });
   });
 });

--- a/packages/platform-android/src/config/findPackageClassName.js
+++ b/packages/platform-android/src/config/findPackageClassName.js
@@ -22,12 +22,19 @@ export default function getPackageClassName(folder) {
 
   const packages = files
     .map(filePath => fs.readFileSync(path.join(folder, filePath), 'utf8'))
-    .map(file =>
-      file.match(
-        /class\s+(.+[^\s])(\s+implements\s+|\s*:)[\s,\w]*[^{]*ReactPackage/,
-      ),
-    )
+    .map(matchClassName)
     .filter(match => match);
 
   return packages.length ? packages[0][1] : null;
+}
+
+/**
+ * Match function that is looking for package's class name in file
+ *
+ * @param {String} file Content of file to match
+ */
+export function matchClassName(file) {
+  return file.match(
+    /class\s+(\w+[^(\s]*)[\s\w():]*(\s+implements\s+|:)[\s\w():,]*[^{]*ReactPackage/,
+  );
 }


### PR DESCRIPTION
Summary:
---------
Current regex doesn't support code like this:
```kotlin
class SomePackage() : ReactPackage {}
```

but kotlin does ;)

In this PR i added support for this

Test Plan:
----------
Try autolinking for Andorid with package class like this:
```kotlin
class SomePackage() : ReactPackage {

    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule> {
        return Collections.emptyList()
    }

    override fun createViewManagers(reactContext: ReactApplicationContext): MutableList<SimpleViewManager<View>> {
       return Collections.emptyList()
    }
}
```
