### PR TITLE
fix: bring `--projectRoot` argument back to `start`

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -48,6 +48,7 @@ async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {
     port: args.port,
     resetCache: args.resetCache,
     watchFolders: args.watchFolders,
+    projectRoot: args.projectRoot,
     sourceExts: args.sourceExts,
     reporter,
   });

--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -35,6 +35,7 @@ export type Args = {|
   verbose?: boolean,
   watchFolders?: string[],
   config?: string,
+  projectRoot?: string,
 |};
 
 async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {

--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -71,6 +71,7 @@ export const getDefaultConfig = (ctx: ConfigT) => {
 export type ConfigOptionsT = {|
   maxWorkers?: number,
   port?: number,
+  projectRoot?: string,
   resetCache?: boolean,
   watchFolders?: string[],
   sourceExts?: string[],


### PR DESCRIPTION
Summary:
---------
#496 by @thymikee fixed projectRoot from metro config got overriden by ctx.root. I think the real error was taking the root from ctx instead of args. previously, an option '--projectRoot' was enabled. the projectRoot from args should override the metro config, if it exists, like the other options of the cli. this PR makes the `--projectRoot` option work again. and, if not specified will use the config option.

Notify:
----------
this should also help with storybook that previously used the `--projectRoot` option to start metro from the storybook root folder, instead of including it in your app (which is very non optimal and the recommendation as of now ). @shilman, @Gongreg is that right?

Test Plan:
----------

create a react native project. set a projectRoot option in the metro config to a new file called a.js, check that it work. try using the cli with --projectRoot option set to a new file called b.js, it should override the metro config and load from b.js. 