### PR TITLE
fix: fallback to default terminal if wrong one passed

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.js
+++ b/packages/platform-android/src/commands/runAndroid/index.js
@@ -339,21 +339,20 @@ function startServerInNewWindow(port, terminal, reactNativePath) {
       });
     } catch (error) {
       // By default, the child shell process will be attached to the parent
-      return execa.sync('sh', [launchPackagerScript], {
-        ...procConfig,
-        detached: false,
-      });
+      return execa.sync('sh', [launchPackagerScript], procConfig);
     }
   }
   if (/^win/.test(process.platform)) {
-    procConfig.detached = true;
-    procConfig.stdio = 'ignore';
     //Temporary fix for #484. See comment on line 254
     fs.writeFileSync(launchPackagerScript, launchPackagerScriptContent, {
       encoding: 'utf8',
       flag: 'w',
     });
-    return execa.sync('cmd.exe', ['/C', launchPackagerScript], procConfig);
+    return execa.sync('cmd.exe', ['/C', launchPackagerScript], {
+      ...procConfig,
+      detached: true,
+      stdio: 'ignore',
+    });
   }
   logger.error(
     `Cannot start the packager. Unknown platform ${process.platform}`,


### PR DESCRIPTION
Summary:
---------

It may happen, that the terminal detected by CLI or passed by the user is wrong and not really an executable. A good example is `vscode`, which sets `TERM_PROGRAM` env var to `vscode`, which is neither a command, nor a macOS app name. This PR introduces a fallback behavior for such cases, so that the terminal will be opened by a default `open` program. If that doesn't work, we produce a warning with directions on what to do now:

<img width="925" alt="Screenshot 2019-07-31 at 21 50 31" src="https://user-images.githubusercontent.com/5106466/62243461-9c200800-b3dd-11e9-923a-8da5f2a40dab.png">


Test Plan:
----------

Packager should start in new terminal window, when running `run-android` from `vscode` or any other terminal.
