### PR TITLE
fix: find node_modules at relative root

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -183,7 +183,7 @@ class ReactNativeModules {
 
     def cmdProcess
     def root = getReactNativeProjectRoot()
-    def command = "node ./node_modules/react-native/cli.js config"
+    def command = "node ${root.toString()}/node_modules/react-native/cli.js config"
     def reactNativeConfigOutput = ""
 
     try {


### PR DESCRIPTION
Summary:
---------
For monorepo apps with custom folder structure (where android folder is not in the same root folder as node_modules) building fails with error: `Text must not be null or empty`.

Test Plan:
----------
To replicate the issue:
- create a new project using the react-native cli tool.
- create a new dir called `app`
- move `android` to `app`
- change all references to node_modules in android build gradle files `../../node_modules` instead of `../node_modules`
- Try building the project for Android
- Watch it fail

With this fix, the build will work no matter what the structure of folders and relative position of the `android` folder to `node_modules` is.