### PR TITLE
fix: corrects sourcedir to be compatible with kotlin projects

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -229,11 +229,12 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String
 ext.applyNativeModulesAppBuildGradle = { Project project, String root = ".." ->
   autoModules.applyBuildGradle(project, root)
 
-  def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java/com/facebook/react")
+  def generatedSrcDir = "generated/rncli/src/main/java"
+  def generatedCodeDir = new File(buildDir, "$generatedSrcDir/com/facebook/react")
 
   task generatePackageList {
     doLast {
-      autoModules.generatePackagesFile(generatedSrcDir, generatedFileName, generatedFileContentsTemplate)
+      autoModules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
     }
   }
 
@@ -243,7 +244,7 @@ ext.applyNativeModulesAppBuildGradle = { Project project, String root = ".." ->
     sourceSets {
       main {
         java {
-          srcDirs += generatedSrcDir
+          srcDirs += "build/$generatedSrcDir"
         }
       }
     }


### PR DESCRIPTION
Summary:
---------
Projects written in kotlin is not able to resolve `PackageList.java` (see #600)

Resolves #600

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Tested in newly initialised project: 

`react-native init test && cd test && react-native run-android`

Also tested in kotlin project where android fails to build prior to this change
