### PR TITLE
[doctor command] Add tests for androidSDK and androidNDK

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
@@ -1,0 +1,66 @@
+import androidNDK from '../androidNDK';
+import getEnvironmentInfo from '../../../../tools/envinfo';
+import {EnvironmentInfo} from '../../types';
+import {NoopLoader} from '../../../../tools/loader';
+
+import * as common from '../common';
+
+const logSpy = jest.spyOn(common, 'logManualInstallation');
+
+describe('androidHomeEnvVariables', () => {
+  let initialEnvironmentInfo: EnvironmentInfo;
+  let environmentInfo: EnvironmentInfo;
+
+  beforeAll(async () => {
+    initialEnvironmentInfo = await getEnvironmentInfo();
+  });
+
+  beforeEach(() => {
+    environmentInfo = initialEnvironmentInfo;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns a message if the Android SDK is not installed', async () => {
+    environmentInfo.SDKs['Android SDK'] = 'Not Found';
+    const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
+    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+  });
+
+  it('returns a message if the Android NDK is not installed', async () => {
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Android NDK': 'Not Found',
+    };
+    const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
+    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+  });
+
+  it('returns a message if the NDK version is not in range', async () => {
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Android NDK': '18',
+    };
+    const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
+    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+  });
+
+  it('returns false if the NDK version is in range', async () => {
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Android NDK': '19',
+    };
+    const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
+  it('logs manual installation steps to the screen', async () => {
+    const loader = new NoopLoader();
+
+    androidNDK.runAutomaticFix({loader, environmentInfo});
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
@@ -7,7 +7,7 @@ import * as common from '../common';
 
 const logSpy = jest.spyOn(common, 'logManualInstallation');
 
-describe('androidHomeEnvVariables', () => {
+describe('androidNDK', () => {
   let initialEnvironmentInfo: EnvironmentInfo;
   let environmentInfo: EnvironmentInfo;
 
@@ -56,7 +56,7 @@ describe('androidHomeEnvVariables', () => {
     expect(diagnostics.needsToBeFixed).toBe(false);
   });
 
-  it('logs manual installation steps to the screen', async () => {
+  it('logs manual installation steps to the screen', () => {
     const loader = new NoopLoader();
 
     androidNDK.runAutomaticFix({loader, environmentInfo});

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
@@ -30,6 +30,7 @@ describe('androidNDK', () => {
   });
 
   it('returns a message if the Android NDK is not installed', async () => {
+    // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
       'Android NDK': 'Not Found',
@@ -39,6 +40,7 @@ describe('androidNDK', () => {
   });
 
   it('returns a message if the NDK version is not in range', async () => {
+    // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
       'Android NDK': '18',
@@ -48,6 +50,7 @@ describe('androidNDK', () => {
   });
 
   it('returns false if the NDK version is in range', async () => {
+    // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
       'Android NDK': '19',

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
@@ -26,7 +26,7 @@ describe('androidNDK', () => {
   it('returns a message if the Android SDK is not installed', async () => {
     environmentInfo.SDKs['Android SDK'] = 'Not Found';
     const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
-    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns a message if the Android NDK is not installed', async () => {
@@ -35,7 +35,7 @@ describe('androidNDK', () => {
       'Android NDK': 'Not Found',
     };
     const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
-    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns a message if the NDK version is not in range', async () => {
@@ -44,7 +44,7 @@ describe('androidNDK', () => {
       'Android NDK': '18',
     };
     const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
-    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns false if the NDK version is in range', async () => {

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -13,7 +13,7 @@ const mockExeca = (stdout: string) => {
   ((execa as unknown) as jest.Mock).mockResolvedValue({stdout});
 };
 
-describe('androidHomeEnvVariables', () => {
+describe('androidSDK', () => {
   let initialEnvironmentInfo: EnvironmentInfo;
   let environmentInfo: EnvironmentInfo;
 
@@ -56,7 +56,7 @@ describe('androidHomeEnvVariables', () => {
     expect(diagnostics.needsToBeFixed).toBe(false);
   });
 
-  it('logs manual installation steps to the screen', async () => {
+  it('logs manual installation steps to the screen', () => {
     const loader = new NoopLoader();
     androidSDK.runAutomaticFix({loader, environmentInfo});
     expect(logSpy).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -1,0 +1,57 @@
+import androidSDK from '../androidSDK';
+import getEnvironmentInfo from '../../../../tools/envinfo';
+import {EnvironmentInfo} from '../../types';
+import {NoopLoader} from '../../../../tools/loader';
+
+import * as common from '../common';
+
+const logSpy = jest.spyOn(common, 'logManualInstallation');
+
+describe('androidHomeEnvVariables', () => {
+  let initialEnvironmentInfo: EnvironmentInfo;
+  let environmentInfo: EnvironmentInfo;
+
+  beforeAll(async () => {
+    initialEnvironmentInfo = await getEnvironmentInfo();
+  });
+
+  beforeEach(() => {
+    environmentInfo = initialEnvironmentInfo;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns a message if the Android SDK is not installed', async () => {
+    environmentInfo.SDKs['Android SDK'] = 'Not Found';
+    const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
+    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+  });
+
+  it('returns a message if the SDK version is not in range', async () => {
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Build Tools': [25],
+    };
+    const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
+    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+  });
+
+  it('returns false if the SDK version is in range', async () => {
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Build Tools': ['27.0'],
+    };
+    const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
+  it('logs manual installation steps to the screen', async () => {
+    const loader = new NoopLoader();
+
+    androidSDK.runAutomaticFix({loader, environmentInfo});
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -33,7 +33,7 @@ describe('androidSDK', () => {
     environmentInfo.SDKs['Android SDK'] = 'Not Found';
     mockExeca('');
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
-    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns a message if the SDK version is not in range', async () => {
@@ -43,7 +43,7 @@ describe('androidSDK', () => {
     };
     mockExeca('build-tools;25.0');
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
-    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns false if the SDK version is in range', async () => {

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -26,6 +26,13 @@ describe('androidHomeEnvVariables', () => {
   it('returns a message if the Android SDK is not installed', async () => {
     environmentInfo.SDKs['Android SDK'] = 'Not Found';
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
+
+    jest.mock('execa', () => ({
+      default: () => {
+        throw new Error('No SDK found');
+      },
+    }));
+
     expect(typeof diagnostics.needsToBeFixed).toBe('string');
   });
 
@@ -34,6 +41,13 @@ describe('androidHomeEnvVariables', () => {
     environmentInfo.SDKs['Android SDK'] = {
       'Build Tools': [25],
     };
+
+    jest.mock('execa', () => ({
+      default: () => {
+        return 'build-tools;25';
+      },
+    }));
+
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(typeof diagnostics.needsToBeFixed).toBe('string');
   });
@@ -43,6 +57,13 @@ describe('androidHomeEnvVariables', () => {
     environmentInfo.SDKs['Android SDK'] = {
       'Build Tools': ['27.0'],
     };
+
+    jest.mock('execa', () => ({
+      default: () => {
+        return 'build-tools;27';
+      },
+    }));
+
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(false);
   });

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -8,10 +8,7 @@ import * as common from '../common';
 
 const logSpy = jest.spyOn(common, 'logManualInstallation');
 
-const mockExeca = (stdout: string) => {
-  jest.mock('execa', () => jest.fn());
-  ((execa as unknown) as jest.Mock).mockResolvedValue({stdout});
-};
+jest.mock('execa', () => jest.fn());
 
 describe('androidSDK', () => {
   let initialEnvironmentInfo: EnvironmentInfo;
@@ -31,7 +28,7 @@ describe('androidSDK', () => {
 
   it('returns a message if the Android SDK is not installed', async () => {
     environmentInfo.SDKs['Android SDK'] = 'Not Found';
-    mockExeca('');
+    ((execa as unknown) as jest.Mock).mockResolvedValue({stdout: ''});
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
@@ -42,7 +39,9 @@ describe('androidSDK', () => {
     environmentInfo.SDKs['Android SDK'] = {
       'Build Tools': [25],
     };
-    mockExeca('build-tools;25.0');
+    ((execa as unknown) as jest.Mock).mockResolvedValue({
+      stdout: 'build-tools;25.0',
+    });
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
@@ -53,7 +52,9 @@ describe('androidSDK', () => {
     environmentInfo.SDKs['Android SDK'] = {
       'Build Tools': ['26.0'],
     };
-    mockExeca('build-tools;26.0');
+    ((execa as unknown) as jest.Mock).mockResolvedValue({
+      stdout: 'build-tools;26.0',
+    });
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(false);
   });

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -37,6 +37,7 @@ describe('androidSDK', () => {
   });
 
   it('returns a message if the SDK version is not in range', async () => {
+    // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
       'Build Tools': [25],
@@ -47,6 +48,7 @@ describe('androidSDK', () => {
   });
 
   it('returns false if the SDK version is in range', async () => {
+    // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
       'Build Tools': ['26.0'],

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -19,7 +19,6 @@ export default {
     // See the PR: https://github.com/tabrindle/envinfo/pull/119
     if (sdks === 'Not Found' && process.platform !== 'darwin') {
       try {
-        // $FlowFixMe bad execa types
         const {stdout} = await execa(
           process.env.ANDROID_HOME
             ? `${process.env.ANDROID_HOME}/tools/bin/sdkmanager`


### PR DESCRIPTION
Summary:
---------

Add unit tests for the healthchecks for `androidSDK` and `androidNDK`

Also removed a `$FlowFixMe` that wasn't removed when the `androidSDK` file was moved to TS.

Related to #694 


Test Plan:
----------

CI is green