### PR TITLE
doctor: fix missing `loader.fail()` call before showing how to fix manually on `ios-deploy`

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.js
@@ -51,7 +51,7 @@ export default ({
         (sdks !== 'Not Found' &&
           doesSoftwareNeedToBeFixed({
             version: sdks['Build Tools'][0],
-            versionRange: versionRanges.ANDROID_NDK,
+            versionRange: versionRanges.ANDROID_SDK,
           })),
     };
   },
@@ -63,11 +63,11 @@ export default ({
     environmentInfo: EnvironmentInfo,
   }) => {
     const version = environmentInfo.SDKs['Android SDK'][0];
-    const isNDKInstalled = version !== 'Not Found';
+    const isSDKInstalled = version !== 'Not Found';
 
     loader.fail();
 
-    if (isNDKInstalled) {
+    if (isSDKInstalled) {
       return logManualInstallation({
         message: installMessage,
       });

--- a/packages/cli/src/commands/doctor/healthchecks/common.js
+++ b/packages/cli/src/commands/doctor/healthchecks/common.js
@@ -22,13 +22,13 @@ const logManualInstallation = ({
 
   if (url) {
     return logMessage(
-      `Read more about how to download ${healthcheck} at ${chalk.dim(url)}`,
+      `Read more about how to download ${healthcheck} at ${chalk.bold(url)}`,
     );
   }
 
   if (command) {
     return logMessage(
-      `Please install ${healthcheck} by running ${chalk.dim(command)}`,
+      `Please install ${healthcheck} by running ${chalk.bold(command)}`,
     );
   }
 };

--- a/packages/cli/src/commands/doctor/healthchecks/common.js
+++ b/packages/cli/src/commands/doctor/healthchecks/common.js
@@ -22,7 +22,9 @@ const logManualInstallation = ({
 
   if (url) {
     return logMessage(
-      `Read more about how to download ${healthcheck} at ${chalk.bold(url)}`,
+      `Read more about how to download ${healthcheck} at ${chalk.dim.underline(
+        url,
+      )}`,
     );
   }
 

--- a/packages/cli/src/commands/doctor/healthchecks/iosDeploy.js
+++ b/packages/cli/src/commands/doctor/healthchecks/iosDeploy.js
@@ -49,6 +49,8 @@ export default ({
 
       loader.succeed();
     } catch (_error) {
+      loader.fail();
+
       logManualInstallation({
         healthcheck: 'ios-deploy',
         command: installationCommand,

--- a/packages/cli/src/commands/doctor/healthchecks/watchman.js
+++ b/packages/cli/src/commands/doctor/healthchecks/watchman.js
@@ -6,8 +6,10 @@ import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import {install} from '../../../tools/install';
 import type {EnvironmentInfo} from '../types';
 
+const label = 'Watchman';
+
 export default {
-  label: 'Watchman',
+  label,
   getDiagnostics: ({Binaries}: EnvironmentInfo) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Watchman.version,
@@ -15,9 +17,10 @@ export default {
     }),
   }),
   runAutomaticFix: async ({loader}: typeof Ora) =>
-    await install(
-      'watchman',
-      'https://facebook.github.io/watchman/docs/install.html',
+    await install({
+      pkg: 'watchman',
+      label,
+      source: 'https://facebook.github.io/watchman/docs/install.html',
       loader,
-    ),
+    }),
 };

--- a/packages/cli/src/tools/brewInstall.ts
+++ b/packages/cli/src/tools/brewInstall.ts
@@ -17,9 +17,9 @@ async function brewInstall({pkg, label, loader}: InstallArgs) {
     loader.succeed();
   } catch (error) {
     loader.fail();
-    logger.log(`\n${error.stderr}`);
+    logger.log(chalk.dim(`\n${error.stderr}`));
     logger.log(
-      `An error occured while trying to install ${pkg}. Please try again manually: ${chalk.dim(
+      `An error occured while trying to install ${pkg}. Please try again manually: ${chalk.bold(
         `brew install ${pkg}`,
       )}`,
     );

--- a/packages/cli/src/tools/brewInstall.ts
+++ b/packages/cli/src/tools/brewInstall.ts
@@ -1,16 +1,27 @@
 import {logger} from '@react-native-community/cli-tools';
 import execa from 'execa';
-import Ora from 'ora';
+import chalk from 'chalk';
+import ora from 'ora';
 
-async function brewInstall(pkg: string, loader: Ora.Ora) {
-  loader.start(`Installing ${pkg}`);
+type InstallArgs = {
+  pkg: string;
+  label?: string;
+  loader: ora.Ora;
+};
+
+async function brewInstall({pkg, label, loader}: InstallArgs) {
+  loader.start(label);
   try {
     await execa('brew', ['install', pkg]);
+
     loader.succeed();
   } catch (error) {
-    logger.log(error.stderr);
-    loader.fail(
-      `An error occured while trying to install ${pkg}. Please try again manually: brew install ${pkg}`,
+    loader.fail();
+    logger.log(`\n${error.stderr}`);
+    logger.log(
+      `An error occured while trying to install ${pkg}. Please try again manually: ${chalk.dim(
+        `brew install ${pkg}`,
+      )}`,
     );
   }
 }

--- a/packages/cli/src/tools/install.ts
+++ b/packages/cli/src/tools/install.ts
@@ -1,11 +1,18 @@
 import ora from 'ora';
 import {brewInstall} from './brewInstall';
 
-async function install(pkg: string, source: string, loader: ora.Ora) {
+type InstallArgs = {
+  pkg: string;
+  label: string;
+  source: string;
+  loader: ora.Ora;
+};
+
+async function install({pkg, label, source, loader}: InstallArgs) {
   try {
     switch (process.platform) {
       case 'darwin':
-        await brewInstall(pkg, loader);
+        await brewInstall({pkg, label, loader});
         break;
       default:
         throw new Error('Not implemented yet');

--- a/packages/cli/src/tools/installPods.ts
+++ b/packages/cli/src/tools/installPods.ts
@@ -87,7 +87,11 @@ async function installCocoaPods(loader: ora.Ora) {
       loader.succeed();
       break;
     case withHomebrew:
-      await brewInstall('cocoapods', loader);
+      await brewInstall({
+        pkg: 'cocoapods',
+        label: 'Installing CocoaPods',
+        loader,
+      });
       break;
   }
 }


### PR DESCRIPTION

Summary:
---------

This is part of the `react-native doctor` issue at #694.

It fixes a problem with the `ios-deploy` healthcheck throwing an error without actually putting a _final state_ in the loader, causing it to leak into the next healthcheck:

![before](https://user-images.githubusercontent.com/6207220/64596193-c0dfa600-d3b3-11e9-8c03-58f1662cc216.png)

It also changes some stuff regarding brew installation to keep consistency of what is being shown to the user (e.g. Watchman showing as `Installing watchman` after you choose fix and the others showing without `Installing` prefix).

<details>
  <summary>Before</summary>

  ![before](https://user-images.githubusercontent.com/6207220/64615533-08c5f380-d3db-11e9-904d-fa6f0944acc1.png)
</details>

<details>
  <summary>After</summary>

  ![after](https://user-images.githubusercontent.com/6207220/64615481-f0ee6f80-d3da-11e9-9ebb-191eadab2e37.png)
</details>
