### PR TITLE
fix: Infinite spinner when installing cocoapods

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "semver": "^5.0.3",
     "serve-static": "^1.13.1",
     "shell-quote": "1.6.1",
+    "sudo-prompt": "^9.0.0",
     "ws": "^1.1.0"
   },
   "peerDependencies": {

--- a/packages/cli/src/tools/installPods.js
+++ b/packages/cli/src/tools/installPods.js
@@ -6,6 +6,7 @@ import Ora from 'ora';
 import inquirer from 'inquirer';
 import {logger} from '@react-native-community/cli-tools';
 import {NoopLoader} from './loader';
+import sudo from 'sudo-prompt';
 
 async function updatePods(loader: typeof Ora) {
   try {
@@ -26,6 +27,18 @@ async function updatePods(loader: typeof Ora) {
       )}`,
     );
   }
+}
+
+function runSudo(command: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    sudo.exec(command, error => {
+      if (error) {
+        reject(error);
+      }
+
+      resolve();
+    });
+  });
 }
 
 async function installPods({
@@ -82,12 +95,7 @@ async function installPods({
         } catch (_error) {
           try {
             // If that doesn't work then try with sudo
-            await execa('sudo', [
-              'gem',
-              'install',
-              'cocoapods',
-              '--no-document',
-            ]);
+            await runSudo('gem install cocoapods --no-document');
           } catch (error) {
             loader.fail();
             logger.log(error.stderr);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8585,6 +8585,11 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
+sudo-prompt@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-9.0.0.tgz#eebedeee9fcd6f661324e6bb46335e3288e8dc8a"
+  integrity sha512-kUn5fiOk0nhY2oKD9onIkcNCE4Zt85WTsvOfSmqCplmlEvXCcPOmp1npH5YWuf8Bmyy9wLWkIxx+D+8cThBORQ==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"


### PR DESCRIPTION
Summary:
---------

When a user doesn't have cocoapods installed and doesn't have sudo permissions they were prompted with infinite spinner. To fix that I've added system password prompt.

cc @orta @cpojer 

This is how it looks like:

![Kapture 2019-08-27 at 14 20 53](https://user-images.githubusercontent.com/9092510/63771156-e1e5c880-c8d6-11e9-97c2-e6968668ecd3.gif)

Or MP4 here: https://dump.video/i/4DnHbM.mp4

Test Plan:
----------
- [x] - Unit tests passing
- [x] - Tested manually
