### PR TITLE
Adding --projectRoot option descriptor to 'start'

### DIFF
--- a/packages/cli/src/commands/server/server.js
+++ b/packages/cli/src/commands/server/server.js
@@ -25,6 +25,10 @@ export default {
       default: '',
     },
     {
+      name: '--projectRoot [path]',
+      description: 'Path to a custom project root',
+    },
+    {
       name: '--watchFolders [list]',
       description:
         'Specify any additional folders to be added to the watch list',


### PR DESCRIPTION
Summary:
---------

Following my PR from yesterday #572 , I forgot to include the --projectRoot option descriptor in the PR, which makes it non usable or documented in --help. This PR fixes it.