### PR TITLE
doctor: only show fix options if there are errors or warnings

### DIFF
--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -194,5 +194,7 @@ export default (async (_, __, options) => {
     }
   };
 
-  printFixOptions({onKeyPress});
+  if (stats.errors || stats.warnings) {
+    printFixOptions({onKeyPress});
+  }
 }) as CommandFunction<FlagsT>;


### PR DESCRIPTION
Summary:
---------

This PR is related to #694, currently the usage section shows even if you have everything correct when running `doctor`, with this change this will no longer happen.

Test Plan:
----------

1. `path/to/cli doctor --fix` (make sure that everything is green)
1. `path/to/cli doctor` - no usage should show up and the process should be terminated successfully