### PR TITLE
fix: add Content-Type header to index page

### DIFF
--- a/packages/cli/src/commands/server/middleware/indexPage.js
+++ b/packages/cli/src/commands/server/middleware/indexPage.js
@@ -12,6 +12,7 @@ import path from 'path';
 
 export default function indexPageMiddleware(req, res, next) {
   if (req.url === '/') {
+    res.setHeader('Content-Type', 'text/html');
     res.end(fs.readFileSync(path.join(__dirname, 'index.html')));
   } else {
     next();


### PR DESCRIPTION
Summary:
---------

Content-Type HTTP header is not set for index page. Chrome renders the page as plain text and Safari triggers download of Unknown.dms file instead.

Test Plan:
----------

Start server, open server index page in web browser and see the page is rendered as HTML not plain text (or doesn't trigger download in case of Safari).

| Before | After |
|--- | --- |
| <img width="804" alt="Screenshot 2019-08-05 10 49 14" src="https://user-images.githubusercontent.com/546887/62451745-22867200-b76f-11e9-84da-459a3789c25a.png"> | <img width="804" alt="Screenshot 2019-08-05 10 50 54" src="https://user-images.githubusercontent.com/546887/62451751-24e8cc00-b76f-11e9-8018-f90fb96aa88b.png">

