### PR TITLE
fix: Change title for newly initialised projects

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -134,6 +134,10 @@ Uses a valid semver version of React Native as a template.
 
 Uses a custom directory instead of `<projectName>`.
 
+### `--title [string]`
+
+Uses a custom title instead of `<projectName>`.
+
 #### `--template [string]`
 
 Uses a custom template. Accepts following template sources:
@@ -162,6 +166,8 @@ type Template = {
   templateDir: string;
   // Path to script, which will be executed after init
   postInitScript?: string;
+  // Placeholder used to rename app title inside values.xml and Info.plist
+  titlePlaceholder?: string;
 };
 ```
 
@@ -170,6 +176,7 @@ Example `template.config.js`:
 ```js
 module.exports = {
   placeholderName: 'ProjectName',
+  titlePlaceholder: 'Project Display Name',
   templateDir: './template',
   postInitScript: './script.js',
 };

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -136,7 +136,7 @@ Uses a custom directory instead of `<projectName>`.
 
 ### `--title [string]`
 
-Uses a custom title instead of `<projectName>`.
+Uses a custom app title instead of `<projectName>`.
 
 #### `--template [string]`
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -72,6 +72,10 @@ module.exports = {
   // Placeholder name that will be replaced in package.json, index.json, android/, ios/ for a project name.
   placeholderName: 'ProjectName',
 
+  // Placeholder title that will be replaced in values.xml and Info.plist with title provided by the user.
+  // We default this value to 'Hello App Display Name', which is default placeholder in react-native template.
+  titlePlaceholder: 'Hello App Display Name',
+
   // Directory with the template which will be copied and processed by React Native CLI. Template directory should have package.json with all dependencies specified, including `react-native`.
   templateDir: './template',
 

--- a/packages/cli/src/commands/init/__fixtures__/editTemplate/android/com/placeholdername/Main.java
+++ b/packages/cli/src/commands/init/__fixtures__/editTemplate/android/com/placeholdername/Main.java
@@ -3,5 +3,6 @@ com.placeholdername;
 public static class Main {
   public static void run() {
     String name = "PlaceholderName";
+    String title = "Hello App Display Name";
   }
 }

--- a/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.js.snap
+++ b/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.js.snap
@@ -21,10 +21,12 @@ exports[`should edit template 2`] = `
 - com.placeholdername;
 + com.projectname;
   
-@@ -4,3 +4,3 @@
+@@ -4,4 +4,4 @@
     public static void run() {
 -     String name = \\"PlaceholderName\\";
+-     String title = \\"Hello App Display Name\\";
 +     String name = \\"ProjectName\\";
++     String title = \\"ProjectName\\";
     }"
 `;
 
@@ -55,4 +57,22 @@ exports[`should edit template 3`] = `
 +   \\"/ios/ProjectNameTests\\",
 +   \\"/ios/ProjectNameTests/.gitkeep\\",
     \\"/node_modules\\","
+`;
+
+exports[`should edit template with custom title 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -1,2 +1,2 @@
+- com.placeholdername;
++ com.projectname;
+  
+@@ -4,4 +4,4 @@
+    public static void run() {
+-     String name = \\"PlaceholderName\\";
+-     String title = \\"Hello App Display Name\\";
++     String name = \\"ProjectName\\";
++     String title = \\"ProjectTitle\\";
+    }"
 `;

--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.js
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.js
@@ -16,6 +16,7 @@ const FIXTURE_DIR = path.resolve(
 );
 const PLACEHOLDER_NAME = 'PlaceholderName';
 const PROJECT_NAME = 'ProjectName';
+const PROJECT_TITLE = 'ProjectTitle';
 
 async function createTestEnv() {
   const TEST_DIR = `rncli-should-edit-template-${Date.now()}`;
@@ -84,5 +85,44 @@ test('should edit template', () => {
     snapshotDiff(fixtureTree.map(slash), transformedTree.map(slash), {
       contextLines: 1,
     }),
+  ).toMatchSnapshot();
+});
+
+test('should edit template with custom title', () => {
+  jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
+
+  changePlaceholderInTemplate(
+    PROJECT_NAME,
+    PLACEHOLDER_NAME,
+    undefined,
+    PROJECT_TITLE,
+  );
+
+  const transformedTree = walk(testPath).map(e => e.replace(testPath, ''));
+  const fixtureTree = walk(FIXTURE_DIR).map(e => e.replace(FIXTURE_DIR, ''));
+
+  const oldJavaFile = fs.readFileSync(
+    path.resolve(
+      FIXTURE_DIR,
+      'android',
+      'com',
+      PLACEHOLDER_NAME.toLowerCase(),
+      'Main.java',
+    ),
+    'utf8',
+  );
+  const newJavaFile = fs.readFileSync(
+    path.resolve(
+      testPath,
+      'android',
+      'com',
+      PROJECT_NAME.toLowerCase(),
+      'Main.java',
+    ),
+    'utf8',
+  );
+
+  expect(
+    snapshotDiff(oldJavaFile, newJavaFile, {contextLines: 1}),
   ).toMatchSnapshot();
 });

--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.js
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.js
@@ -42,7 +42,10 @@ afterEach(() => {
 test('should edit template', () => {
   jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
 
-  changePlaceholderInTemplate(PROJECT_NAME, PLACEHOLDER_NAME);
+  changePlaceholderInTemplate({
+    projectName: PROJECT_NAME,
+    placeholderName: PLACEHOLDER_NAME,
+  });
 
   const transformedTree = walk(testPath).map(e => e.replace(testPath, ''));
   const fixtureTree = walk(FIXTURE_DIR).map(e => e.replace(FIXTURE_DIR, ''));
@@ -91,15 +94,11 @@ test('should edit template', () => {
 test('should edit template with custom title', () => {
   jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
 
-  changePlaceholderInTemplate(
-    PROJECT_NAME,
-    PLACEHOLDER_NAME,
-    undefined,
-    PROJECT_TITLE,
-  );
-
-  const transformedTree = walk(testPath).map(e => e.replace(testPath, ''));
-  const fixtureTree = walk(FIXTURE_DIR).map(e => e.replace(FIXTURE_DIR, ''));
+  changePlaceholderInTemplate({
+    projectName: PROJECT_NAME,
+    placeholderName: PLACEHOLDER_NAME,
+    projectTitle: PROJECT_TITLE,
+  });
 
   const oldJavaFile = fs.readFileSync(
     path.resolve(

--- a/packages/cli/src/commands/init/editTemplate.js
+++ b/packages/cli/src/commands/init/editTemplate.js
@@ -4,6 +4,8 @@ import path from 'path';
 import walk from '../../tools/walk';
 import {logger} from '@react-native-community/cli-tools';
 
+const DEFAULT_TITLE_PLACEHOLDER = 'Hello App Display Name';
+
 function replaceNameInUTF8File(
   filePath: string,
   projectName: string,
@@ -65,6 +67,8 @@ function processDotfiles(filePath: string) {
 export function changePlaceholderInTemplate(
   projectName: string,
   placeholderName: string,
+  placeholderTitle?: string = DEFAULT_TITLE_PLACEHOLDER,
+  projectTitle?: string = projectName,
 ) {
   logger.debug(`Changing ${placeholderName} for ${projectName} in template`);
 
@@ -76,6 +80,7 @@ export function changePlaceholderInTemplate(
       }
       if (!fs.statSync(filePath).isDirectory()) {
         replaceNameInUTF8File(filePath, projectName, placeholderName);
+        replaceNameInUTF8File(filePath, projectTitle, placeholderTitle);
       }
       if (shouldRenameFile(filePath, placeholderName)) {
         renameFile(filePath, placeholderName, projectName);

--- a/packages/cli/src/commands/init/editTemplate.js
+++ b/packages/cli/src/commands/init/editTemplate.js
@@ -4,6 +4,10 @@ import path from 'path';
 import walk from '../../tools/walk';
 import {logger} from '@react-native-community/cli-tools';
 
+/**
+  TODO: This is a default placeholder for title in react-native template.
+  We should get rid of this once custom templates adapt `placeholderTitle` in their configurations.
+*/
 const DEFAULT_TITLE_PLACEHOLDER = 'Hello App Display Name';
 
 function replaceNameInUTF8File(
@@ -64,12 +68,17 @@ function processDotfiles(filePath: string) {
   renameFile(filePath, `_${dotfile}`, `.${dotfile}`);
 }
 
-export function changePlaceholderInTemplate(
+export function changePlaceholderInTemplate({
+  projectName,
+  placeholderName,
+  placeholderTitle = DEFAULT_TITLE_PLACEHOLDER,
+  projectTitle = projectName,
+}: {
   projectName: string,
   placeholderName: string,
-  placeholderTitle?: string = DEFAULT_TITLE_PLACEHOLDER,
-  projectTitle?: string = projectName,
-) {
+  placeholderTitle?: string,
+  projectTitle?: string,
+}) {
   logger.debug(`Changing ${placeholderName} for ${projectName} in template`);
 
   walk(process.cwd())

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -26,7 +26,7 @@ export default {
     },
     {
       name: '--title [string]',
-      description: 'Uses a custom title name for application',
+      description: 'Uses a custom app title name for application',
     },
   ],
 };

--- a/packages/cli/src/commands/init/index.js
+++ b/packages/cli/src/commands/init/index.js
@@ -24,5 +24,9 @@ export default {
       name: '--directory [string]',
       description: 'Uses a custom directory instead of `<projectName>`.',
     },
+    {
+      name: '--title [string]',
+      description: 'Uses a custom title name for application',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -32,6 +32,8 @@ type Options = {|
   template?: string,
   npm?: boolean,
   directory?: string,
+  displayName?: string,
+  title?: string,
 |};
 
 function doesDirectoryExist(dir: string) {
@@ -92,11 +94,13 @@ async function createFromTemplate({
   templateName,
   npm,
   directory,
+  projectTitle,
 }: {
   projectName: string,
   templateName: string,
   npm?: boolean,
   directory: string,
+  projectTitle?: string,
 }) {
   logger.debug('Initializing new project');
   logger.log(banner);
@@ -125,7 +129,12 @@ async function createFromTemplate({
     loader.succeed();
     loader.start('Processing template');
 
-    changePlaceholderInTemplate(projectName, templateConfig.placeholderName);
+    changePlaceholderInTemplate(
+      projectName,
+      templateConfig.placeholderName,
+      templateConfig.titlePlaceholder,
+      projectTitle,
+    );
 
     loader.succeed();
     const {postInitScript} = templateConfig;
@@ -191,6 +200,7 @@ async function createProject(
     templateName,
     npm: options.npm,
     directory,
+    projectTitle: options.title,
   });
 }
 

--- a/packages/cli/src/commands/init/init.js
+++ b/packages/cli/src/commands/init/init.js
@@ -129,12 +129,12 @@ async function createFromTemplate({
     loader.succeed();
     loader.start('Processing template');
 
-    changePlaceholderInTemplate(
+    changePlaceholderInTemplate({
       projectName,
-      templateConfig.placeholderName,
-      templateConfig.titlePlaceholder,
       projectTitle,
-    );
+      placeholderName: templateConfig.placeholderName,
+      titlePlaceholder: templateConfig.titlePlaceholder,
+    });
 
     loader.succeed();
     const {postInitScript} = templateConfig;

--- a/packages/cli/src/commands/init/template.js
+++ b/packages/cli/src/commands/init/template.js
@@ -10,6 +10,7 @@ export type TemplateConfig = {
   placeholderName: string,
   templateDir: string,
   postInitScript?: string,
+  titlePlaceholder?: string,
 };
 
 export function installTemplatePackage(


### PR DESCRIPTION
Summary:
---------

Fixes: #561 

Apart from fixing a bug, I've added the ability to specify title placeholder for custom templates. Additionally, you can specify custom `title` for the project by passing `--title` flag.

Test Plan:
----------

- [x] - Tested manually
- [x] - UT passing
