### PR TITLE
Doctor/windows

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
@@ -3,13 +3,19 @@ import {logManualInstallation} from './common';
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 
+const installMessage = `Read more about how to update Android SDK at ${chalk.dim(
+  'https://developer.android.com/studio',
+)}`;
+
 export default {
   label: 'Android SDK',
   getDiagnosticsAsync: async ({SDKs}) => ({
-    needsToBeFixed: doesSoftwareNeedToBeFixed({
-      version: SDKs['Android SDK']['Build Tools'][0],
-      versionRange: versionRanges.ANDROID_NDK,
-    }),
+    needsToBeFixed:
+      (SDKs['Android SDK'] === 'Not Found' && installMessage) ||
+      doesSoftwareNeedToBeFixed({
+        version: SDKs['Android SDK']['Build Tools'][0],
+        versionRange: versionRanges.ANDROID_NDK,
+      }),
   }),
   runAutomaticFix: async ({loader, environmentInfo}) => {
     const version = environmentInfo.SDKs['Android SDK'][0];
@@ -19,9 +25,7 @@ export default {
 
     if (isNDKInstalled) {
       return logManualInstallation({
-        message: `Read more about how to update Android SDK at ${chalk.dim(
-          'https://developer.android.com/studio',
-        )}`,
+        message: installMessage,
       });
     }
 

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
@@ -68,7 +68,7 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android SDK',
-      url: 'https://developer.android.com/studio',
+      url: 'https://facebook.github.io/react-native/docs/getting-started',
     });
   },
 };

--- a/packages/cli/src/commands/doctor/healthchecks/index.js
+++ b/packages/cli/src/commands/doctor/healthchecks/index.js
@@ -16,7 +16,12 @@ export const HEALTHCHECK_TYPES = {
 export const getHealthchecks = ({contributor}) => ({
   common: {
     label: 'Common',
-    healthchecks: [nodeJS, yarn, npm, watchman],
+    healthchecks: [
+      nodeJS,
+      yarn,
+      npm,
+      ...(process.platform === 'darwin' ? [watchman] : []),
+    ],
   },
   android: {
     label: 'Android',


### PR DESCRIPTION
Summary:
---------

This fixes multiple issues on Windows:
1. It was crashing when checking Android SDKs if no Android SDKs installed.
2. It was checking for watchman, which is not part of the install guide for Windows.
3. There is a bug in envinfo which does not get Android Studio info correctly: https://github.com/tabrindle/envinfo/pull/119. This has a workaround until that is fixed.


Test Plan:
----------

Run `doctor` on a Windows machine with no Android SDKs installed to see #1, and then install Android SDKs and see that it was still showing an error.