### PR TITLE
feat: Add prefers-color-scheme dark mode

### DIFF
--- a/packages/cli/src/commands/server/debugger-ui/index.html
+++ b/packages/cli/src/commands/server/debugger-ui/index.html
@@ -35,7 +35,6 @@
   const Page = window.Page = {
 
     state: {
-      isDark: localStorage.getItem('darkTheme') === 'on',
       isPriorityMaintained: localStorage.getItem('maintainPriority') === 'on',
       status: {type: 'disconnected'},
       visibilityState: document.visibilityState,
@@ -48,7 +47,6 @@
 
     render() {
       const {
-        isDark,
         isPriorityMaintained,
         status,
         visibilityState,
@@ -82,11 +80,6 @@
         }
       }
 
-      const darkCheckbox = document.getElementById('dark');
-      document.body.classList.toggle('dark', isDark);
-      darkCheckbox.checked = isDark;
-      localStorage.setItem('darkTheme', isDark ? 'on' : '');
-
       const maintainPriorityCheckbox = document.getElementById('maintain-priority');
       const silence = document.getElementById('silence');
       silence.volume = 0.1;
@@ -97,10 +90,6 @@
       }
       maintainPriorityCheckbox.checked = isPriorityMaintained;
       localStorage.setItem('maintainPriority', isPriorityMaintained ? 'on' : '');
-    },
-
-    toggleDarkTheme() {
-      Page.setState({isDark: !Page.state.isDark});
     },
 
     togglePriorityMaintenance() {
@@ -253,26 +242,27 @@
   .content {
     padding: 10px;
   }
-  body.dark {
-    background-color: #242424;
-    color: #afafaf;
-  }
-  .dark .shortcut {
-    color: #c1c1c1;
-  }
-  .dark a {
-    color: #3b99fc;
-  }
   input[type=checkbox] {
     vertical-align: middle;
+  }
+  @media (prefers-color-scheme: dark) {
+    body {
+      background-color: #242424;
+      color: #afafaf;
+    }
+
+    .shortcut {
+      color: #c1c1c1;
+    }
+
+    a {
+      color: #3b99fc;
+    }
   }
 </style>
 </head>
 <body>
   <div class="content">
-    <label for="dark">
-      <input type="checkbox" id="dark" onclick="Page.toggleDarkTheme()"> Dark Theme
-    </label>
     <label for="maintain-priority">
       <input type="checkbox" id="maintain-priority" onclick="Page.togglePriorityMaintenance()"> Maintain Priority
     </label>

--- a/packages/cli/src/commands/server/debugger-ui/index.html
+++ b/packages/cli/src/commands/server/debugger-ui/index.html
@@ -35,6 +35,7 @@
   const Page = window.Page = {
 
     state: {
+      isDark: localStorage.getItem('darkTheme') === null ? window.matchMedia("(prefers-color-scheme: dark)").matches : localStorage.getItem('darkTheme') === 'on',
       isPriorityMaintained: localStorage.getItem('maintainPriority') === 'on',
       status: {type: 'disconnected'},
       visibilityState: document.visibilityState,
@@ -47,6 +48,7 @@
 
     render() {
       const {
+        isDark,
         isPriorityMaintained,
         status,
         visibilityState,
@@ -80,6 +82,11 @@
         }
       }
 
+      const darkCheckbox = document.getElementById('dark');
+      document.body.classList.toggle('dark', isDark);
+      darkCheckbox.checked = isDark;
+      localStorage.setItem('darkTheme', isDark ? 'on' : '');
+
       const maintainPriorityCheckbox = document.getElementById('maintain-priority');
       const silence = document.getElementById('silence');
       silence.volume = 0.1;
@@ -90,6 +97,10 @@
       }
       maintainPriorityCheckbox.checked = isPriorityMaintained;
       localStorage.setItem('maintainPriority', isPriorityMaintained ? 'on' : '');
+    },
+
+    toggleDarkTheme() {
+      Page.setState({isDark: !Page.state.isDark});
     },
 
     togglePriorityMaintenance() {
@@ -242,27 +253,26 @@
   .content {
     padding: 10px;
   }
+  body.dark {
+    background-color: #242424;
+    color: #afafaf;
+  }
+  .dark .shortcut {
+    color: #c1c1c1;
+  }
+  .dark a {
+    color: #3b99fc;
+  }
   input[type=checkbox] {
     vertical-align: middle;
-  }
-  @media (prefers-color-scheme: dark) {
-    body {
-      background-color: #242424;
-      color: #afafaf;
-    }
-
-    .shortcut {
-      color: #c1c1c1;
-    }
-
-    a {
-      color: #3b99fc;
-    }
   }
 </style>
 </head>
 <body>
   <div class="content">
+    <label for="dark">
+      <input type="checkbox" id="dark" onclick="Page.toggleDarkTheme()"> Dark Theme
+    </label>
     <label for="maintain-priority">
       <input type="checkbox" id="maintain-priority" onclick="Page.togglePriorityMaintenance()"> Maintain Priority
     </label>


### PR DESCRIPTION
Summary:
---------

Automatically set the appearance based on the global system dark mode, and remove the manual Dark Theme toggle.

Test Plan:
----------

Set macOS Appearance to Light and Dark in System Preferences -> General and watch the debugging UI background change from white to black. Tested myself in Chrome 76 and Safari 12.1.2 on macOS 10.14.6.

<img width="780" alt="Screen Shot 2019-08-02 at 10 22 32 AM" src="https://user-images.githubusercontent.com/4108718/62376813-8579ce00-b50f-11e9-8a4d-868375baedf7.png">
