### PR TITLE
feat: print `config` condensed by default, add `--format` flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,6 +110,14 @@ react-native config
 
 Output project and dependencies configuration in JSON format to stdout. Used by [autolinking](./autolinking.md).
 
+#### Options
+
+#### `--format [boolean]`
+
+> default: false
+
+Display config JSON formatted nicely.
+
 ### `init`
 
 > Available since 0.60.0

--- a/packages/cli/src/commands/config/config.js
+++ b/packages/cli/src/commands/config/config.js
@@ -23,10 +23,22 @@ function filterConfig(config) {
   return filtered;
 }
 
+type Args = {|
+  format: boolean,
+|};
+
 export default {
   name: 'config',
   description: 'Print CLI configuration',
-  func: async (argv: string[], ctx: ConfigT) => {
-    console.log(JSON.stringify(filterConfig(ctx), null, 2));
+  func: async (argv: string[], ctx: ConfigT, args: Args) => {
+    const indent = args.format ? 2 : 0;
+    console.log(JSON.stringify(filterConfig(ctx), null, indent));
   },
+  options: [
+    {
+      name: '--format [boolean]',
+      description: 'Display config JSON formatted nicely',
+      default: false,
+    },
+  ],
 };


### PR DESCRIPTION
Summary:
---------

An attempt to partially fix #576 and make the config command a bit faster by outputting less to stdout by default.

Adds `--format` flag to `config`.


Test Plan:
----------

cc @theweavrs can you make sure it doesn't break Windows?
