### PR TITLE
fix: CLI stuck on "Starting JS server" on Windows

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -356,7 +356,7 @@ function startServerInNewWindow(
       encoding: 'utf8',
       flag: 'w',
     });
-    return execa.sync('cmd.exe', ['/C', launchPackagerScript], {
+    return execa('cmd.exe', ['/C', launchPackagerScript], {
       ...procConfig,
       detached: true,
       stdio: 'ignore',

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -356,6 +356,8 @@ function startServerInNewWindow(
       encoding: 'utf8',
       flag: 'w',
     });
+
+    // Awaiting this causes the CLI to hang indefinitely, so this must execute without await.
     return execa('cmd.exe', ['/C', launchPackagerScript], {
       ...procConfig,
       detached: true,


### PR DESCRIPTION
Summary:
---------
This fixes [RN Issue #25904](https://github.com/facebook/react-native/issues/25904) where CLI gets stuck on `Starting JS Server...` in Windows.

This was due to using the `sync` command of `execa` which doesn't allow multiple commands to run side by side. In the issue, if you close the Metro Bundler, the `run-android` command continues.

Test Plan:
----------
Tested on a new RN Project

cc @thymikee 
