### PR TITLE
[Doctor] Export default functions directly

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.js
+++ b/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.js
@@ -10,7 +10,7 @@ const URLS = {
 
 const label = 'ANDROID_HOME';
 
-const iosDeploy = {
+export default {
   label,
   getDiagnostics: () => ({
     needsToBeFixed: !process.env.ANDROID_HOME,
@@ -25,5 +25,3 @@ const iosDeploy = {
     });
   },
 };
-
-export default iosDeploy;

--- a/packages/cli/src/commands/doctor/healthchecks/androidNDK.js
+++ b/packages/cli/src/commands/doctor/healthchecks/androidNDK.js
@@ -3,7 +3,7 @@ import {logManualInstallation} from './common';
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 
-const iosDeploy = {
+export default {
   label: 'Android NDK',
   getDiagnosticsAsync: async ({SDKs}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
@@ -31,5 +31,3 @@ const iosDeploy = {
     });
   },
 };
-
-export default iosDeploy;

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
@@ -3,7 +3,7 @@ import {logManualInstallation} from './common';
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 
-const iosDeploy = {
+export default {
   label: 'Android SDK',
   getDiagnosticsAsync: async ({SDKs}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
@@ -31,5 +31,3 @@ const iosDeploy = {
     });
   },
 };
-
-export default iosDeploy;

--- a/packages/cli/src/commands/doctor/healthchecks/cocoaPods.js
+++ b/packages/cli/src/commands/doctor/healthchecks/cocoaPods.js
@@ -19,7 +19,7 @@ const reportLoader = async ({loader, type, userHasSudoGranted}) => {
   loader[type]();
 };
 
-const cocoaPods = {
+export default {
   label: 'CocoaPods',
   getDiagnosticsAsync: async () => ({
     needsToBeFixed: !(await isSoftwareInstalled('pod')),
@@ -50,5 +50,3 @@ const cocoaPods = {
     }
   },
 };
-
-export default cocoaPods;

--- a/packages/cli/src/commands/doctor/healthchecks/iosDeploy.js
+++ b/packages/cli/src/commands/doctor/healthchecks/iosDeploy.js
@@ -15,7 +15,7 @@ const getInstallationCommand = () => {
   return undefined;
 };
 
-const iosDeploy = {
+export default {
   label: 'ios-deploy',
   isRequired: false,
   getDiagnosticsAsync: async () => ({
@@ -52,5 +52,3 @@ const iosDeploy = {
     }
   },
 };
-
-export default iosDeploy;

--- a/packages/cli/src/commands/doctor/healthchecks/nodeJS.js
+++ b/packages/cli/src/commands/doctor/healthchecks/nodeJS.js
@@ -2,7 +2,7 @@ import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import {logManualInstallation} from './common';
 
-const issue = {
+export default {
   label: 'Node.js',
   getDiagnostics: ({Binaries}) => ({
     version: Binaries.Node.version,
@@ -20,5 +20,3 @@ const issue = {
     });
   },
 };
-
-export default issue;

--- a/packages/cli/src/commands/doctor/healthchecks/watchman.js
+++ b/packages/cli/src/commands/doctor/healthchecks/watchman.js
@@ -1,7 +1,7 @@
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 
-const watchman = {
+export default {
   label: 'Watchman',
   getDiagnostics: ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
@@ -11,5 +11,3 @@ const watchman = {
   }),
   runAutomaticFix: () => console.log('should fix watchman'),
 };
-
-export default watchman;

--- a/packages/cli/src/commands/doctor/healthchecks/xcode.js
+++ b/packages/cli/src/commands/doctor/healthchecks/xcode.js
@@ -2,7 +2,7 @@ import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import {logManualInstallation} from './common';
 
-const xcode = {
+export default {
   label: 'Xcode',
   getDiagnostics: ({IDEs}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
@@ -19,5 +19,3 @@ const xcode = {
     });
   },
 };
-
-export default xcode;

--- a/packages/cli/src/commands/doctor/printFixOptions.js
+++ b/packages/cli/src/commands/doctor/printFixOptions.js
@@ -27,7 +27,8 @@ const printOptions = () => {
   printOption(`${chalk.dim('Press')} Enter ${chalk.dim('to exit.')}`);
 };
 
-const printFixOptions = ({onKeyPress}) => {
+export {KEYS};
+export default ({onKeyPress}) => {
   printOptions();
 
   process.stdin.setRawMode(true);
@@ -35,6 +36,3 @@ const printFixOptions = ({onKeyPress}) => {
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', onKeyPress);
 };
-
-export {KEYS};
-export default printFixOptions;

--- a/packages/cli/src/commands/doctor/runAutomaticFix.js
+++ b/packages/cli/src/commands/doctor/runAutomaticFix.js
@@ -9,7 +9,8 @@ const AUTOMATIC_FIX_LEVELS = {
   WARNINGS: 'WARNINGS',
 };
 
-const runAutomaticFix = async ({
+export {AUTOMATIC_FIX_LEVELS};
+export default async ({
   healthchecks,
   automaticFixLevel,
   stats,
@@ -77,6 +78,3 @@ const runAutomaticFix = async ({
     }
   }
 };
-
-export {AUTOMATIC_FIX_LEVELS};
-export default runAutomaticFix;


### PR DESCRIPTION
@thymikee 

Summary:
---------
There were wrong variable (iosDeploy) names in some android js files (androidHomeEnvVariable.js). I fixed this by just exporting default functions directly which makes it cleaner anyway.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Not needed

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
