### PR TITLE
feat: fallback to default browser if Chrome is not found

### DIFF
--- a/packages/cli/src/commands/server/launchDebugger.js
+++ b/packages/cli/src/commands/server/launchDebugger.js
@@ -28,7 +28,7 @@ function commandExistsUnixSync(commandName) {
 
 function commandExistsWindowsSync(commandName) {
   try {
-    var stdout = execSync('where ' + commandName, {stdio: []});
+    const stdout = execSync('where ' + commandName, {stdio: []});
     return !!stdout;
   } catch (error) {
     return false;
@@ -87,7 +87,7 @@ function launchDebugger(url: string) {
     launchBrowser(url);
     return;
   }
-  launchChrome();
+  launchChrome(url);
 }
 
 export default launchDebugger;

--- a/packages/cli/src/commands/server/launchDebugger.js
+++ b/packages/cli/src/commands/server/launchDebugger.js
@@ -11,7 +11,7 @@
 import open from 'open';
 import {execSync} from 'child_process';
 import {logger} from '@react-native-community/cli-tools';
-import launchBrowser from './launchBrowser';
+import launchDefaultBrowser from './launchDefaultBrowser';
 import chalk from 'chalk';
 
 function commandExistsUnixSync(commandName) {
@@ -83,8 +83,7 @@ function launchDebugger(url: string) {
         'https://www.google.com/chrome/',
       )}`,
     );
-    //fallback to default browser
-    launchBrowser(url);
+    launchDefaultBrowser(url);
     return;
   }
   launchChrome(url);

--- a/packages/cli/src/commands/server/launchDebugger.js
+++ b/packages/cli/src/commands/server/launchDebugger.js
@@ -11,6 +11,8 @@
 import open from 'open';
 import {execSync} from 'child_process';
 import {logger} from '@react-native-community/cli-tools';
+import launchBrowser from './launchBrowser';
+import chalk from 'chalk';
 
 function commandExistsUnixSync(commandName) {
   try {
@@ -21,6 +23,28 @@ function commandExistsUnixSync(commandName) {
     return !!stdout;
   } catch (error) {
     return false;
+  }
+}
+
+function commandExistsWindowsSync(commandName) {
+  try {
+    var stdout = execSync('where ' + commandName, {stdio: []});
+    return !!stdout;
+  } catch (error) {
+    return false;
+  }
+}
+
+function commandExists(commandName) {
+  switch (process.platform) {
+    case 'win32':
+      return commandExistsWindowsSync(commandName);
+    case 'linux':
+    case 'darwin':
+      return commandExistsUnixSync(commandName);
+    default:
+      // assume it doesn't exist, just to be safe.
+      return false;
   }
 }
 
@@ -52,4 +76,18 @@ function launchChrome(url: string) {
   });
 }
 
-export default launchChrome;
+function launchDebugger(url: string) {
+  if (!commandExists(getChromeAppName())) {
+    logger.info(
+      `For a better debugging experience please install Google Chrome from: ${chalk.underline.dim(
+        'https://www.google.com/chrome/',
+      )}`,
+    );
+    //fallback to default browser
+    launchBrowser(url);
+    return;
+  }
+  launchChrome();
+}
+
+export default launchDebugger;

--- a/packages/cli/src/commands/server/launchDefaultBrowser.js
+++ b/packages/cli/src/commands/server/launchDefaultBrowser.js
@@ -11,7 +11,7 @@
 import open from 'open';
 import {logger} from '@react-native-community/cli-tools';
 
-function launchBrowser(url: string) {
+function launchDefaultBrowser(url: string) {
   open(url, err => {
     if (err) {
       logger.error('Browser exited with error:', err);
@@ -19,4 +19,4 @@ function launchBrowser(url: string) {
   });
 }
 
-export default launchBrowser;
+export default launchDefaultBrowser;

--- a/packages/cli/src/commands/server/middleware/MiddlewareManager.js
+++ b/packages/cli/src/commands/server/middleware/MiddlewareManager.js
@@ -33,7 +33,7 @@ type Options = {
 
 type WebSocketProxy = {
   server: WebSocketServer,
-  isChromeConnected: () => boolean,
+  isDebuggerConnected: () => boolean,
 };
 
 type Connect = $Call<connect>;
@@ -72,7 +72,7 @@ export default class MiddlewareManager {
 
   attachDevToolsSocket(socket: WebSocketProxy) {
     this.app.use(
-      getDevToolsMiddleware(this.options, () => socket.isChromeConnected()),
+      getDevToolsMiddleware(this.options, () => socket.isDebuggerConnected()),
     );
   }
 }

--- a/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.js
+++ b/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.js
@@ -6,14 +6,14 @@
  *
  * @format
  */
-import launchChrome from '../launchChrome';
 import {logger} from '@react-native-community/cli-tools';
 import {exec} from 'child_process';
+import launchDebugger from './../launchDebugger';
 
-function launchChromeDevTools(port, args = '') {
+function launchDefaultDebugger(port, args = '') {
   const debuggerURL = `http://localhost:${port}/debugger-ui${args}`;
   logger.info('Launching Dev Tools...');
-  launchChrome(debuggerURL);
+  launchDebugger(debuggerURL);
 }
 
 function escapePath(pathname) {
@@ -21,14 +21,14 @@ function escapePath(pathname) {
   return `"${pathname}"`;
 }
 
-function launchDevTools({port, watchFolders}, isChromeConnected) {
+function launchDevTools({port, watchFolders}, isDebuggerConnected) {
   // Explicit config always wins
   const customDebugger = process.env.REACT_DEBUGGER;
   if (customDebugger) {
     startCustomDebugger({watchFolders, customDebugger});
-  } else if (!isChromeConnected()) {
-    // Dev tools are not yet open; we need to open a session
-    launchChromeDevTools(port);
+  } else if (!isDebuggerConnected()) {
+    // Debugger is not yet open; we need to open a session
+    launchDefaultDebugger(port);
   }
 }
 
@@ -43,10 +43,10 @@ function startCustomDebugger({watchFolders, customDebugger}) {
   });
 }
 
-export default function getDevToolsMiddleware(options, isChromeConnected) {
+export default function getDevToolsMiddleware(options, isDebuggerConnected) {
   return function devToolsMiddleware(req, res, next) {
     if (req.url === '/launch-js-devtools') {
-      launchDevTools(options, isChromeConnected);
+      launchDevTools(options, isDebuggerConnected);
       res.end('OK');
     } else {
       next();

--- a/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.js
+++ b/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.js
@@ -8,7 +8,7 @@
  */
 import {logger} from '@react-native-community/cli-tools';
 import {exec} from 'child_process';
-import launchDebugger from './../launchDebugger';
+import launchDebugger from '../launchDebugger';
 
 function launchDefaultDebugger(port, args = '') {
   const debuggerURL = `http://localhost:${port}/debugger-ui${args}`;

--- a/packages/cli/src/commands/server/middleware/openURLMiddleware.js
+++ b/packages/cli/src/commands/server/middleware/openURLMiddleware.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-import launchBrowser from '../launchBrowser';
+import launchDefaultBrowser from '../launchDefaultBrowser';
 import {logger} from '@react-native-community/cli-tools';
 
 /**
@@ -17,7 +17,7 @@ export default function openURLMiddleware(req, res, next) {
   if (req.url === '/open-url') {
     const {url} = JSON.parse(req.rawBody);
     logger.info(`Opening ${url}...`);
-    launchBrowser(url);
+    launchDefaultBrowser(url);
     res.end('OK');
   } else {
     next();

--- a/packages/cli/src/commands/server/webSocketProxy.js
+++ b/packages/cli/src/commands/server/webSocketProxy.js
@@ -75,7 +75,7 @@ function attachToServer(server, path) {
 
   return {
     server: wss,
-    isChromeConnected() {
+    isDebuggerConnected() {
       return !!debuggerSocket;
     },
   };


### PR DESCRIPTION
Summary:
---------

It can be annoying for users (like me) who do not have Google Chrome installed to enable 'Remote Debugging' only to receive an error. This rectifies that by falling back to the default installed browser making the whole experience more fluid.

Test Plan:
----------
Tested on a sample app by enabling 'Remote Debugging'.
