### PR TITLE
chore: use react-native 0.61.0 as peerDependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
     "ws": "^1.1.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0 || ^0.61.0"
+    "react-native": "^0.61.0"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
     "ws": "^1.1.0"
   },
   "peerDependencies": {
-    "react-native": "^0.60.0"
+    "react-native": "^0.60.0 || ^0.61.0"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",


### PR DESCRIPTION
Fix for react-native 0.61.0:
npm WARN @react-native-community/cli@3.0.0-alpha.2 requires a peer of react-native@^0.60.0 but none is installed. You must install peer dependencies yourself.