### PR TITLE
chore: Migrate doctor command to TypeScript (3)

### DIFF
--- a/packages/cli/src/commands/doctor/doctor.js
+++ b/packages/cli/src/commands/doctor/doctor.js
@@ -2,6 +2,7 @@
 import chalk from 'chalk';
 import envinfo from 'envinfo';
 import {logger} from '@react-native-community/cli-tools';
+// $FlowFixMe - converted to TS
 import {getHealthchecks, HEALTHCHECK_TYPES} from './healthchecks';
 // $FlowFixMe - converted to TS
 import {getLoader} from '../../tools/loader';

--- a/packages/cli/src/commands/doctor/healthchecks/androidNDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidNDK.ts
@@ -7,12 +7,16 @@ import {EnvironmentInfo, HealthCheckInterface} from '../types';
 
 export default {
   label: 'Android NDK',
-  getDiagnostics: async ({SDKs}: EnvironmentInfo) => ({
-    needsToBeFixed: doesSoftwareNeedToBeFixed({
-      version: SDKs['Android SDK']['Android NDK'],
-      versionRange: versionRanges.ANDROID_NDK,
-    }),
-  }),
+  getDiagnostics: async ({SDKs}: EnvironmentInfo) => {
+    const androidSdk = SDKs['Android SDK'];
+    return {
+      needsToBeFixed: doesSoftwareNeedToBeFixed({
+        version:
+          androidSdk === 'Not Found' ? 'Not Found' : androidSdk['Android NDK'],
+        versionRange: versionRanges.ANDROID_NDK,
+      }),
+    };
+  },
   runAutomaticFix: async ({
     loader,
     environmentInfo,
@@ -20,8 +24,9 @@ export default {
     loader: Ora;
     environmentInfo: EnvironmentInfo;
   }) => {
-    const version = environmentInfo.SDKs['Android SDK']['Android NDK'];
-    const isNDKInstalled = version !== 'Not Found';
+    const androidSdk = environmentInfo.SDKs['Android SDK'];
+    const isNDKInstalled =
+      androidSdk !== 'Not Found' && androidSdk['Android NDK'] !== 'Not Found';
 
     loader.fail();
 

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -1,22 +1,17 @@
-// @flow
 import chalk from 'chalk';
-import Ora from 'ora';
-// $FlowFixMe - converted to TS
 import {logManualInstallation} from './common';
-// $FlowFixMe - converted to TS
 import versionRanges from '../versionRanges';
-// $FlowFixMe - converted to TS
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import execa from 'execa';
-import type {EnvironmentInfo, HealthCheckInterface} from '../types';
+import {HealthCheckInterface} from '../types';
 
 const installMessage = `Read more about how to update Android SDK at ${chalk.dim(
   'https://developer.android.com/studio',
 )}`;
 
-export default ({
+export default {
   label: 'Android SDK',
-  getDiagnostics: async ({SDKs}: EnvironmentInfo) => {
+  getDiagnostics: async ({SDKs}) => {
     let sdks = SDKs['Android SDK'];
 
     // This is a workaround for envinfo's Android SDK check not working on
@@ -58,13 +53,7 @@ export default ({
           })),
     };
   },
-  runAutomaticFix: async ({
-    loader,
-    environmentInfo,
-  }: {
-    loader: typeof Ora,
-    environmentInfo: EnvironmentInfo,
-  }) => {
+  runAutomaticFix: async ({loader, environmentInfo}) => {
     const version = environmentInfo.SDKs['Android SDK'][0];
     const isSDKInstalled = version !== 'Not Found';
 
@@ -81,4 +70,4 @@ export default ({
       url: 'https://facebook.github.io/react-native/docs/getting-started',
     });
   },
-}: HealthCheckInterface);
+} as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -38,6 +38,9 @@ export default {
         if (matches.length > 0) {
           sdks = {
             'Build Tools': matches,
+            'API Levels': 'Not Found',
+            'Android NDK': 'Not Found',
+            'System Images': 'Not Found',
           };
         }
       } catch {}
@@ -54,7 +57,7 @@ export default {
     };
   },
   runAutomaticFix: async ({loader, environmentInfo}) => {
-    const version = environmentInfo.SDKs['Android SDK'][0];
+    const version = environmentInfo.SDKs['Android SDK'];
     const isSDKInstalled = version !== 'Not Found';
 
     loader.fail();

--- a/packages/cli/src/commands/doctor/healthchecks/index.js
+++ b/packages/cli/src/commands/doctor/healthchecks/index.js
@@ -2,6 +2,7 @@
 import nodeJS from './nodeJS';
 // $FlowFixMe - converted to TS
 import {yarn, npm} from './packageManagers';
+// $FlowFixMe - converted to TS
 import watchman from './watchman';
 // $FlowFixMe - converted to TS
 import androidHomeEnvVariable from './androidHomeEnvVariable';

--- a/packages/cli/src/commands/doctor/healthchecks/index.js
+++ b/packages/cli/src/commands/doctor/healthchecks/index.js
@@ -1,5 +1,6 @@
 // @flow
 import nodeJS from './nodeJS';
+// $FlowFixMe - converted to TS
 import {yarn, npm} from './packageManagers';
 import watchman from './watchman';
 // $FlowFixMe - converted to TS
@@ -7,9 +8,11 @@ import androidHomeEnvVariable from './androidHomeEnvVariable';
 import androidSDK from './androidSDK';
 // $FlowFixMe - converted to TS
 import androidNDK from './androidNDK';
+// $FlowFixMe - converted to TS
 import xcode from './xcode';
 // $FlowFixMe - converted to TS
 import cocoaPods from './cocoaPods';
+// $FlowFixMe - converted to TS
 import iosDeploy from './iosDeploy';
 
 export const HEALTHCHECK_TYPES = {

--- a/packages/cli/src/commands/doctor/healthchecks/index.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/index.ts
@@ -1,19 +1,11 @@
-// @flow
 import nodeJS from './nodeJS';
-// $FlowFixMe - converted to TS
 import {yarn, npm} from './packageManagers';
-// $FlowFixMe - converted to TS
 import watchman from './watchman';
-// $FlowFixMe - converted to TS
 import androidHomeEnvVariable from './androidHomeEnvVariable';
 import androidSDK from './androidSDK';
-// $FlowFixMe - converted to TS
 import androidNDK from './androidNDK';
-// $FlowFixMe - converted to TS
 import xcode from './xcode';
-// $FlowFixMe - converted to TS
 import cocoaPods from './cocoaPods';
-// $FlowFixMe - converted to TS
 import iosDeploy from './iosDeploy';
 
 export const HEALTHCHECK_TYPES = {
@@ -22,8 +14,8 @@ export const HEALTHCHECK_TYPES = {
 };
 
 type Options = {
-  fix: boolean | void,
-  contributor: boolean | void,
+  fix: boolean | void;
+  contributor: boolean | void;
 };
 
 export const getHealthchecks = ({contributor}: Options) => ({

--- a/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
@@ -1,12 +1,8 @@
-// @flow
 import execa from 'execa';
-import Ora from 'ora';
-// $FlowFixMe - converted to TS
 import {checkSoftwareInstalled, PACKAGE_MANAGERS} from '../checkInstallation';
 import {packageManager} from './packageManagers';
-// $FlowFixMe - converted to TS
 import {logManualInstallation} from './common';
-import type {HealthCheckInterface} from '../types';
+import {HealthCheckInterface} from '../types';
 
 const getInstallationCommand = () => {
   if (packageManager === PACKAGE_MANAGERS.YARN) {
@@ -20,13 +16,13 @@ const getInstallationCommand = () => {
   return undefined;
 };
 
-export default ({
+export default {
   label: 'ios-deploy',
   isRequired: false,
   getDiagnostics: async () => ({
     needsToBeFixed: await checkSoftwareInstalled('ios-deploy'),
   }),
-  runAutomaticFix: async ({loader}: {loader: typeof Ora}) => {
+  runAutomaticFix: async ({loader}) => {
     const installationCommand = getInstallationCommand();
 
     // This means that we couldn't "guess" the package manager
@@ -59,4 +55,4 @@ export default ({
       });
     }
   },
-}: HealthCheckInterface);
+} as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/nodeJS.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/nodeJS.ts
@@ -1,23 +1,18 @@
-// @flow
-import Ora from 'ora';
-// $FlowFixMe - converted to TS
 import versionRanges from '../versionRanges';
-// $FlowFixMe - converted to TS
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
-// $FlowFixMe - converted to TS
 import {logManualInstallation} from './common';
-import type {EnvironmentInfo, HealthCheckInterface} from '../types';
+import {HealthCheckInterface} from '../types';
 
-export default ({
+export default {
   label: 'Node.js',
-  getDiagnostics: async ({Binaries}: EnvironmentInfo) => ({
+  getDiagnostics: async ({Binaries}) => ({
     version: Binaries.Node.version,
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Node.version,
       versionRange: versionRanges.NODE_JS,
     }),
   }),
-  runAutomaticFix: async ({loader}: {loader: typeof Ora}) => {
+  runAutomaticFix: async ({loader}) => {
     loader.fail();
 
     logManualInstallation({
@@ -25,4 +20,4 @@ export default ({
       url: 'https://nodejs.org/en/download/',
     });
   },
-}: HealthCheckInterface);
+} as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/packageManagers.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/packageManagers.ts
@@ -1,16 +1,11 @@
-// @flow
 import fs from 'fs';
-import Ora from 'ora';
-// $FlowFixMe - converted to TS
 import versionRanges from '../versionRanges';
 import {
   PACKAGE_MANAGERS,
   doesSoftwareNeedToBeFixed,
-  // $FlowFixMe - converted to TS
 } from '../checkInstallation';
-// $FlowFixMe - converted to TS
 import {install} from '../../../tools/install';
-import type {EnvironmentInfo, HealthCheckInterface} from '../types';
+import {HealthCheckInterface} from '../types';
 
 const packageManager = (() => {
   if (fs.existsSync('yarn.lock')) {
@@ -26,7 +21,7 @@ const packageManager = (() => {
 
 const yarn: HealthCheckInterface = {
   label: 'yarn',
-  getDiagnostics: async ({Binaries}: EnvironmentInfo) => ({
+  getDiagnostics: async ({Binaries}) => ({
     version: Binaries.Node.version,
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Yarn.version,
@@ -37,13 +32,18 @@ const yarn: HealthCheckInterface = {
   // or if we can't identify that the user uses yarn or npm
   visible:
     packageManager === PACKAGE_MANAGERS.YARN || packageManager === undefined,
-  runAutomaticFix: async ({loader}: typeof Ora) =>
-    await install('yarn', 'https://yarnpkg.com/docs/install', loader),
+  runAutomaticFix: async ({loader}) =>
+    await install({
+      pkg: 'yarn',
+      label: 'yarn',
+      source: 'https://yarnpkg.com/docs/install',
+      loader,
+    }),
 };
 
 const npm: HealthCheckInterface = {
   label: 'npm',
-  getDiagnostics: async ({Binaries}: EnvironmentInfo) => ({
+  getDiagnostics: async ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.npm.version,
       versionRange: versionRanges.NPM,
@@ -53,8 +53,13 @@ const npm: HealthCheckInterface = {
   // or if we can't identify that the user uses yarn or npm
   visible:
     packageManager === PACKAGE_MANAGERS.NPM || packageManager === undefined,
-  runAutomaticFix: async ({loader}: typeof Ora) =>
-    await install('node', 'https://nodejs.org/', loader),
+  runAutomaticFix: async ({loader}) =>
+    await install({
+      pkg: 'node',
+      label: 'node',
+      source: 'https://nodejs.org/',
+      loader,
+    }),
 };
 
 export {packageManager, yarn, npm};

--- a/packages/cli/src/commands/doctor/healthchecks/watchman.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/watchman.ts
@@ -1,28 +1,23 @@
-// @flow
-import Ora from 'ora';
-// $FlowFixMe - converted to TS
 import versionRanges from '../versionRanges';
-// $FlowFixMe - converted to TS
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
-// $FlowFixMe - converted to TS
 import {install} from '../../../tools/install';
-import type {EnvironmentInfo} from '../types';
+import {HealthCheckInterface} from '../types';
 
 const label = 'Watchman';
 
 export default {
   label,
-  getDiagnostics: ({Binaries}: EnvironmentInfo) => ({
+  getDiagnostics: async ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Watchman.version,
       versionRange: versionRanges.WATCHMAN,
     }),
   }),
-  runAutomaticFix: async ({loader}: typeof Ora) =>
+  runAutomaticFix: async ({loader}) =>
     await install({
       pkg: 'watchman',
       label,
       source: 'https://facebook.github.io/watchman/docs/install.html',
       loader,
     }),
-};
+} as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/xcode.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/xcode.ts
@@ -1,22 +1,17 @@
-// @flow
-import Ora from 'ora';
-// $FlowFixMe - converted to TS
 import versionRanges from '../versionRanges';
-// $FlowFixMe - converted to TS
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
-// $FlowFixMe - converted to TS
 import {logManualInstallation} from './common';
-import type {EnvironmentInfo, HealthCheckInterface} from '../types';
+import {HealthCheckInterface} from '../types';
 
-export default ({
+export default {
   label: 'Xcode',
-  getDiagnostics: async ({IDEs}: EnvironmentInfo) => ({
+  getDiagnostics: async ({IDEs}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: IDEs.Xcode.version.split('/')[0],
       versionRange: versionRanges.XCODE,
     }),
   }),
-  runAutomaticFix: async ({loader}: {loader: typeof Ora}) => {
+  runAutomaticFix: async ({loader}) => {
     loader.info();
 
     logManualInstallation({
@@ -24,4 +19,4 @@ export default ({
       url: 'https://developer.apple.com/xcode/',
     });
   },
-}: HealthCheckInterface);
+} as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/runAutomaticFix.js
+++ b/packages/cli/src/commands/doctor/runAutomaticFix.js
@@ -2,6 +2,7 @@
 import chalk from 'chalk';
 import ora from 'ora';
 import {logger} from '@react-native-community/cli-tools';
+// $FlowFixMe - converted to TS
 import {HEALTHCHECK_TYPES} from './healthchecks';
 import type {EnvironmentInfo} from './types';
 

--- a/packages/cli/src/commands/doctor/types.ts
+++ b/packages/cli/src/commands/doctor/types.ts
@@ -32,12 +32,14 @@ export type EnvironmentInfo = {
     'iOS SDK': {
       Platforms: string[];
     };
-    'Android SDK': {
-      'API Levels': string[];
-      'Build Tools': string[];
-      'System Images': string[];
-      'Android NDK': string;
-    };
+    'Android SDK':
+      | {
+          'API Levels': string[] | 'Not Found';
+          'Build Tools': string[] | 'Not Found';
+          'System Images': string[] | 'Not Found';
+          'Android NDK': string | 'Not Found';
+        }
+      | 'Not Found';
   };
   IDEs: {
     'Android Studio': string;


### PR DESCRIPTION
Summary:
---------

Finish the healthchecks migration to TS, continuing the work from #712 and #716 (linked to #683):

* `androidSDK`
* `iosDeploy`
* `nodeJs`
* `packageManagers`
* `watchman`

Test Plan:
----------

- [x] CI is green ✅ 
- [ ] The changes made make sense