### PR TITLE
fix: safe check for `config` command

### DIFF
--- a/packages/cli/src/commands/config/config.js
+++ b/packages/cli/src/commands/config/config.js
@@ -7,9 +7,9 @@ function isValidRNDependency(config) {
   return (
     Object.keys(config.platforms).filter(key => Boolean(config.platforms[key]))
       .length !== 0 ||
-    Object.keys(config.hooks).length !== 0 ||
-    config.assets.length !== 0 ||
-    config.params.length !== 0
+    (config.hooks && Object.keys(config.hooks).length !== 0) ||
+    (config.assets && config.assets.length !== 0) ||
+    (config.params && config.params.length !== 0)
   );
 }
 


### PR DESCRIPTION
Summary:
---------

Fixes issues building for android when `react-native.config.js` has packages with `platforms` filter

Test Plan:
----------

With the latest version of `cli` create/modify the `react-native.config.js` with a package and any platform as such:
```js
module.exports = {
  dependencies: {
    'interactable': {
      platforms: {
        ios: null, 
      },
    },
    'appcenter': {
      platforms: {
        android: null,
      },
    },
  }
}
```
The cli will build without throwing the error `TypeError: Cannot convert undefined or null to object at Function.keys () at isValidRNDependency`
