### PR TITLE
fix: preserve project folder after init failure

### DIFF
--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -213,7 +213,6 @@ export default (async function initialize(
     projectName,
     directory: options.directory || projectName,
   });
-  const directoryExists = doesDirectoryExist(directoryName);
 
   try {
     await createProject(projectName, directoryName, version, options);

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -222,9 +222,6 @@ export default (async function initialize(
     printRunInstructions(projectFolder, projectName);
   } catch (e) {
     logger.error(e.message);
-    // Only remove project if it didn't exist before running `init`
-    if (!directoryExists) {
-      fs.removeSync(path.resolve(rootFolder, directoryName));
-    }
+    // Do not remove project, to allow for manual troubleshooting.
   }
 });

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -222,6 +222,5 @@ export default (async function initialize(
     printRunInstructions(projectFolder, projectName);
   } catch (e) {
     logger.error(e.message);
-    // Do not remove project, to allow for manual troubleshooting.
   }
 });


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Fixes issues regarding [this comment](https://github.com/react-native-community/cli/issues/448#issuecomment-512796812) on [#448](https://github.com/react-native-community/cli).

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Create a new project with the `init` command. It should no longer delete the project folder if the project creation process fails.