### PR TITLE
doctor: add health check description field

### DIFF
--- a/packages/cli/src/commands/doctor/checkInstallation.ts
+++ b/packages/cli/src/commands/doctor/checkInstallation.ts
@@ -6,13 +6,13 @@ export enum PACKAGE_MANAGERS {
   NPM = 'NPM',
 }
 
-const checkSoftwareInstalled = async (command: string) => {
+const isSoftwareNotInstalled = async (command: string): Promise<boolean> => {
   try {
     await commandExists(command);
 
     return false;
   } catch (_ignored) {
-    return 'should be installed';
+    return true;
   }
 };
 
@@ -22,14 +22,14 @@ const doesSoftwareNeedToBeFixed = ({
 }: {
   version: string;
   versionRange: string;
-}) => {
+}): boolean => {
   const coercedVersion = semver.coerce(version);
+
   return (
-    (version === 'Not Found' ||
-      coercedVersion === null ||
-      !semver.satisfies(coercedVersion, versionRange)) &&
-    `version ${versionRange} is required`
+    version === 'Not Found' ||
+    coercedVersion === null ||
+    !semver.satisfies(coercedVersion, versionRange)
   );
 };
 
-export {checkSoftwareInstalled, doesSoftwareNeedToBeFixed};
+export {isSoftwareNotInstalled, doesSoftwareNeedToBeFixed};

--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -81,7 +81,7 @@ export default (async (_, __, options) => {
         return {
           label: healthcheck.label,
           needsToBeFixed: Boolean(needsToBeFixed),
-          description: String(needsToBeFixed),
+          description: healthcheck.description,
           runAutomaticFix: healthcheck.runAutomaticFix,
           isRequired,
           type: needsToBeFixed

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -14,14 +14,14 @@ describe('androidHomeEnvVariables', () => {
     jest.resetAllMocks();
   });
 
-  it('returns a message if no ANDROID_HOME is defined', async () => {
+  it('returns true if no ANDROID_HOME is defined', async () => {
     delete process.env.ANDROID_HOME;
 
     const environmentInfo = await getEnvironmentInfo();
     const diagnostics = await androidHomeEnvVariables.getDiagnostics(
       environmentInfo,
     );
-    expect(typeof diagnostics.needsToBeFixed).toBe('string');
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns false if ANDROID_HOME is defined', async () => {

--- a/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.ts
@@ -23,7 +23,7 @@ const message = `Read more about how to set the ${label} at ${chalk.dim(
 export default {
   label,
   getDiagnostics: async () => ({
-    needsToBeFixed: !process.env.ANDROID_HOME && message,
+    needsToBeFixed: !process.env.ANDROID_HOME,
   }),
   runAutomaticFix: async ({loader}: {loader: Ora}) => {
     loader.info();

--- a/packages/cli/src/commands/doctor/healthchecks/androidNDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidNDK.ts
@@ -7,6 +7,7 @@ import {EnvironmentInfo, HealthCheckInterface} from '../types';
 
 export default {
   label: 'Android NDK',
+  description: 'required for building React Native from the source',
   getDiagnostics: async ({SDKs}: EnvironmentInfo) => {
     const androidSdk = SDKs['Android SDK'];
     return {

--- a/packages/cli/src/commands/doctor/healthchecks/androidNDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidNDK.ts
@@ -13,7 +13,7 @@ export default {
     return {
       needsToBeFixed: doesSoftwareNeedToBeFixed({
         version:
-          androidSdk === 'Not Found' ? 'Not Found' : androidSdk['Android NDK'],
+          androidSdk === 'Not Found' ? androidSdk : androidSdk['Android NDK'],
         versionRange: versionRanges.ANDROID_NDK,
       }),
     };

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -49,12 +49,11 @@ export default {
 
     return {
       needsToBeFixed:
-        (sdks === 'Not Found' && installMessage) ||
-        (sdks !== 'Not Found' &&
-          doesSoftwareNeedToBeFixed({
-            version: sdks['Build Tools'][0],
-            versionRange: versionRanges.ANDROID_SDK,
-          })),
+        sdks === 'Not Found' ||
+        doesSoftwareNeedToBeFixed({
+          version: sdks['Build Tools'][0],
+          versionRange: versionRanges.ANDROID_SDK,
+        }),
     };
   },
   runAutomaticFix: async ({loader, environmentInfo}) => {

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -11,6 +11,7 @@ const installMessage = `Read more about how to update Android SDK at ${chalk.dim
 
 export default {
   label: 'Android SDK',
+  description: 'required for building and installing your app on Android',
   getDiagnostics: async ({SDKs}) => {
     let sdks = SDKs['Android SDK'];
 

--- a/packages/cli/src/commands/doctor/healthchecks/cocoaPods.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/cocoaPods.ts
@@ -12,6 +12,7 @@ import {HealthCheckInterface} from '../types';
 
 export default {
   label: 'CocoaPods',
+  description: 'required for installing iOS dependencies',
   getDiagnostics: async () => ({
     needsToBeFixed: await checkSoftwareInstalled('pod'),
   }),

--- a/packages/cli/src/commands/doctor/healthchecks/cocoaPods.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/cocoaPods.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
-import {checkSoftwareInstalled} from '../checkInstallation';
+import {isSoftwareNotInstalled} from '../checkInstallation';
 import {
   promptCocoaPodsInstallationQuestion,
   runSudo,
@@ -14,7 +14,7 @@ export default {
   label: 'CocoaPods',
   description: 'required for installing iOS dependencies',
   getDiagnostics: async () => ({
-    needsToBeFixed: await checkSoftwareInstalled('pod'),
+    needsToBeFixed: await isSoftwareNotInstalled('pod'),
   }),
   runAutomaticFix: async ({loader}) => {
     loader.stop();

--- a/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
@@ -57,6 +57,8 @@ const installLibrary = async ({
 export default {
   label,
   isRequired: false,
+  description:
+    'required for installing your app on a physical device with the CLI',
   getDiagnostics: async () => ({
     needsToBeFixed: await checkSoftwareInstalled('ios-deploy'),
   }),

--- a/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 // @ts-ignore untyped
 import inquirer from 'inquirer';
 import {logger} from '@react-native-community/cli-tools';
-import {checkSoftwareInstalled, PACKAGE_MANAGERS} from '../checkInstallation';
+import {isSoftwareNotInstalled, PACKAGE_MANAGERS} from '../checkInstallation';
 import {packageManager} from './packageManagers';
 import {logManualInstallation, removeMessage} from './common';
 import {HealthCheckInterface} from '../types';
@@ -60,7 +60,7 @@ export default {
   description:
     'required for installing your app on a physical device with the CLI',
   getDiagnostics: async () => ({
-    needsToBeFixed: await checkSoftwareInstalled('ios-deploy'),
+    needsToBeFixed: await isSoftwareNotInstalled('ios-deploy'),
   }),
   runAutomaticFix: async ({loader}) => {
     loader.stop();

--- a/packages/cli/src/commands/doctor/healthchecks/watchman.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/watchman.ts
@@ -7,6 +7,8 @@ const label = 'Watchman';
 
 export default {
   label,
+  description:
+    'used for watching changes in the filesystem when in development mode',
   getDiagnostics: async ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Watchman.version,

--- a/packages/cli/src/commands/doctor/healthchecks/xcode.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/xcode.ts
@@ -5,6 +5,7 @@ import {HealthCheckInterface} from '../types';
 
 export default {
   label: 'Xcode',
+  description: 'required for building and installing your app on iOS',
   getDiagnostics: async ({IDEs}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: IDEs.Xcode.version.split('/')[0],

--- a/packages/cli/src/commands/doctor/types.ts
+++ b/packages/cli/src/commands/doctor/types.ts
@@ -86,6 +86,7 @@ export type HealthCheckInterface = {
   label: string;
   visible?: boolean | void;
   isRequired?: boolean;
+  description?: string;
   getDiagnostics: (
     environmentInfo: EnvironmentInfo,
   ) => Promise<{version?: string; needsToBeFixed: boolean | string}>;
@@ -95,7 +96,7 @@ export type HealthCheckInterface = {
 export type HealthCheckResult = {
   label: string;
   needsToBeFixed: boolean;
-  description: string;
+  description: string | undefined;
   runAutomaticFix: RunAutomaticFix;
   isRequired: boolean;
   type?: string;


### PR DESCRIPTION
Summary:
---------

This PR is related to #694, it adds a `description` field to each health check as discussed on [#672](https://github.com/react-native-community/cli/pull/672#discussion_r322698027), it also refactor a few that were using the `needsToBeFixed` as a `description`.

### Before

![Without description](https://user-images.githubusercontent.com/6207220/65415027-2fc9ef80-ddf5-11e9-9c7e-f163e04ec38b.png)


### After

![With description](https://user-images.githubusercontent.com/6207220/65414992-1c1e8900-ddf5-11e9-84d0-63b3b0c673a4.png)


Test Plan:
----------

1. Uninstall something that's covered by `doctor` (e.g. `sudo gem uninstall cocoapods`);
1. `/path/to/cli doctor`.
