### PR TITLE
feat: Allow passing in MainPackageConfig to PackageList

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -66,6 +66,7 @@ The [native_modules.gradle](https://github.com/react-native-community/cli/blob/m
    1. A first Gradle plugin (in `settings.gradle`) runs `applyNativeModulesSettingsGradle` method. It uses the package metadata from `react-native config` to add Android projects.
    1. A second Gradle plugin (in `app/build.gradle`) runs `applyNativeModulesAppBuildGradle` method. It creates a list of React Native packages to include in the generated `/android/build/generated/rn/src/main/java/com/facebook/react/PackageList.java` file.
 1. At runtime, the list of React Native packages generated in step 1.2 is registered by `getPackages` method of `ReactNativeHost` in `MainApplication.java`.
+   1. You can optionally pass in an instance of `MainPackageConfig` when initializing `PackageList` if you want to override the default configuration of `MainReactPackage`.
 
 ### Example
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.content.res.Resources;
 
 import com.facebook.react.ReactPackage;
+import com.facebook.react.shell.MainPackageConfig;
 import com.facebook.react.shell.MainReactPackage;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -20,13 +21,25 @@ import java.util.ArrayList;
 public class PackageList {
   private Application application;
   private ReactNativeHost reactNativeHost;
+  private MainPackageConfig mConfig;
+
   public PackageList(ReactNativeHost reactNativeHost) {
-    this.reactNativeHost = reactNativeHost;
+    this(reactNativeHost, null);
   }
 
   public PackageList(Application application) {
+    this(application, null);
+  }
+
+  public PackageList(ReactNativeHost reactNativeHost, MainPackageConfig config) {
+    this.reactNativeHost = reactNativeHost;
+    mConfig = config;
+  }
+
+  public PackageList(Application application, MainPackageConfig config) {
     this.reactNativeHost = null;
     this.application = application;
+    mConfig = config;
   }
 
   private ReactNativeHost getReactNativeHost() {
@@ -48,7 +61,7 @@ public class PackageList {
 
   public ArrayList<ReactPackage> getPackages() {
     return new ArrayList<>(Arrays.<ReactPackage>asList(
-      new MainReactPackage(){{ packageClassInstances }}
+      new MainReactPackage(mConfig){{ packageClassInstances }}
     ));
   }
 }


### PR DESCRIPTION

Summary:
---------

This allow customizing configuration for the MainReactPackage.
Right now this is limited to changing how FrescoModule gets initialized
but in the future this can allow changes in behavior for other core modules


Test Plan:
----------

Since this is a template only change, it shouldn't require any tests.
I have verified that this is not a breaking change for existing users.