### PR TITLE
fix semver check was breaking for non-semver versions

### DIFF
--- a/packages/cli/src/commands/doctor/checkInstallation.js
+++ b/packages/cli/src/commands/doctor/checkInstallation.js
@@ -17,6 +17,7 @@ const isSoftwareInstalled = async command => {
 };
 
 const doesSoftwareNeedToBeFixed = ({version, versionRange}) =>
-  version === 'Not Found' || !semver.satisfies(semver.coerce(version), versionRange);
+  version === 'Not Found' ||
+  !semver.satisfies(semver.coerce(version), versionRange);
 
 export {PACKAGE_MANAGERS, isSoftwareInstalled, doesSoftwareNeedToBeFixed};

--- a/packages/cli/src/commands/doctor/checkInstallation.js
+++ b/packages/cli/src/commands/doctor/checkInstallation.js
@@ -17,6 +17,6 @@ const isSoftwareInstalled = async command => {
 };
 
 const doesSoftwareNeedToBeFixed = ({version, versionRange}) =>
-  version === 'Not Found' || !semver.satisfies(version, versionRange);
+  version === 'Not Found' || !semver.satisfies(semver.coerce(version), versionRange);
 
 export {PACKAGE_MANAGERS, isSoftwareInstalled, doesSoftwareNeedToBeFixed};


### PR DESCRIPTION
Summary:
---------

The semver check was failing for version numbers that don't fit semver, like for Xcode version 10.3.
