### PR TITLE
Migrate doctor command to TypeScript

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
     "react-native": "^0.60.0"
   },
   "devDependencies": {
+    "@types/command-exists": "^1.2.0",
     "@types/graceful-fs": "^4.1.3",
     "@types/semver": "^6.0.2",
     "slash": "^3.0.0",

--- a/packages/cli/src/commands/doctor/checkInstallation.ts
+++ b/packages/cli/src/commands/doctor/checkInstallation.ts
@@ -1,4 +1,3 @@
-// @flow
 import semver from 'semver';
 import commandExists from 'command-exists';
 
@@ -21,11 +20,16 @@ const doesSoftwareNeedToBeFixed = ({
   version,
   versionRange,
 }: {
-  version: string,
-  versionRange: string,
-}) =>
-  (version === 'Not Found' ||
-    !semver.satisfies(semver.coerce(version), versionRange)) &&
-  `version ${versionRange} is required`;
+  version: string;
+  versionRange: string;
+}) => {
+  const coercedVersion = semver.coerce(version);
+  return (
+    (version === 'Not Found' ||
+      coercedVersion === null ||
+      !semver.satisfies(coercedVersion, versionRange)) &&
+    `version ${versionRange} is required`
+  );
+};
 
 export {PACKAGE_MANAGERS, checkSoftwareInstalled, doesSoftwareNeedToBeFixed};

--- a/packages/cli/src/commands/doctor/healthchecks/common.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/common.ts
@@ -1,9 +1,8 @@
-// @flow
 import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
 
 // Space is necessary to keep correct ordering on screen
-const logMessage = message => logger.log(`   ${message}`);
+const logMessage = (message: string) => logger.log(`   ${message}`);
 
 const logManualInstallation = ({
   healthcheck = '',
@@ -11,10 +10,10 @@ const logManualInstallation = ({
   command,
   message,
 }: {
-  healthcheck?: string,
-  url?: string,
-  command?: string,
-  message?: string,
+  healthcheck?: string;
+  url?: string;
+  command?: string;
+  message?: string;
 }) => {
   if (message) {
     return logMessage(message);

--- a/packages/cli/src/commands/doctor/printFixOptions.ts
+++ b/packages/cli/src/commands/doctor/printFixOptions.ts
@@ -1,4 +1,3 @@
-// @flow
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 
@@ -9,7 +8,7 @@ const KEYS = {
   EXIT: '\r',
 };
 
-const printOption = option => logger.log(` \u203A ${option}`);
+const printOption = (option: string) => logger.log(` \u203A ${option}`);
 const printOptions = () => {
   logger.log();
   logger.log(chalk.bold('Usage'));
@@ -30,11 +29,12 @@ const printOptions = () => {
 };
 
 export {KEYS};
-export default ({onKeyPress}: {onKeyPress: any}) => {
+export default ({onKeyPress}: {onKeyPress: (...args: any[]) => void}) => {
   printOptions();
 
-  // $FlowFixMe
-  process.stdin.setRawMode(true);
+  if (process.stdin.setRawMode) {
+    process.stdin.setRawMode(true);
+  }
   process.stdin.resume();
   process.stdin.setEncoding('utf8');
   process.stdin.on('data', onKeyPress);

--- a/packages/cli/src/commands/doctor/versionRanges.ts
+++ b/packages/cli/src/commands/doctor/versionRanges.ts
@@ -1,4 +1,3 @@
-// @flow
 export default {
   // Common
   NODE_JS: '>= 8.3',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,6 +2027,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/command-exists@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@types/command-exists/-/command-exists-1.2.0.tgz#d97e0ed10097090e4ab0367ed425b0312fad86f3"
+  integrity sha512-ugsxEJfsCuqMLSuCD4PIJkp5Uk2z6TCMRCgYVuhRo5cYQY3+1xXTQkSlPtkpGHuvWMjS2KTeVQXxkXRACMbM6A==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"


### PR DESCRIPTION
Summary:
---------

Migrate `packages/cli/src/commands/doctor` to TypeScript, with the exported type definitions in `cli-types`.

Related to #683 

Current progress:
-----------------

- [ ] `healthchecks/**`
- [ ] `doctor`
- [ ] `index`
- [x] `printFixOptions`
- [ ] `runAutomaticFix`
- [x] `versionRanges`


Test Plan:
----------

CI should be green