### PR TITLE
docs: fix typo in commands section

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -179,7 +179,7 @@ npx react-native init MyApp --template file:///Users/name/template-path
 npx react-native init MyApp --template file:///Users/name/template-name-1.0.0.tgz
 ```
 
-A template is any directory or npm package that contains a `template.config.js` file in the root with following of the following type:
+A template is any directory or npm package that contains a `template.config.js` file in the root with the following type:
 
 ```ts
 type Template = {


### PR DESCRIPTION
Summary:
---------

There's a small typo in the Commands section of the docs. This fixes it :)


Test Plan:
----------

N/A