### PR TITLE
Handle name conflict for --version option

### DIFF
--- a/packages/cli/src/cliEntry.js
+++ b/packages/cli/src/cliEntry.js
@@ -189,7 +189,7 @@ async function setupAndRun() {
   // We handle --version as a special case like this because both `commander`
   // and `yargs` append it to every command and we don't want to do that.
   // E.g. outside command `init` has --version flag and we want to preserve it.
-  if (commander.args.length === 0 && commander.version === true) {
+  if (commander.args.length === 0 && commander.rawArgs.includes('--version')) {
     console.log(pkgJson.version);
   }
 


### PR DESCRIPTION
Summary:
---------

Fixes #711 

The global `--version` option wouldn't print anything. That's because the name `version` conflicts with the built-in commander method `commander.version()`. Therefore, when calling `commander.version`, it wouldn't understand that it should use our --version option.

Here's an issue on `commander` that explains the same issue: https://github.com/tj/commander.js/issues/1020

I have fixed this by checking if the raw arguments contain the `--version` argument. Even though sub-commands like `init` has a different `--version` parameter, this check is safe because of the existing check on `commander.args.length === 0`. The global `--version` option will only be used if no sub-command is used.

Test Plan:
----------

Before applying the changes, I ran `node packages/cli --version` and saw that it printed nothing.
After applying the changes, I ran the same command and saw that it returned the version stated in package.json.
