### PR TITLE
Update run instructions to use projectDir

### DIFF
--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -26,14 +26,14 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
   logger.log(`
   ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-    • cd ${projectName} && react-native run-ios
+    • cd ${projectDir} && react-native run-ios
     ${chalk.dim('- or -')}
     • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
     • Hit the Run button
 
   ${chalk.green(`Run instructions for ${chalk.bold('Android')}`)}:
     • Have an Android emulator running (quickest way to get started), or a device connected.
-    • cd ${projectName} && react-native run-android
+    • cd ${projectDir} && react-native run-android
 `);
 }
 


### PR DESCRIPTION

Summary:
---------

Run instructions use projectName
Updated to use projectDir to display correct instruction when using the --direction option


