### PR TITLE
fix: use posix path.sep in linking of header search path

### DIFF
--- a/packages/platform-ios/src/link/__tests__/getHeaderSearchPath-test.js
+++ b/packages/platform-ios/src/link/__tests__/getHeaderSearchPath-test.js
@@ -9,8 +9,7 @@
  */
 
 import getHeaderSearchPath from '../getHeaderSearchPath';
-
-const path = require('path');
+import {posix as path} from 'path';
 
 const SRC_DIR = path.join('react-native-project', 'ios');
 

--- a/packages/platform-ios/src/link/getHeaderSearchPath.js
+++ b/packages/platform-ios/src/link/getHeaderSearchPath.js
@@ -7,7 +7,7 @@
  * @format
  */
 
-import path from 'path';
+import {posix as path} from 'path';
 import {last, union} from 'lodash';
 
 /**
@@ -22,14 +22,14 @@ import {last, union} from 'lodash';
  */
 const getOuterDirectory = directories =>
   directories.reduce((topDir, currentDir) => {
-    const currentFolders = currentDir.split('/');
-    const topMostFolders = topDir.split('/');
+    const currentFolders = currentDir.split(path.sep);
+    const topMostFolders = topDir.split(path.sep);
 
     if (
       currentFolders.length === topMostFolders.length &&
       last(currentFolders) !== last(topMostFolders)
     ) {
-      return currentFolders.slice(0, -1).join('/');
+      return currentFolders.slice(0, -1).join(path.sep);
     }
 
     return currentFolders.length < topMostFolders.length ? currentDir : topDir;


### PR DESCRIPTION
Summary:
---------

Using `path.posix` for `getHeaderSearchPath-test` to make it pass on Windows.


Test Plan:
----------

Windows CI green
