### PR TITLE
feat: backport reload endpoint to 1.x

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -92,6 +92,11 @@ async function runServer(argv: Array<string>, ctx: ContextT, args: Args) {
   middlewareManager.attachDevToolsSocket(wsProxy);
   middlewareManager.attachDevToolsSocket(ms);
 
+  middlewareManager.getConnectInstance().use('/reload', (req, res) => {
+    ms.broadcast('reload', null);
+    res.end('OK');
+  });
+
   // In Node 8, the default keep-alive for an HTTP connection is 5 seconds. In
   // early versions of Node 8, this was implemented in a buggy way which caused
   // some HTTP responses (like those containing large JS bundles) to be


### PR DESCRIPTION
Summary:
---------

Backports https://github.com/react-native-community/cli/pull/574 to 1.x.


Test Plan:
----------

Copy this change manually into a 0.59 project and reload devices by hitting the endpoint.
