### PR TITLE
chore: update ws dependency to version without security vulnerability

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -62,7 +62,7 @@
     "strip-ansi": "^5.2.0",
     "sudo-prompt": "^9.0.0",
     "wcwidth": "^1.0.1",
-    "ws": "^1.1.0"
+    "ws": "^3.3.3"
   },
   "peerDependencies": {
     "react-native": "^0.60.0"

--- a/packages/global-cli/package.json
+++ b/packages/global-cli/package.json
@@ -11,9 +11,6 @@
     "type": "git",
     "url": "https://github.com/react-native-community/react-native-cli.git"
   },
-  "scripts": {
-    "test": "mocha"
-  },
   "bin": {
     "react-native": "index.js"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9051,6 +9051,11 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
+  integrity sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==
+
 umask@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/umask/-/umask-1.1.0.tgz#f29cebf01df517912bb58ff9c4e50fde8e33320d"
@@ -9414,12 +9419,21 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^1.1.0, ws@^1.1.5:
+ws@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-1.1.5.tgz#cbd9e6e75e09fc5d2c90015f21f0c40875e0dd51"
   dependencies:
     options ">=0.0.5"
     ultron "1.0.x"
+
+ws@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-3.3.3.tgz#f1cf84fe2d5e901ebce94efaece785f187a228f2"
+  integrity sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==
+  dependencies:
+    async-limiter "~1.0.0"
+    safe-buffer "~5.1.0"
+    ultron "~1.1.0"
 
 ws@^5.2.0:
   version "5.2.2"


### PR DESCRIPTION
Summary:
---------

github was warning me about the transitive 'ws' dependency brought in from the cli package - it has a security vulnerability apparently.

This PR updates the dependency to one after the vulnerability was fixed. There is still some other part of the dependency chain that requires a vulnerable version - if you ask `yarn why ws` in the monorepo root, it looks like metro is bringing it in?

In general the dependencies are pretty out of date here but I'm not confident in my testing skills on this repo so I just updated this one, and not to current.

There is a separate unrelated change - I expected to just run 'npx lerna run test' and have it work (it's a reflex of mine) but it failed because one project defined it as a script, using mocha, but there were no tests defined. So I just removed that script and now even though `npx lerna run test` is a no-op, it doesn't fail.

Test Plan:
----------

I made the change in packages/cli/package.json (note: not all the way to ws@^7 as that did not seem to work, but to the ti pof ws@^3 (which is 3.3.3) was fine)

I ran `npx lerna bootstrap` in cli root

I  followed directions here https://github.com/react-native-community/cli/blob/master/CONTRIBUTING.md#running-start-command and ran `REACT_NATIVE_APP_ROOT=/home/mike/work/react-random/cli/  node /home/mike/work/react-random/cli/packages/cli/build/index.js start` and it seemed to work?

As mentioned above, I'm not very confident in my testing skills here. It seemed to work for me and I hope I didn't break anything.