### PR TITLE
Add ability to reload all connected devices and simulators

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -98,6 +98,11 @@ async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {
   middlewareManager.attachDevToolsSocket(wsProxy);
   middlewareManager.attachDevToolsSocket(ms);
 
+  middlewareManager.getConnectInstance().use('/reload', (req, res) => {
+    ms.broadcast('reload', null);
+    res.end('OK');
+  });
+
   // In Node 8, the default keep-alive for an HTTP connection is 5 seconds. In
   // early versions of Node 8, this was implemented in a buggy way which caused
   // some HTTP responses (like those containing large JS bundles) to be


### PR DESCRIPTION
Summary:
---------

At Facebook we have a hotkey hooked up to the ability to reload all connected devices and simulators. This is incredibly useful! However, we make this work by deploying an app to everyone's laptop that listens for a global hotkey to tell metro to reload. Since it isn't feasible to do that in open source, this seems like a reasonable approach. 

This PR adds the ability to hit the server host /reload, for example: `http://localhost:8081/reload` and metro will send a command to reload all connected apps.

Personally, I plan on wiring up a hotkey with better touch tool to curl this endpoint. I imagine people can set up alfred workflows or wire it into other apps too.


Test Plan:
----------

![reloadall](https://user-images.githubusercontent.com/249164/61670672-58b8f180-ac99-11e9-93f2-98a35ad87f64.gif)
