### PR TITLE
doctor: improve error messages

### DIFF
--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -32,7 +32,9 @@ const printIssue = ({
       : chalk.yellow('●')
     : chalk.green('✓');
 
-  logger.log(` ${symbol} ${label}${needsToBeFixed ? ': ' + description : ''}`);
+  const descriptionToShow = needsToBeFixed && description ? `: ${description}` : '';
+
+  logger.log(` ${symbol} ${label}${descriptionToShow}`);
 };
 
 const printOverallStats = ({

--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -32,7 +32,8 @@ const printIssue = ({
       : chalk.yellow('●')
     : chalk.green('✓');
 
-  const descriptionToShow = needsToBeFixed && description ? `: ${description}` : '';
+  const descriptionToShow =
+    needsToBeFixed && description ? `: ${description}` : '';
 
   logger.log(` ${symbol} ${label}${descriptionToShow}`);
 };

--- a/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.ts
@@ -18,7 +18,7 @@ const platform = process.platform as 'darwin' | 'win32' | 'linux';
 
 const message = `Read more about how to set the ${label} at ${chalk.dim(
   URLS[platform],
-)}.`;
+)}`;
 
 export default {
   label,

--- a/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidHomeEnvVariable.ts
@@ -26,7 +26,7 @@ export default {
     needsToBeFixed: !process.env.ANDROID_HOME,
   }),
   runAutomaticFix: async ({loader}: {loader: Ora}) => {
-    loader.info();
+    loader.fail();
 
     logManualInstallation({
       message,

--- a/packages/cli/src/commands/doctor/healthchecks/cocoaPods.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/cocoaPods.ts
@@ -1,17 +1,17 @@
 import execa from 'execa';
-import chalk from 'chalk';
-import {logger} from '@react-native-community/cli-tools';
 import {isSoftwareNotInstalled} from '../checkInstallation';
 import {
   promptCocoaPodsInstallationQuestion,
   runSudo,
 } from '../../../tools/installPods';
-import {removeMessage} from './common';
+import {removeMessage, logError} from './common';
 import {brewInstall} from '../../../tools/brewInstall';
 import {HealthCheckInterface} from '../types';
 
+const label = 'CocoaPods';
+
 export default {
-  label: 'CocoaPods',
+  label,
   description: 'required for installing iOS dependencies',
   getDiagnostics: async () => ({
     needsToBeFixed: await isSoftwareNotInstalled('pod'),
@@ -29,8 +29,8 @@ export default {
       installMethod === 'homebrew'
         ? installMethod.substr(0, 1).toUpperCase() + installMethod.substr(1)
         : installMethod;
-    const loaderInstallationMessage = `CocoaPods (installing with ${installMethodCapitalized})`;
-    const loaderSucceedMessage = `CocoaPods (installed with ${installMethodCapitalized})`;
+    const loaderInstallationMessage = `${label} (installing with ${installMethodCapitalized})`;
+    const loaderSucceedMessage = `${label} (installed with ${installMethodCapitalized})`;
 
     // Remove the prompt after the question of how to install CocoaPods is answered
     removeMessage(promptQuestion);
@@ -52,14 +52,12 @@ export default {
 
           return loader.succeed(loaderSucceedMessage);
         } catch (error) {
-          loader.fail();
-          logger.log(chalk.dim(`\n${error.message}`));
-
-          return logger.log(
-            `An error occured while trying to install CocoaPods. Please try again manually: ${chalk.bold(
-              'sudo gem install cocoapods',
-            )}`,
-          );
+          logError({
+            healthcheck: label,
+            loader,
+            error,
+            command: 'sudo gem install cocoapods',
+          });
         }
       }
     }

--- a/packages/cli/src/commands/doctor/healthchecks/common.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/common.ts
@@ -2,13 +2,28 @@ import chalk from 'chalk';
 import readline from 'readline';
 import wcwidth from 'wcwidth';
 import stripAnsi from 'strip-ansi';
+import {Ora} from 'ora';
 import {logger} from '@react-native-community/cli-tools';
 
 // Space is necessary to keep correct ordering on screen
-const logMessage = (message: string) => logger.log(`   ${message}`);
+const logMessage = (message?: string) => {
+  const indentation = '   ';
+
+  if (typeof message !== 'string') {
+    logger.log();
+
+    return;
+  }
+
+  const messageByLine = message.split('\n');
+
+  return logger.log(`${indentation}${messageByLine.join(`\n${indentation}`)}`);
+};
+
+const addBlankLine = () => logMessage();
 
 const logManualInstallation = ({
-  healthcheck = '',
+  healthcheck,
   url,
   command,
   message,
@@ -23,18 +38,56 @@ const logManualInstallation = ({
   }
 
   if (url) {
-    return logMessage(
+    logMessage(
       `Read more about how to download ${healthcheck} at ${chalk.dim.underline(
         url,
       )}`,
     );
+
+    return;
   }
 
   if (command) {
-    return logMessage(
+    logMessage(
       `Please install ${healthcheck} by running ${chalk.bold(command)}`,
     );
   }
+};
+
+const logError = ({
+  healthcheck,
+  loader,
+  error,
+  message,
+  command,
+}: {
+  healthcheck: string;
+  loader?: Ora;
+  error: Error;
+  message?: string;
+  command: string;
+}) => {
+  if (loader) {
+    loader.fail();
+  }
+
+  addBlankLine();
+
+  logMessage(chalk.dim(error.message));
+
+  if (message) {
+    logMessage(message);
+    addBlankLine();
+
+    return;
+  }
+
+  logMessage(
+    `The error above occured while trying to install ${healthcheck}. Please try again manually: ${chalk.bold(
+      command,
+    )}`,
+  );
+  addBlankLine();
 };
 
 // Calculate the size of a message on terminal based on rows
@@ -51,4 +104,4 @@ function removeMessage(message: string) {
   readline.clearScreenDown(process.stdout);
 }
 
-export {logManualInstallation, removeMessage};
+export {logManualInstallation, logError, removeMessage};

--- a/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/iosDeploy.ts
@@ -2,10 +2,9 @@ import execa from 'execa';
 import chalk from 'chalk';
 // @ts-ignore untyped
 import inquirer from 'inquirer';
-import {logger} from '@react-native-community/cli-tools';
 import {isSoftwareNotInstalled, PACKAGE_MANAGERS} from '../checkInstallation';
 import {packageManager} from './packageManagers';
-import {logManualInstallation, removeMessage} from './common';
+import {logManualInstallation, logError, removeMessage} from './common';
 import {HealthCheckInterface} from '../types';
 import {Ora} from 'ora';
 
@@ -44,11 +43,10 @@ const installLibrary = async ({
 
     loader.succeed(`${label} (installed with ${packageManagerToUse})`);
   } catch (error) {
-    loader.fail();
-    logger.log(chalk.dim(`\n${error.message}`));
-
-    logManualInstallation({
-      healthcheck: 'ios-deploy',
+    logError({
+      healthcheck: label,
+      loader,
+      error,
       command: installationCommand,
     });
   }

--- a/packages/cli/src/commands/doctor/healthchecks/packageManagers.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/packageManagers.ts
@@ -36,7 +36,7 @@ const yarn: HealthCheckInterface = {
     await install({
       pkg: 'yarn',
       label: 'yarn',
-      source: 'https://yarnpkg.com/docs/install',
+      url: 'https://yarnpkg.com/docs/install',
       loader,
     }),
 };
@@ -57,7 +57,7 @@ const npm: HealthCheckInterface = {
     await install({
       pkg: 'node',
       label: 'node',
-      source: 'https://nodejs.org/',
+      url: 'https://nodejs.org/',
       loader,
     }),
 };

--- a/packages/cli/src/commands/doctor/healthchecks/watchman.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/watchman.ts
@@ -19,7 +19,7 @@ export default {
     await install({
       pkg: 'watchman',
       label,
-      source: 'https://facebook.github.io/watchman/docs/install.html',
+      url: 'https://facebook.github.io/watchman/docs/install.html',
       loader,
     }),
 } as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/xcode.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/xcode.ts
@@ -13,7 +13,7 @@ export default {
     }),
   }),
   runAutomaticFix: async ({loader}) => {
-    loader.info();
+    loader.fail();
 
     logManualInstallation({
       healthcheck: 'Xcode',

--- a/packages/cli/src/tools/brewInstall.ts
+++ b/packages/cli/src/tools/brewInstall.ts
@@ -1,7 +1,6 @@
-import {logger} from '@react-native-community/cli-tools';
 import execa from 'execa';
-import chalk from 'chalk';
 import ora from 'ora';
+import {logError} from '../commands/doctor/healthchecks/common';
 
 type InstallArgs = {
   pkg: string;
@@ -33,13 +32,12 @@ async function brewInstall({
       return onFail();
     }
 
-    loader.fail();
-    logger.log(chalk.dim(`\n${error.stderr}`));
-    logger.log(
-      `An error occured while trying to install ${pkg}. Please try again manually: ${chalk.bold(
-        `brew install ${pkg}`,
-      )}`,
-    );
+    logError({
+      healthcheck: label || pkg,
+      loader,
+      error,
+      command: `brew install ${pkg}`,
+    });
   }
 }
 

--- a/packages/cli/src/tools/install.ts
+++ b/packages/cli/src/tools/install.ts
@@ -1,14 +1,15 @@
 import ora from 'ora';
 import {brewInstall} from './brewInstall';
+import {logManualInstallation} from '../commands/doctor/healthchecks/common';
 
 type InstallArgs = {
   pkg: string;
   label: string;
-  source: string;
+  url: string;
   loader: ora.Ora;
 };
 
-async function install({pkg, label, source, loader}: InstallArgs) {
+async function install({pkg, label, url, loader}: InstallArgs) {
   try {
     switch (process.platform) {
       case 'darwin':
@@ -18,7 +19,12 @@ async function install({pkg, label, source, loader}: InstallArgs) {
         throw new Error('Not implemented yet');
     }
   } catch (_error) {
-    loader.info(`Please download and install '${pkg}' from ${source}.`);
+    loader.fail();
+
+    logManualInstallation({
+      healthcheck: label,
+      url,
+    });
   }
 }
 


### PR DESCRIPTION
Summary:
---------

This is related to #694, it improves the error messages by maintaining consistency between the health checks with one separated function to log errors.

It also fixes a problem introduced on #743 where it shows `undefined` when the `description` is not provided on a health check.

### Before

![Before](https://user-images.githubusercontent.com/6207220/65512572-c5d74600-ded9-11e9-8680-808c58e0e4d5.png)

### After

![After with consistent error messages](https://user-images.githubusercontent.com/6207220/65512569-c374ec00-ded9-11e9-9b1c-fa675a8513c8.png)


Test Plan:
----------

1. Make a health check fail;
1. `/path/to/cli doctor`.
