### PR TITLE
Fix getVersionToUpgradeTo

### DIFF
--- a/packages/cli/src/commands/upgrade/upgrade.js
+++ b/packages/cli/src/commands/upgrade/upgrade.js
@@ -77,7 +77,7 @@ const getVersionToUpgradeTo = async (argv, currentVersion, projectDir) => {
     return null;
   }
 
-  if (semver.gt(currentVersion, newVersion)) {
+  if (semver.gt(newVersion, currentVersion)) {
     logger.error(
       `Trying to upgrade from newer version "${currentVersion}" to older "${newVersion}"`,
     );


### PR DESCRIPTION
Summary:
---------

Semver's `gt` is defined as `gt(v1, v2): v1 > v2`

This PR fixes the order of versions from `currentVersion, newVersion` which will always return `false` to `newVersion, currentVersion`.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
