### PR TITLE
feat: install pods after upgrade

### DIFF
--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -162,7 +162,7 @@ async function installDependencies({
   });
 
   if (process.platform === 'darwin') {
-    await installPods({projectName, loader});
+    await installPods({projectName, loader, shouldUpdatePods: false});
   }
 
   loader.succeed();

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -296,7 +296,7 @@ test('cleans up if patching fails,', async () => {
     [fs] unlink tmp-upgrade-rn.patch
     $ execa git status -s
     error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
-    warn After resolving conflicts don't forget to change into \\"ios\\" directory and run \\"pod install\\"
+    warn After resolving conflicts don't forget to run \\"pod install\\" inside \\"ios\\" directory
     info You may find these resources helpful:
     • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
     • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -107,6 +107,9 @@ beforeEach(() => {
   fs.unlinkSync = jest.fn((...args) => mockPushLog('[fs] unlink', args));
   logs = [];
   (execa: any).mockImplementation(mockExecaDefault);
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
 });
 
 afterEach(() => {

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -192,24 +192,24 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
     opts,
   );
   expect(flushOutput()).toMatchInlineSnapshot(`
-        "info Fetching diff between v0.57.8 and v0.58.4...
-        [fs] write tmp-upgrade-rn.patch
-        $ execa git rev-parse --show-prefix
-        $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-        info Applying diff...
-        $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-        [fs] unlink tmp-upgrade-rn.patch
-        $ execa git status -s
-        info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-        $ execa npm info react-native@0.58.4 peerDependencies --json
-        $ yarn add react-native@0.58.4 react@16.6.3
-        $ execa git add package.json
-        $ execa git add yarn.lock
-        $ execa git add package-lock.json
-        info Installing CocoaPods dependencies (this may take a few minutes)
-        info Running \\"git status\\" to check what changed...
-        $ execa git status
-        success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    info Applying diff...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+    $ execa npm info react-native@0.58.4 peerDependencies --json
+    $ yarn add react-native@0.58.4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Installing CocoaPods dependencies (this may take a few minutes)
+    info Running \\"git status\\" to check what changed...
+    $ execa git status
+    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
     `);
   expect(
     snapshotDiff(samplePatch, (fs.writeFileSync: any).mock.calls[0][1], {
@@ -225,25 +225,25 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
   const config = {...ctx, root: '/project/root/NestedApp'};
   await upgrade.func([newVersion], config, opts);
   expect(flushOutput()).toMatchInlineSnapshot(`
-        "info Fetching diff between v0.57.8 and v0.58.4...
-        [fs] write tmp-upgrade-rn.patch
-        $ execa git rev-parse --show-prefix
-        $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-        info Applying diff...
-        $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-        [fs] unlink tmp-upgrade-rn.patch
-        $ execa git status -s
-        info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-        $ execa npm info react-native@0.58.4 peerDependencies --json
-        $ yarn add react-native@0.58.4 react@16.6.3
-        $ execa git add package.json
-        $ execa git add yarn.lock
-        $ execa git add package-lock.json
-        info Installing CocoaPods dependencies (this may take a few minutes)
-        info Running \\"git status\\" to check what changed...
-        $ execa git status
-        success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-    `);
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    info Applying diff...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+    $ execa npm info react-native@0.58.4 peerDependencies --json
+    $ yarn add react-native@0.58.4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Installing CocoaPods dependencies (this may take a few minutes)
+    info Running \\"git status\\" to check what changed...
+    $ execa git status
+    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+  `);
 }, 60000);
 test('cleans up if patching fails,', async () => {
   mockFetch(samplePatch, 200);
@@ -274,31 +274,31 @@ test('cleans up if patching fails,', async () => {
     );
   }
   expect(flushOutput()).toMatchInlineSnapshot(`
-        "info Fetching diff between v0.57.8 and v0.58.4...
-        [fs] write tmp-upgrade-rn.patch
-        $ execa git rev-parse --show-prefix
-        $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-        info Applying diff...
-        warn Excluding files that exist in the template, but not in your project:
-          - .flowconfig
-        error Excluding files that failed to apply the diff:
-          - ios/MyApp.xcodeproj/project.pbxproj
-        Please make sure to check the actual changes after the upgrade command is finished.
-        You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
-        $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
-        debug \\"git apply\\" failed. Error output:
-        error: .flowconfig: does not exist in index
-        error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
-        error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
-        [fs] unlink tmp-upgrade-rn.patch
-        $ execa git status -s
-        error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
-        warn After resolving conflicts don't forget to change into \\"ios\\" directory and run \\"pod install\\"
-        info You may find these resources helpful:
-        • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
-        • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
-        • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
-    `);
+    "info Fetching diff between v0.57.8 and v0.58.4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    info Applying diff...
+    warn Excluding files that exist in the template, but not in your project:
+      - .flowconfig
+    error Excluding files that failed to apply the diff:
+      - ios/MyApp.xcodeproj/project.pbxproj
+    Please make sure to check the actual changes after the upgrade command is finished.
+    You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
+    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
+    debug \\"git apply\\" failed. Error output:
+    error: .flowconfig: does not exist in index
+    error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
+    error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
+    warn After resolving conflicts don't forget to change into \\"ios\\" directory and run \\"pod install\\"
+    info You may find these resources helpful:
+    • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
+    • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
+    • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
+  `);
 }, 60000);
 test('works with --name-ios and --name-android', async () => {
   mockFetch(samplePatch, 200);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.js
@@ -174,6 +174,7 @@ test('fetches empty patch and installs deps', async () => {
     $ execa git add package.json
     $ execa git add yarn.lock
     $ execa git add package-lock.json
+    info Installing CocoaPods dependencies (this may take a few minutes)
     success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
   `);
 }, 60000);
@@ -191,24 +192,25 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
     opts,
   );
   expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    info Applying diff...
-    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-    $ execa npm info react-native@0.58.4 peerDependencies --json
-    $ yarn add react-native@0.58.4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Running \\"git status\\" to check what changed...
-    $ execa git status
-    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-  `);
+        "info Fetching diff between v0.57.8 and v0.58.4...
+        [fs] write tmp-upgrade-rn.patch
+        $ execa git rev-parse --show-prefix
+        $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+        info Applying diff...
+        $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+        [fs] unlink tmp-upgrade-rn.patch
+        $ execa git status -s
+        info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+        $ execa npm info react-native@0.58.4 peerDependencies --json
+        $ yarn add react-native@0.58.4 react@16.6.3
+        $ execa git add package.json
+        $ execa git add yarn.lock
+        $ execa git add package-lock.json
+        info Installing CocoaPods dependencies (this may take a few minutes)
+        info Running \\"git status\\" to check what changed...
+        $ execa git status
+        success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+    `);
   expect(
     snapshotDiff(samplePatch, (fs.writeFileSync: any).mock.calls[0][1], {
       contextLines: 1,
@@ -223,24 +225,25 @@ test('fetches regular patch, adds remote, applies patch, installs deps, removes 
   const config = {...ctx, root: '/project/root/NestedApp'};
   await upgrade.func([newVersion], config, opts);
   expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-    info Applying diff...
-    $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-    $ execa npm info react-native@0.58.4 peerDependencies --json
-    $ yarn add react-native@0.58.4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Running \\"git status\\" to check what changed...
-    $ execa git status
-    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-  `);
+        "info Fetching diff between v0.57.8 and v0.58.4...
+        [fs] write tmp-upgrade-rn.patch
+        $ execa git rev-parse --show-prefix
+        $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+        info Applying diff...
+        $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+        [fs] unlink tmp-upgrade-rn.patch
+        $ execa git status -s
+        info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+        $ execa npm info react-native@0.58.4 peerDependencies --json
+        $ yarn add react-native@0.58.4 react@16.6.3
+        $ execa git add package.json
+        $ execa git add yarn.lock
+        $ execa git add package-lock.json
+        info Installing CocoaPods dependencies (this may take a few minutes)
+        info Running \\"git status\\" to check what changed...
+        $ execa git status
+        success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+    `);
 }, 60000);
 test('cleans up if patching fails,', async () => {
   mockFetch(samplePatch, 200);
@@ -271,30 +274,31 @@ test('cleans up if patching fails,', async () => {
     );
   }
   expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    info Applying diff...
-    warn Excluding files that exist in the template, but not in your project:
-      - .flowconfig
-    error Excluding files that failed to apply the diff:
-      - ios/MyApp.xcodeproj/project.pbxproj
-    Please make sure to check the actual changes after the upgrade command is finished.
-    You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
-    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
-    debug \\"git apply\\" failed. Error output:
-    error: .flowconfig: does not exist in index
-    error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
-    error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
-    info You may find these resources helpful:
-    • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
-    • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
-    • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
-  `);
+        "info Fetching diff between v0.57.8 and v0.58.4...
+        [fs] write tmp-upgrade-rn.patch
+        $ execa git rev-parse --show-prefix
+        $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+        info Applying diff...
+        warn Excluding files that exist in the template, but not in your project:
+          - .flowconfig
+        error Excluding files that failed to apply the diff:
+          - ios/MyApp.xcodeproj/project.pbxproj
+        Please make sure to check the actual changes after the upgrade command is finished.
+        You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
+        $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
+        debug \\"git apply\\" failed. Error output:
+        error: .flowconfig: does not exist in index
+        error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
+        error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
+        [fs] unlink tmp-upgrade-rn.patch
+        $ execa git status -s
+        error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
+        warn After resolving conflicts don't forget to change into \\"ios\\" directory and run \\"pod install\\"
+        info You may find these resources helpful:
+        • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
+        • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
+        • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
+    `);
 }, 60000);
 test('works with --name-ios and --name-android', async () => {
   mockFetch(samplePatch, 200);

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -166,15 +166,28 @@ const installDeps = async (newVersion, projectDir) => {
 
 const installCocoaPodsDeps = async (projectDir, thirdPartyIOSDeps) => {
   if (process.platform === 'darwin') {
-    logger.info(
-      `Installing CocoaPods dependencies ${chalk.dim(
-        '(this may take a few minutes)',
-      )}`,
-    );
-    await installPods({
-      projectName: projectDir.split('/').pop(),
-      shouldUpdatePods: thirdPartyIOSDeps.length > 0,
-    });
+    try {
+      logger.info(
+        `Installing CocoaPods dependencies ${chalk.dim(
+          '(this may take a few minutes)',
+        )}`,
+      );
+      await installPods({
+        projectName: projectDir.split('/').pop(),
+        shouldUpdatePods: thirdPartyIOSDeps.length > 0,
+      });
+    } catch (error) {
+      if (error.stderr) {
+        logger.debug(
+          `"pod install" or "pod repo update" failed. Error output:\n${
+            error.stderr
+          }`,
+        );
+      }
+      logger.error(
+        'Installation of CocoaPods dependencies failed. Try to install them manually by running "pod install" in "ios" directory after finishing upgrade',
+      );
+    }
   }
 };
 

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -365,7 +365,7 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
       }
       if (process.platform === 'darwin') {
         logger.warn(
-          'After resolving conflicts don\'t forget to change into "ios" directory and run "pod install"',
+          'After resolving conflicts don\'t forget to run "pod install" inside "ios" directory',
         );
       }
       logger.info(`You may find these resources helpful:

--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -7,6 +7,7 @@ import execa from 'execa';
 import type {ConfigT} from 'types';
 import {logger, CLIError, fetch} from '@react-native-community/cli-tools';
 import * as PackageManager from '../../tools/packageManager';
+import installPods from '../../tools/installPods';
 import legacyUpgrade from './legacyUpgrade';
 
 type FlagsT = {
@@ -163,6 +164,20 @@ const installDeps = async (newVersion, projectDir) => {
   }
 };
 
+const installCocoaPodsDeps = async (projectDir, thirdPartyIOSDeps) => {
+  if (process.platform === 'darwin') {
+    logger.info(
+      `Installing CocoaPods dependencies ${chalk.dim(
+        '(this may take a few minutes)',
+      )}`,
+    );
+    await installPods({
+      projectName: projectDir.split('/').pop(),
+      shouldUpdatePods: thirdPartyIOSDeps.length > 0,
+    });
+  }
+};
+
 const applyPatch = async (
   currentVersion: string,
   newVersion: string,
@@ -265,6 +280,10 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
     projectDir,
     'node_modules/react-native/package.json',
   ));
+  const thirdPartyIOSDeps = Object.values(ctx.dependencies).filter(
+    // $FlowFixMe
+    dependency => dependency.platforms.ios,
+  );
 
   const newVersion = await getVersionToUpgradeTo(
     argv,
@@ -285,6 +304,8 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
   if (patch === '') {
     logger.info('Diff has no changes to apply, proceeding further');
     await installDeps(newVersion, projectDir);
+    await installCocoaPodsDeps(projectDir, thirdPartyIOSDeps);
+
     logger.success(
       `Upgraded React Native to v${newVersion} 🎉. Now you can review and commit the changes`,
     );
@@ -319,6 +340,7 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
       }
     } else {
       await installDeps(newVersion, projectDir);
+      await installCocoaPodsDeps(projectDir, thirdPartyIOSDeps);
       logger.info('Running "git status" to check what changed...');
       await execa('git', ['status'], {stdio: 'inherit'});
     }
@@ -326,6 +348,11 @@ async function upgrade(argv: Array<string>, ctx: ConfigT, args: FlagsT) {
       if (stdout) {
         logger.warn(
           'Please run "git diff" to review the conflicts and resolve them',
+        );
+      }
+      if (process.platform === 'darwin') {
+        logger.warn(
+          'After resolving conflicts don\'t forget to change into "ios" directory and run "pod install"',
         );
       }
       logger.info(`You may find these resources helpful:


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Added calls to `installPods` in `upgrade` command to automatically
update pods after applying patch and installing JS dependencies.
Changed `installPods` helper to also accept argument determining whether
`pod repo update` should be ran before `install` and refactored it
slightly.
Added warnings when patch was not successfully applied to remind users
about running `pod install`.

Resolves #212

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Tested changes manually by initialising new project on 0.60.2 and upgrading to 0.60.3 (happy path) and 0.60.4 (applying diff fails), updated snapshots with warning about manually updating pods if upgrade fails.
