### PR TITLE
feat: use server.enhanceMiddleware from custom metro configuration

### DIFF
--- a/packages/cli/src/commands/server/runServer.js
+++ b/packages/cli/src/commands/server/runServer.js
@@ -79,8 +79,15 @@ async function runServer(argv: Array<string>, ctx: ConfigT, args: Args) {
     middlewareManager.serveStatic.bind(middlewareManager),
   );
 
-  metroConfig.server.enhanceMiddleware = middleware =>
-    middlewareManager.getConnectInstance().use(middleware);
+  const customEnhanceMiddleware = metroConfig.server.enhanceMiddleware;
+
+  metroConfig.server.enhanceMiddleware = (middleware, server) => {
+    if (customEnhanceMiddleware) {
+      middleware = customEnhanceMiddleware(middleware, server);
+    }
+
+    return middlewareManager.getConnectInstance().use(middleware);
+  };
 
   const serverInstance = await Metro.runServer(metroConfig, {
     host: args.host,


### PR DESCRIPTION
Summary:
---------

I want to customize my Metro server with `server.enhanceMiddleware` in my `metro.config.js`. Currently [runServer.js:82](https://github.com/react-native-community/cli/blob/4a5192479de327b4215b0ae09ba13d82874a8d2e/packages/cli/src/commands/server/runServer.js#L82) overriddes this configuration option. PR enables usage of custom `enhanceMiddleware` from metro configuration for react-native-cli. 


Test Plan:
----------

Add this to your `rn-cli.config.js` or `metro.config.js` to clean react native project:

```js
const assert = require('assert');

module.exports = {
  /* ... */
  server: {
    /* ... */
    enhanceMiddleware: (middleware, server) => {
      assert.equal(typeof middleware, 'function');
      assert.equal(server.constructor.name, 'Server');
      console.log('Middleware enhanced');

      return (req, res, next) => {
        assert.equal(req.constructor.name, 'IncomingMessage');
        assert.equal(res.constructor.name, 'ServerResponse');
        assert.equal(typeof next, 'function');
        assert.equal(next.name, 'next');
        console.log('Enhanced middleware used for: ' + req.url);

        return middleware(req, res, next);
      }
    }
  },
};
```

**Steps**:

  - 1️⃣ Start server -> Observe server starts and prints "Middleware enhanced" and doesn't throw any error.
  - 2️⃣ Request `/index.bundle?platform=ios` -> Observe server prints "Enhanced middleware used for: /index.bundle?platform=ios" and returns bundle properly without throwing error.

```
$ react-native start
┌──────────────────────────────────────────────────────────────────────────────┐
│                                                                              │
│  Running Metro Bundler on port 8081.                                         │
│                                                                              │
│  Keep Metro running while developing on any JS projects. Feel free to        │
│  close this tab and run your own Metro instance if you prefer.               │
│                                                                              │
│  https://github.com/facebook/react-native                                    │
│                                                                              │
└──────────────────────────────────────────────────────────────────────────────┘

1️⃣ Middleware enhanced
Looking for JS files in
   /Users/lukasweber/dev/test-rn-project/

Loading dependency graph, done.
2️⃣ Enhanced middleware used for: /index.bundle?platform=ios
 BUNDLE  [ios, dev] ./index.js ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ 100.0% (2/2), done.
```