### PR TITLE
fix: link project assets when not linking deps

### DIFF
--- a/packages/cli/src/commands/link/linkAll.js
+++ b/packages/cli/src/commands/link/linkAll.js
@@ -43,9 +43,8 @@ function linkAll(
       () => promisify(config.commands.prelink || commandStub),
       () => linkDependency(platforms, project, config),
       () => promisify(config.commands.postlink || commandStub),
-      () => linkAssets(platforms, project, assets),
     ]),
-  );
+  ).concat([() => linkAssets(platforms, project, assets)]);
 
   return promiseWaterfall(tasks).catch(err => {
     logger.error(


### PR DESCRIPTION
Summary:
---------

Fixes #584 by moving the asset linking task outside the dependency linking tasks.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
