### PR TITLE
Warn user if pod install was not run

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.js
+++ b/packages/platform-ios/src/commands/runIOS/index.js
@@ -16,6 +16,7 @@ import findXcodeProject from './findXcodeProject';
 import parseIOSDevicesList from './parseIOSDevicesList';
 import findMatchingSimulator from './findMatchingSimulator';
 import warnAboutManuallyLinkedLibs from '../../link/warnAboutManuallyLinkedLibs';
+import warnAboutPodInstall from '../../link/warnAboutPodInstall';
 import {
   logger,
   CLIError,
@@ -43,6 +44,7 @@ function runIOS(_: Array<string>, ctx: ConfigT, args: FlagsT) {
   }
 
   warnAboutManuallyLinkedLibs(ctx);
+  warnAboutPodInstall(ctx);
 
   process.chdir(args.projectPath);
 

--- a/packages/platform-ios/src/link-pods/readPodfileLock.ts
+++ b/packages/platform-ios/src/link-pods/readPodfileLock.ts
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import {logger} from '@react-native-community/cli-tools';
+
+export default function readPodfileLock(podfileLockPath: string) {
+  logger.debug(`Reading ${podfileLockPath}`);
+  const podLockContent = fs.readFileSync(podfileLockPath, 'utf8');
+  return podLockContent.split(/\r?\n/g);
+}

--- a/packages/platform-ios/src/link/warnAboutPodInstall.ts
+++ b/packages/platform-ios/src/link/warnAboutPodInstall.ts
@@ -1,0 +1,42 @@
+import {logger} from '@react-native-community/cli-tools';
+import readPodfileLock from '../link-pods/readPodfileLock';
+// TODO: move to cli-tools once platform-ios and platform-android are migrated
+// to TS and unify with Android implementation
+export default function warnAboutPodInstall(config: any) {
+  let podLockContent;
+  try {
+    podLockContent = readPodfileLock(`${config.project.ios.podfile}.lock`);
+  } catch (err) {
+    logger.error('Could not find Podfile.lock, did you run pod `install`');
+    return;
+  }
+
+  const podLockDepsIndexStart = podLockContent.findIndex(
+    line => line === 'DEPENDENCIES:',
+  );
+  const podLockDepsIndexEnd =
+    podLockContent.slice(podLockDepsIndexStart).findIndex(line => line === '') +
+    podLockDepsIndexStart;
+
+  const podLockDeps = podLockContent
+    .slice(podLockDepsIndexStart + 1, podLockDepsIndexEnd)
+    .map(name => name.replace(/ {2}- "?/, '').replace(/ \(.*/, ''));
+
+  const podDeps = Object.keys(config.dependencies)
+    .map(depName =>
+      config.dependencies[depName].platforms.ios
+        ? config.dependencies[depName].platforms.ios.podspecPath
+            .replace(/.*\//, '')
+            .replace(/\.podspec/, '')
+        : '',
+    )
+    .filter(podDep => podDep !== '');
+
+  const missingPods = podDeps.filter(podDep => !podLockDeps.includes(podDep));
+
+  if (missingPods.length) {
+    logger.error(
+      `Could not find the following native modules [${missingPods}], did you forget to run \`pod install\` ?`,
+    );
+  }
+}


### PR DESCRIPTION
Summary:
---------

Let's detect if the user forgot to run pod install after installing a native library 😄 


Test Plan:
----------

yarn add some-library-with-ios-native-code

react-native run-ios will print an error message until you run pod install warning you that some-library-with-ios-native-code has not been found in the lockfile so it's probably not properly linked