### PR TITLE
Match device names which include parentheses

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
+++ b/packages/platform-ios/src/commands/runIOS/findMatchingSimulator.js
@@ -27,7 +27,7 @@ function findMatchingSimulator(simulators, simulatorString) {
   const devices = simulators.devices;
 
   const parsedSimulatorName = simulatorString
-    ? simulatorString.match(/(.*)? (?:\((\d+\.\d+)?\))$/)
+    ? simulatorString.match(/(.*)?\s(?:\[(.*)?\])?/)
     : [];
 
   if (parsedSimulatorName && parsedSimulatorName[2] !== undefined) {


### PR DESCRIPTION

Summary:
---------
I ran into this problem trying to bring up the simulator for the iPad Pro (11-inch):
Currently running `react-native run-ios --simulator='iPad Pro (11-inch)'` results in an error, because only device names without parentheses, e.g. "iPhone 6" are being matched successfully. 
Replacing the regex for `simulatorString.match()` with `/(.*)?\s(?:\[(.*)?\])?/`should do the trick.

Test Plan:
----------
Calling the command with `--simulator` set to different variants of device names including the following:

- iPad Pro (11-inch)
- iPad Pro (12.9-inch) (3rd generation)
- iPhone 5s
- iPhone 6
- iPhone 6 Plus

demonstrates the fix.