### PR TITLE
Remove unused import (child_process.exec)

### DIFF
--- a/packages/global-cli/index.js
+++ b/packages/global-cli/index.js
@@ -38,7 +38,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const exec = require('child_process').exec;
 const execSync = require('child_process').execSync;
 const chalk = require('chalk');
 const prompt = require('prompt');


### PR DESCRIPTION
One-line removal of an un-used import. It isn't much but removing un-used code always helps in getting things understandable.