### PR TITLE
feat: launch emulator during run-android

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/__mocks__/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/__mocks__/tryLaunchEmulator.ts
@@ -1,0 +1,1 @@
+export default async () => true;

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -14,6 +14,7 @@ jest.mock('child_process', () => ({
 }));
 
 jest.mock('../getAdbPath');
+jest.mock('../tryLaunchEmulator');
 const {execFileSync} = require('child_process');
 
 describe('--appFolder', () => {
@@ -21,18 +22,17 @@ describe('--appFolder', () => {
     jest.clearAllMocks();
   });
 
-  it('uses task "install[Variant]" as default task', () => {
+  it('uses task "install[Variant]" as default task', async () => {
     // @ts-ignore
-    runOnAllDevices({
+    await runOnAllDevices({
       variant: 'debug',
     });
-
     expect(execFileSync.mock.calls[0][1]).toContain('installDebug');
   });
 
-  it('uses appFolder and default variant', () => {
+  it('uses appFolder and default variant', async () => {
     // @ts-ignore
-    runOnAllDevices({
+    await runOnAllDevices({
       appFolder: 'someApp',
       variant: 'debug',
     });
@@ -40,9 +40,9 @@ describe('--appFolder', () => {
     expect(execFileSync.mock.calls[0][1]).toContain('someApp:installDebug');
   });
 
-  it('uses appFolder and custom variant', () => {
+  it('uses appFolder and custom variant', async () => {
     // @ts-ignore
-    runOnAllDevices({
+    await runOnAllDevices({
       appFolder: 'anotherApp',
       variant: 'staging',
     });
@@ -52,9 +52,9 @@ describe('--appFolder', () => {
     );
   });
 
-  it('uses only task argument', () => {
+  it('uses only task argument', async () => {
     // @ts-ignore
-    runOnAllDevices({
+    await runOnAllDevices({
       tasks: ['someTask'],
       variant: 'debug',
     });
@@ -62,9 +62,9 @@ describe('--appFolder', () => {
     expect(execFileSync.mock.calls[0][1]).toContain('someTask');
   });
 
-  it('uses appFolder and custom task argument', () => {
+  it('uses appFolder and custom task argument', async () => {
     // @ts-ignore
-    runOnAllDevices({
+    await runOnAllDevices({
       appFolder: 'anotherApp',
       tasks: ['someTask'],
       variant: 'debug',
@@ -73,9 +73,9 @@ describe('--appFolder', () => {
     expect(execFileSync.mock.calls[0][1]).toContain('anotherApp:someTask');
   });
 
-  it('uses multiple tasks', () => {
+  it('uses multiple tasks', async () => {
     // @ts-ignore
-    runOnAllDevices({
+    await runOnAllDevices({
       appFolder: 'app',
       tasks: ['clean', 'someTask'],
     });

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import path from 'path';
 import execa from 'execa';
 import chalk from 'chalk';
@@ -119,7 +118,7 @@ function getPackageNameWithSuffix(
 }
 
 // Builds the app and runs it on a connected emulator / device.
-function buildAndRun(args: Flags) {
+async function buildAndRun(args: Flags) {
   process.chdir(path.join(args.root, 'android'));
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
@@ -135,7 +134,6 @@ function buildAndRun(args: Flags) {
     args.appIdSuffix,
     packageName,
   );
-
   const adbPath = getAdbPath();
   if (args.deviceId) {
     return runOnSpecificDevice(
@@ -146,7 +144,7 @@ function buildAndRun(args: Flags) {
       adbPath,
     );
   } else {
-    return runOnAllDevices(
+    return await runOnAllDevices(
       args,
       cmd,
       packageNameWithSuffix,

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -118,7 +118,7 @@ function getPackageNameWithSuffix(
 }
 
 // Builds the app and runs it on a connected emulator / device.
-async function buildAndRun(args: Flags) {
+function buildAndRun(args: Flags) {
   process.chdir(path.join(args.root, 'android'));
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
@@ -144,7 +144,7 @@ async function buildAndRun(args: Flags) {
       adbPath,
     );
   } else {
-    return await runOnAllDevices(
+    return runOnAllDevices(
       args,
       cmd,
       packageNameWithSuffix,

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -47,7 +47,7 @@ async function runOnAllDevices(
         `Failed to launch emulator. Reason: ${chalk.dim(result.error || '')}.`,
       );
       logger.warn(
-        'Please launch an emulator manually or connect a device. Otherwise app launch may fail.',
+        'Please launch an emulator manually or connect a device. Otherwise app may fail to launch.',
       );
     }
   }

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -35,12 +35,13 @@ async function runOnAllDevices(
   packageName: string,
   adbPath: string,
 ) {
-  const devices = adb.getDevices(adbPath);
+  let devices = adb.getDevices(adbPath);
   if (devices.length === 0) {
     logger.info('Trying to launch emulator...');
     const result = await tryLaunchEmulator(adbPath);
     if (result.success) {
       logger.info('Emulator launched!');
+      devices = adb.getDevices(adbPath);
     } else {
       logger.error('Emulator launch failed.');
       if (result.error !== undefined) {

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -37,16 +37,15 @@ async function runOnAllDevices(
 ) {
   let devices = adb.getDevices(adbPath);
   if (devices.length === 0) {
-    logger.info('Trying to launch emulator...');
+    logger.info('Launching emulator...');
     const result = await tryLaunchEmulator(adbPath);
     if (result.success) {
-      logger.info('Emulator launched!');
+      logger.info('Successfully launched emulator.');
       devices = adb.getDevices(adbPath);
     } else {
-      logger.error('Emulator launch failed.');
-      if (result.error !== undefined) {
-        logger.error(result.error);
-      }
+      logger.error(
+        `Failed to launch emulator. Reason: ${chalk.dim(result.error || '')}.`,
+      );
       logger.warn(
         'Please launch an emulator manually or connect a device. Otherwise app launch may fail.',
       );

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -39,10 +39,16 @@ async function runOnAllDevices(
   if (devices.length === 0) {
     logger.info('Trying to launch emulator...');
     const result = await tryLaunchEmulator(adbPath);
-    if (result) {
-      logger.info('Emulator launch succeeded!');
+    if (result.success) {
+      logger.info('Emulator launched!');
     } else {
-      logger.warn('Emulator launch failed.');
+      logger.error('Emulator launch failed.');
+      if (result.error !== undefined) {
+        logger.error(result.error);
+      }
+      logger.warn(
+        'Please launch an emulator manually or connect a device. Otherwise app launch may fail.',
+      );
     }
   }
 

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -12,10 +12,16 @@ const getEmulators = () => {
 
 const launchEmulator = async (emulatorName: string, adbPath: string) => {
   return new Promise((resolve, reject) => {
-    const cp = execa('emulator', [`@${emulatorName}`], {
-      detached: true,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
+    const cp = execa(
+      process.env.ANDROID_HOME
+        ? `${process.env.ANDROID_HOME}/emulator/emulator`
+        : 'emulator',
+      [`@${emulatorName}`],
+      {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    );
 
     const timeout = 30;
 

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -1,9 +1,13 @@
 import execa from 'execa';
 import Adb from './adb';
 
+const emulatorCommand = process.env.ANDROID_HOME
+  ? `${process.env.ANDROID_HOME}/emulator/emulator`
+  : 'emulator';
+
 const getEmulators = () => {
   try {
-    const emulatorsOutput = execa.sync('emulator', ['-list-avds']).stdout;
+    const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
     return emulatorsOutput.split('\n').filter(name => name !== '');
   } catch {
     return [];
@@ -12,16 +16,10 @@ const getEmulators = () => {
 
 const launchEmulator = async (emulatorName: string, adbPath: string) => {
   return new Promise((resolve, reject) => {
-    const cp = execa(
-      process.env.ANDROID_HOME
-        ? `${process.env.ANDROID_HOME}/emulator/emulator`
-        : 'emulator',
-      [`@${emulatorName}`],
-      {
-        detached: true,
-        stdio: 'ignore',
-      },
-    );
+    const cp = execa(emulatorCommand, [`@${emulatorName}`], {
+      detached: true,
+      stdio: 'ignore',
+    });
     cp.unref();
     const timeout = 30;
 

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -1,9 +1,9 @@
-import {execFileSync, spawn} from 'child_process';
+import execa from 'execa';
 import Adb from './adb';
 
 const getEmulators = () => {
   try {
-    const emulatorsOutput = execFileSync('emulator', ['-list-avds']).toString();
+    const emulatorsOutput = execa.sync('emulator', ['-list-avds']).stdout;
     return emulatorsOutput.split('\n').filter(name => name !== '');
   } catch {
     return [];
@@ -12,50 +12,69 @@ const getEmulators = () => {
 
 const launchEmulator = async (emulatorName: string, adbPath: string) => {
   return new Promise((resolve, reject) => {
-    const cp = spawn('emulator', [`@${emulatorName}`], {
+    const cp = execa('emulator', [`@${emulatorName}`], {
       detached: true,
       stdio: ['ignore', 'pipe', 'ignore'],
     });
 
+    const timeout = 30;
+
     // Reject command after timeout
     const rejectTimeout = setTimeout(() => {
-      cp.stdout.destroy();
-      reject();
-    }, 30 * 1000);
+      cleanup();
+      reject(`Could not start emulator within ${timeout} seconds.`);
+    }, timeout * 1000);
 
     // When emulator is started from snapshot, it does not emit boot completed message.
-    // It starts immediately so we can check if device is present
-    setTimeout(() => {
+    // It starts immediately so we can check if device is present after some short delay
+    const snapshotStartTimeout = setTimeout(() => {
       if (Adb.getDevices(adbPath).length > 0) {
+        cleanup();
         resolve();
       }
     }, 5000);
 
+    const cleanup = () => {
+      clearTimeout(rejectTimeout);
+      clearTimeout(snapshotStartTimeout);
+      cp.stdout.destroy();
+    };
+
     cp.unref();
 
     cp.stdout.addListener('data', message => {
-      if (message.toString().indexOf('boot completed') >= 0) {
-        clearTimeout(rejectTimeout);
-        cp.stdout.destroy();
+      if (message.toString().includes('boot completed')) {
+        cleanup();
         resolve();
       }
     });
 
-    cp.on('close', () => {
-      reject();
+    cp.on('exit', () => {
+      cleanup();
+      reject('Emulator exited before boot.');
+    });
+
+    cp.on('error', error => {
+      cleanup();
+      reject(error.message);
     });
   });
 };
 
-export default async function tryLaunchEmulator(adbPath: string) {
+export default async function tryLaunchEmulator(
+  adbPath: string,
+): Promise<{success: boolean; error?: string}> {
   const emulators = getEmulators();
   if (emulators.length > 0) {
     try {
       await launchEmulator(emulators[0], adbPath);
-      return true;
-    } catch (e) {
-      console.log('Emulator error', e);
+      return {success: true};
+    } catch (error) {
+      return {success: false, error};
     }
   }
-  return false;
+  return {
+    success: false,
+    error: 'No emulators found as an output of `emulator -list-avds`',
+  };
 }

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -1,0 +1,61 @@
+import {execFileSync, spawn} from 'child_process';
+import Adb from './adb';
+
+const getEmulators = () => {
+  try {
+    const emulatorsOutput = execFileSync('emulator', ['-list-avds']).toString();
+    return emulatorsOutput.split('\n').filter(name => name !== '');
+  } catch {
+    return [];
+  }
+};
+
+const launchEmulator = async (emulatorName: string, adbPath: string) => {
+  return new Promise((resolve, reject) => {
+    const cp = spawn('emulator', [`@${emulatorName}`], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+
+    // Reject command after timeout
+    const rejectTimeout = setTimeout(() => {
+      cp.stdout.destroy();
+      reject();
+    }, 30 * 1000);
+
+    // When emulator is started from snapshot, it does not emit boot completed message.
+    // It starts immediately so we can check if device is present
+    setTimeout(() => {
+      if (Adb.getDevices(adbPath).length > 0) {
+        resolve();
+      }
+    }, 5000);
+
+    cp.unref();
+
+    cp.stdout.addListener('data', message => {
+      if (message.toString().indexOf('boot completed') >= 0) {
+        clearTimeout(rejectTimeout);
+        cp.stdout.destroy();
+        resolve();
+      }
+    });
+
+    cp.on('close', () => {
+      reject();
+    });
+  });
+};
+
+export default async function tryLaunchEmulator(adbPath: string) {
+  const emulators = getEmulators();
+  if (emulators.length > 0) {
+    try {
+      await launchEmulator(emulators[0], adbPath);
+      return true;
+    } catch (e) {
+      console.log('Emulator error', e);
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
Summary:
---------

This PR resolves #142
TLDR; 
During`react-native run-android` the  first of user's emulators will be launched if there is no any running android device/emulator

`emulator -list-advs` to get a list of emulators
`emulator @FIRST_ON_LIST` to run the first available emulator

Test Plan:
----------

* Generate a project with React-native >60.0
* install CLI from my fork
* run `react-native run-android` without launched emulator -> emulator is launching
* run `react-native run-android` with launched emulator -> nothing new happens
* run `react-native run-android` with device connected -> nothing new happens
* run `react-native run-android` without launched emulator, emulator has saved snapshot -> emulator is launching
