### PR TITLE
propagate react-native config error stream to logs

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -188,7 +188,7 @@ class ReactNativeModules {
 
     try {
       cmdProcess = Runtime.getRuntime().exec(command, null, root)
-      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getOutputStream()))
+      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
       def buff = ""
       def readBuffer = new StringBuffer()
       while ((buff = bufferedReader.readLine()) != null){
@@ -198,6 +198,15 @@ class ReactNativeModules {
     } catch (Exception exception) {
       this.logger.warn("${LOG_PREFIX}${exception.message}")
       this.logger.warn("${LOG_PREFIX}Automatic import of native modules failed.")
+
+      def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
+      def buff = ""
+      def readBuffer = new StringBuffer()
+      while ((buff = bufferedErrorReader.readLine()) != null){
+          readBuffer.append(buff)
+      }
+      this.logger.warn("${LOG_PREFIX}${readBuffer.toString()}")
+
       return reactNativeModules
     }
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -188,7 +188,7 @@ class ReactNativeModules {
 
     try {
       cmdProcess = Runtime.getRuntime().exec(command, null, root)
-      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
+      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getOutputStream()))
       def buff = ""
       def readBuffer = new StringBuffer()
       while ((buff = bufferedReader.readLine()) != null){


### PR DESCRIPTION
Use output of subprocess in gradle file instead of input

Summary:
---------

See https://github.com/react-native-community/cli/issues/740.


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Android Studio synchronizes.
