### PR TITLE
feat: set a default `symbolicator.customizeFrame` value

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.js
+++ b/packages/cli/src/tools/loadMetroConfig.js
@@ -25,6 +25,13 @@ const getWatchFolders = () => {
 
 const getBlacklistRE = () => createBlacklist([/.*\/__fixtures__\/.*/]);
 
+const INTERNAL_CALLSITES_REGEX = new RegExp(
+  [
+    '/Libraries/Renderer/implementations/.+\\.js$',
+    '/Libraries/BatchedBridge/MessageQueue\\.js$',
+  ].join('|'),
+);
+
 /**
  * Default configuration
  *
@@ -54,6 +61,14 @@ export const getDefaultConfig = (ctx: ConfigT) => {
     },
     server: {
       port: Number(process.env.RCT_METRO_PORT) || 8081,
+    },
+    symbolicator: {
+      customizeFrame: (frame: {+file: ?string}) => {
+        const collapse = Boolean(
+          frame.file && INTERNAL_CALLSITES_REGEX.test(frame.file),
+        );
+        return {collapse};
+      },
     },
     transformer: {
       babelTransformerPath: require.resolve(


### PR DESCRIPTION
Summary:
---------

Sets a default `symbolicator.customizeFrame` value. This configuration option was added to Metro in https://github.com/facebook/metro/pull/435.

This is part of a redesign of https://github.com/facebook/react-native/pull/24662.

Test Plan:
----------

Equivalent config change tested as part of https://github.com/facebook/react-native/pull/25839.