### PR TITLE
docs: update link to react-devtools

### DIFF
--- a/packages/cli/src/commands/server/debugger-ui/index.html
+++ b/packages/cli/src/commands/server/debugger-ui/index.html
@@ -255,7 +255,7 @@
       React Native JS code runs as a web worker inside this tab.
     </p>
     <p>Press <kbd id="shortcut" class="shortcut">⌘⌥I</kbd> to open Developer Tools. Enable <a href="https://stackoverflow.com/a/17324511/232122" target="_blank">Pause On Caught Exceptions</a> for a better debugging experience.</p>
-    <p>You may also install <a href="https://github.com/facebook/react-devtools/tree/master/packages/react-devtools" target="_blank">the standalone version of React Developer Tools</a> to inspect the React component hierarchy, their props, and state.</p>
+    <p>You may also install <a href="https://github.com/facebook/react/tree/master/packages/react-devtools" target="_blank">the standalone version of React Developer Tools</a> to inspect the React component hierarchy, their props, and state.</p>
     <p>Status: <span id="status">Loading...</span></p>
     <button class="reload-btn" onclick="onReloadClicked()">
       Reload app


### PR DESCRIPTION
As per project migration notice at https://github.com/facebook/react-devtools

Summary:
---------

The [react-devtools](https://github.com/facebook/react-devtools) project was moved [into the main React repository](https://github.com/facebook/react/tree/master/packages/react-devtools).