### PR TITLE
adding projectRoot to options and resolve it

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -408,6 +408,10 @@ Starts the server that communicates with connected devices
 
 Specify port to listen on
 
+#### `--projectRoot [list]`
+
+Path to a custom project root
+
 #### `--watchFolders [list]`
 
 Specify any additional folders to be added to the watch list

--- a/packages/cli/src/commands/server/server.js
+++ b/packages/cli/src/commands/server/server.js
@@ -25,10 +25,16 @@ export default {
       default: '',
     },
     {
+      name: '--projectRoot [path]',
+      description: 'Path to a custom project root',
+      parse: (val: string) => path.resolve(val),
+    },
+    {
       name: '--watchFolders [list]',
       description:
         'Specify any additional folders to be added to the watch list',
-      parse: (val: string) => val.split(','),
+      parse: (val: string) =>
+        val.split(',').map((folder: string) => path.resolve(folder)),
     },
     {
       name: '--assetPlugins [list]',

--- a/packages/cli/src/commands/server/server.js
+++ b/packages/cli/src/commands/server/server.js
@@ -34,7 +34,7 @@ export default {
       description:
         'Specify any additional folders to be added to the watch list',
       parse: (val: string) =>
-        val.split(',').map((folder: string) => path.resolve(folder)),
+        val.split(',').map<string>((folder: string) => path.resolve(folder)),
     },
     {
       name: '--assetPlugins [list]',


### PR DESCRIPTION
Summary:
---------
Following my PR from yesterday #572 , I forgot to include the --projectRoot option descriptor in the PR, which makes it non usable or documented in --help. This PR fixes it.

i also went ahead and added path.resolve to the parsing of it, and of --watchFolders.

Test Plan:
----------
try using the cli start with custom project root set in metro config, it should load from the custom root. try using the cli start with --projectRoot that point to another directory (you can also check for relative path), it should override the metro config. try using the cli with a --watchFolders with relative paths, the folders you specified should be resolved and merged to those in the metro config.
