### PR TITLE
[doctor command] Add tests for androidHomeEnvVariable

### DIFF
--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -57,7 +57,7 @@ export default (async (_, __, options) => {
 
   loader.start('Running diagnostics...');
 
-  const environmentInfo = JSON.parse(await getEnvironmentInfo());
+  const environmentInfo = await getEnvironmentInfo();
 
   const iterateOverHealthChecks = async ({
     label,
@@ -117,10 +117,7 @@ export default (async (_, __, options) => {
   };
 
   healthchecksPerCategory.forEach((issueCategory, key) => {
-    printCategory({
-      ...issueCategory,
-      key,
-    });
+    printCategory({...issueCategory, key});
 
     issueCategory.healthchecks.forEach(healthcheck => {
       printIssue(healthcheck);

--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -1,6 +1,4 @@
 import chalk from 'chalk';
-// @ts-ignore
-import envinfo from 'envinfo';
 import {logger} from '@react-native-community/cli-tools';
 import {getHealthchecks, HEALTHCHECK_TYPES} from './healthchecks';
 import {getLoader} from '../../tools/loader';
@@ -12,6 +10,7 @@ import {
   HealthCheckCategoryResult,
   HealthCheckResult,
 } from './types';
+import getEnvironmentInfo from '../../tools/envinfo';
 
 const printCategory = ({label, key}: {label: string; key: number}) => {
   if (key > 0) {
@@ -58,18 +57,7 @@ export default (async (_, __, options) => {
 
   loader.start('Running diagnostics...');
 
-  const environmentInfo = JSON.parse(
-    await envinfo.run(
-      {
-        Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
-        IDEs: ['Xcode', 'Android Studio'],
-        SDKs: ['iOS SDK', 'Android SDK'],
-        npmPackages: ['react', 'react-native', '@react-native-community/cli'],
-        npmGlobalPackages: ['*react-native*'],
-      },
-      {json: true, showNotFound: true},
-    ),
-  );
+  const environmentInfo = JSON.parse(await getEnvironmentInfo());
 
   const iterateOverHealthChecks = async ({
     label,
@@ -106,8 +94,9 @@ export default (async (_, __, options) => {
     )).filter(healthcheck => healthcheck !== undefined) as HealthCheckResult[],
   });
 
-  // Remove all the categories that don't have any healthcheck with `needsToBeFixed`
-  // so they don't show when the user taps to fix encountered issues
+  // Remove all the categories that don't have any healthcheck with
+  // `needsToBeFixed` so they don't show when the user taps to fix encountered
+  // issues
   const removeFixedCategories = (categories: HealthCheckCategoryResult[]) =>
     categories.filter(category =>
       category.healthchecks.some(healthcheck => healthcheck.needsToBeFixed),
@@ -128,7 +117,10 @@ export default (async (_, __, options) => {
   };
 
   healthchecksPerCategory.forEach((issueCategory, key) => {
-    printCategory({...issueCategory, key});
+    printCategory({
+      ...issueCategory,
+      key,
+    });
 
     issueCategory.healthchecks.forEach(healthcheck => {
       printIssue(healthcheck);

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -1,6 +1,7 @@
 import androidHomeEnvVariables from '../androidHomeEnvVariable';
 import getEnvironmentInfo from '../../../../tools/envinfo';
 import {EnvironmentInfo} from '../../types';
+import {NoopLoader} from '../../../../tools/loader';
 
 jest.mock('../common');
 
@@ -34,9 +35,7 @@ describe('androidHomeEnvVariables', () => {
   });
 
   it('logs manual installation steps to the screen', async () => {
-    const loader: any = {
-      info: jest.fn(),
-    };
+    const loader = new NoopLoader();
 
     const environmentInfo: EnvironmentInfo = JSON.parse(
       await getEnvironmentInfo(),

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -1,0 +1,56 @@
+import androidHomeEnvVariables from '../androidHomeEnvVariable';
+import getEnvironmentInfo from '../../../../tools/envinfo';
+import {EnvironmentInfo} from '../../types';
+import {Ora} from 'ora';
+
+jest.mock('../common');
+
+import {logManualInstallation} from '../common';
+
+describe('androidHomeEnvVariables', () => {
+  const OLD_ENV = process.env;
+
+  it('returns a message if no ANDROID_HOME is defined', async () => {
+    delete process.env.ANDROID_HOME;
+
+    const environmentInfo: EnvironmentInfo = JSON.parse(
+      await getEnvironmentInfo(),
+    );
+    const diagnostics = await androidHomeEnvVariables.getDiagnostics(
+      environmentInfo,
+    );
+    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+  });
+
+  it('returns false if ANDROID_HOME is defined', async () => {
+    process.env.ANDROID_HOME = '/fake/path/to/android/home';
+
+    const environmentInfo: EnvironmentInfo = JSON.parse(
+      await getEnvironmentInfo(),
+    );
+    const diagnostics = await androidHomeEnvVariables.getDiagnostics(
+      environmentInfo,
+    );
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
+  it('logs manual installation steps to the screen', async () => {
+    // @ts-ignore
+    const loader: Ora = {
+      info: jest.fn(),
+    };
+
+    const environmentInfo: EnvironmentInfo = JSON.parse(
+      await getEnvironmentInfo(),
+    );
+
+    androidHomeEnvVariables.runAutomaticFix({loader, environmentInfo});
+
+    expect(logManualInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.resetAllMocks();
+  });
+});

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -3,19 +3,22 @@ import getEnvironmentInfo from '../../../../tools/envinfo';
 import {EnvironmentInfo} from '../../types';
 import {NoopLoader} from '../../../../tools/loader';
 
-jest.mock('../common');
+import * as common from '../common';
 
-import {logManualInstallation} from '../common';
+const logSpy = jest.spyOn(common, 'logManualInstallation');
 
 describe('androidHomeEnvVariables', () => {
   const OLD_ENV = process.env;
 
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.resetAllMocks();
+  });
+
   it('returns a message if no ANDROID_HOME is defined', async () => {
     delete process.env.ANDROID_HOME;
 
-    const environmentInfo: EnvironmentInfo = JSON.parse(
-      await getEnvironmentInfo(),
-    );
+    const environmentInfo: EnvironmentInfo = await getEnvironmentInfo();
     const diagnostics = await androidHomeEnvVariables.getDiagnostics(
       environmentInfo,
     );
@@ -25,9 +28,7 @@ describe('androidHomeEnvVariables', () => {
   it('returns false if ANDROID_HOME is defined', async () => {
     process.env.ANDROID_HOME = '/fake/path/to/android/home';
 
-    const environmentInfo: EnvironmentInfo = JSON.parse(
-      await getEnvironmentInfo(),
-    );
+    const environmentInfo: EnvironmentInfo = await getEnvironmentInfo();
     const diagnostics = await androidHomeEnvVariables.getDiagnostics(
       environmentInfo,
     );
@@ -37,17 +38,10 @@ describe('androidHomeEnvVariables', () => {
   it('logs manual installation steps to the screen', async () => {
     const loader = new NoopLoader();
 
-    const environmentInfo: EnvironmentInfo = JSON.parse(
-      await getEnvironmentInfo(),
-    );
+    const environmentInfo: EnvironmentInfo = await getEnvironmentInfo();
 
     androidHomeEnvVariables.runAutomaticFix({loader, environmentInfo});
 
-    expect(logManualInstallation).toHaveBeenCalledTimes(1);
-  });
-
-  afterEach(() => {
-    process.env = OLD_ENV;
-    jest.resetAllMocks();
+    expect(logSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -1,7 +1,6 @@
 import androidHomeEnvVariables from '../androidHomeEnvVariable';
 import getEnvironmentInfo from '../../../../tools/envinfo';
 import {EnvironmentInfo} from '../../types';
-import {Ora} from 'ora';
 
 jest.mock('../common');
 
@@ -35,8 +34,7 @@ describe('androidHomeEnvVariables', () => {
   });
 
   it('logs manual installation steps to the screen', async () => {
-    // @ts-ignore
-    const loader: Ora = {
+    const loader: any = {
       info: jest.fn(),
     };
 

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -1,6 +1,5 @@
 import androidHomeEnvVariables from '../androidHomeEnvVariable';
 import getEnvironmentInfo from '../../../../tools/envinfo';
-import {EnvironmentInfo} from '../../types';
 import {NoopLoader} from '../../../../tools/loader';
 
 import * as common from '../common';
@@ -18,7 +17,7 @@ describe('androidHomeEnvVariables', () => {
   it('returns a message if no ANDROID_HOME is defined', async () => {
     delete process.env.ANDROID_HOME;
 
-    const environmentInfo: EnvironmentInfo = await getEnvironmentInfo();
+    const environmentInfo = await getEnvironmentInfo();
     const diagnostics = await androidHomeEnvVariables.getDiagnostics(
       environmentInfo,
     );
@@ -28,7 +27,7 @@ describe('androidHomeEnvVariables', () => {
   it('returns false if ANDROID_HOME is defined', async () => {
     process.env.ANDROID_HOME = '/fake/path/to/android/home';
 
-    const environmentInfo: EnvironmentInfo = await getEnvironmentInfo();
+    const environmentInfo = await getEnvironmentInfo();
     const diagnostics = await androidHomeEnvVariables.getDiagnostics(
       environmentInfo,
     );
@@ -38,7 +37,7 @@ describe('androidHomeEnvVariables', () => {
   it('logs manual installation steps to the screen', async () => {
     const loader = new NoopLoader();
 
-    const environmentInfo: EnvironmentInfo = await getEnvironmentInfo();
+    const environmentInfo = await getEnvironmentInfo();
 
     androidHomeEnvVariables.runAutomaticFix({loader, environmentInfo});
 

--- a/packages/cli/src/commands/info/info.ts
+++ b/packages/cli/src/commands/info/info.ts
@@ -5,23 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// @ts-ignore untyped
-import envinfo from 'envinfo';
 import {logger} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
 import releaseChecker from '../../tools/releaseChecker';
+import getEnvironmentInfo from '../../tools/envinfo';
 
 const info = async function getInfo(_argv: Array<string>, ctx: Config) {
   try {
     logger.info('Fetching system and libraries information...');
-    const output = await envinfo.run({
-      System: ['OS', 'CPU', 'Memory', 'Shell'],
-      Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
-      IDEs: ['Xcode', 'Android Studio'],
-      SDKs: ['iOS SDK', 'Android SDK'],
-      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
-      npmGlobalPackages: '*react-native*',
-    });
+    const output = await getEnvironmentInfo();
     logger.log(output.trim());
   } catch (err) {
     logger.error(`Unable to print environment info.\n${err}`);

--- a/packages/cli/src/commands/info/info.ts
+++ b/packages/cli/src/commands/info/info.ts
@@ -5,15 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// @ts-ignore untyped
+import envinfo from 'envinfo';
 import {logger} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
 import releaseChecker from '../../tools/releaseChecker';
-import getEnvironmentInfo from '../../tools/envinfo';
 
 const info = async function getInfo(_argv: Array<string>, ctx: Config) {
   try {
     logger.info('Fetching system and libraries information...');
-    const output = await getEnvironmentInfo();
+    const output = await envinfo.run({
+      System: ['OS', 'CPU', 'Memory', 'Shell'],
+      Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
+      IDEs: ['Xcode', 'Android Studio'],
+      SDKs: ['iOS SDK', 'Android SDK'],
+      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
+      npmGlobalPackages: '*react-native*',
+    });
     logger.log(output.trim());
   } catch (err) {
     logger.error(`Unable to print environment info.\n${err}`);

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -4,6 +4,7 @@ import envinfo from 'envinfo';
 export default async function getEnvironmentInfo() {
   return envinfo.run(
     {
+      System: ['OS', 'CPU', 'Memory', 'Shell'],
       Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
       IDEs: ['Xcode', 'Android Studio'],
       SDKs: ['iOS SDK', 'Android SDK'],

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -2,17 +2,19 @@
 import envinfo from 'envinfo';
 
 export default async function getEnvironmentInfo() {
-  return envinfo.run(
-    {
-      Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
-      IDEs: ['Xcode', 'Android Studio'],
-      SDKs: ['iOS SDK', 'Android SDK'],
-      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
-      npmGlobalPackages: ['*react-native*'],
-    },
-    {
-      json: true,
-      showNotFound: true,
-    },
+  return JSON.parse(
+    await envinfo.run(
+      {
+        Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
+        IDEs: ['Xcode', 'Android Studio'],
+        SDKs: ['iOS SDK', 'Android SDK'],
+        npmPackages: ['react', 'react-native', '@react-native-community/cli'],
+        npmGlobalPackages: ['*react-native*'],
+      },
+      {
+        json: true,
+        showNotFound: true,
+      },
+    ),
   );
 }

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -4,7 +4,6 @@ import envinfo from 'envinfo';
 export default async function getEnvironmentInfo() {
   return envinfo.run(
     {
-      System: ['OS', 'CPU', 'Memory', 'Shell'],
       Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
       IDEs: ['Xcode', 'Android Studio'],
       SDKs: ['iOS SDK', 'Android SDK'],

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import envinfo from 'envinfo';
+import {EnvironmentInfo} from '../commands/doctor/types';
 
 export default async function getEnvironmentInfo() {
   return JSON.parse(
@@ -16,5 +17,5 @@ export default async function getEnvironmentInfo() {
         showNotFound: true,
       },
     ),
-  );
+  ) as EnvironmentInfo;
 }

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -1,0 +1,18 @@
+// @ts-ignore
+import envinfo from 'envinfo';
+
+export default async function getEnvironmentInfo() {
+  return envinfo.run(
+    {
+      Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
+      IDEs: ['Xcode', 'Android Studio'],
+      SDKs: ['iOS SDK', 'Android SDK'],
+      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
+      npmGlobalPackages: ['*react-native*'],
+    },
+    {
+      json: true,
+      showNotFound: true,
+    },
+  );
+}


### PR DESCRIPTION
Summary:
---------

Started writing tests for the `doctor` healthchecks, starting with `androidHomeEnvVariable`.

Since I needed the `envinfo` output in the test, and I will need it in all the upcomming tests, I moved it to the `tools` folder. Maybe it's not the best place, I'm not sure.

I only wrote one test to have feedback about the way of writing them, feel free to comment.

IMHO since these are unit tests we should mock all the imports and just make sure we call them when expected.
I didn't test the hard-coded SO links because it seems like a detail that wasn't worth testing.

Related to #694

Test Plan:
----------

This is a test so... CI is green? ✅ 