### PR TITLE
fix: update init banner message with website tagline

### DIFF
--- a/packages/cli/src/commands/init/banner.js
+++ b/packages/cli/src/commands/init/banner.js
@@ -34,7 +34,7 @@ const reactLogoArray = [
 const welcomeMessage =
   '                  Welcome to React Native!                ';
 const learnOnceMessage =
-  '                 Learn Once Write Anywhere                ';
+  '                 Learn once, write anywhere.              ';
 
 export default `${chalk.blue(reactLogoArray.join('\n'))}
 


### PR DESCRIPTION
Summary:
---------

Updated the banner message to use the same as what we have on the RN website: https://facebook.github.io/react-native/

Test Plan:
----------

yolo