### PR TITLE
feat: add fallback behavior when running a default simulator on iOS

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -67,6 +67,7 @@ For react-native versions 0.57 and above the bundle output path should be:
 To find out the correct path for previous react-native versions, take a look at the <code>react.gradle</code> file here: https://github.com/facebook/react-native/blob/0.57-stable/react.gradle or inside your <code>node_modules/react-native</code> directory.
 
 The expected path for the js bundle can be found on the line that starts with <code>jsBundleDir = </code>.
+
 </details>
 
 #### `--bundle-encoding [string]`
@@ -106,8 +107,8 @@ For react-native versions 0.57 and above the <code>--assets-dest</code> path sho
 <code>android/app/build/generated/res/react/debug</code>
 
 The expected path for the assets can be found in the react.gradle file on the line that starts with <code>resourcesDir =</code>
-</details>
 
+</details>
 
 #### `--reset-cache`
 
@@ -379,7 +380,13 @@ Builds your app and starts it on iOS simulator.
 
 Explicitly set the simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version, e.g. `"iPhone 6 (10.0)"`.
 
-Default: `"iPhone X"`
+Default: `""`
+
+Notes: If the argument is not provided, cli will look for devices in following order:
+
+- `iPhone 11`
+- `iPhone X`
+- `iPhone 8`
 
 Notes: `simulator_name` must be a valid iOS simulator name. If in doubt, open your AwesomeApp/ios/AwesomeApp.xcodeproj folder on XCode and unroll the dropdown menu containing the simulator list. The dropdown menu is situated on the right hand side of the play button (top left corner).
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -380,8 +380,6 @@ Builds your app and starts it on iOS simulator.
 
 Explicitly set the simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version, e.g. `"iPhone 6 (10.0)"`.
 
-Default: `""`
-
 Notes: If the argument is not provided, cli will look for devices in following order:
 
 - `iPhone 11`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -378,11 +378,12 @@ Builds your app and starts it on iOS simulator.
 
 #### `--simulator [simulator_name]`
 
+> default: iPhone 11
+
 Explicitly set the simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version, e.g. `"iPhone 6 (10.0)"`.
 
-Notes: If the argument is not provided, cli will look for devices in following order:
+Notes: If selected simulator does not exist, cli will try to run fallback simulators in following order:
 
-- `iPhone 11`
 - `iPhone X`
 - `iPhone 8`
 

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -129,8 +129,7 @@ async function runOnSimulator(
   }
 
   /**
-   * If no simulator was chosen, try simulators in following order
-   * - iPhone 11
+   * If provided simulator does not exist, try simulators in following order
    * - iPhone X
    * - iPhone 8
    */

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -128,37 +128,20 @@ async function runOnSimulator(
     throw new CLIError('Could not parse the simulator list output', error);
   }
 
-  let simulator: string = args.simulator;
-  let selectedSimulator: {
-    udid: string;
-    name: string;
-    booted: boolean;
-    version: string;
-  } | null = null;
-
   /**
    * If no simulator was chosen, try simulators in following order
    * - iPhone 11
    * - iPhone X
    * - iPhone 8
    */
-  const defaultSimulators = ['iPhone 11', 'iPhone X', 'iPhone 8'];
-  if (!simulator) {
-    defaultSimulators.some(target => {
-      selectedSimulator = findMatchingSimulator(simulators, target);
-      return selectedSimulator;
-    });
 
-    if (!selectedSimulator) {
-      throw new CLIError(
-        'Could not find any of the following simulators: "iPhone 11" "iPhone X "iPhone 8"',
-      );
-    }
-  } else {
-    selectedSimulator = findMatchingSimulator(simulators, simulator);
-    if (!selectedSimulator) {
-      throw new CLIError(`Could not find "${simulator}" simulator`);
-    }
+  const fallbackSimulators = ['iPhone X', 'iPhone 8'];
+  const selectedSimulator = fallbackSimulators.reduce((simulator, fallback) => {
+    return simulator || findMatchingSimulator(simulators, fallback);
+  }, findMatchingSimulator(simulators, args.simulator));
+
+  if (!selectedSimulator) {
+    throw new CLIError(`Could not find "${args.simulator}" simulator`);
   }
 
   /**
@@ -520,6 +503,7 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
+      default: 'iPhone 11',
     },
     {
       name: '--configuration [string]',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -507,7 +507,6 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
-      default: '',
     },
     {
       name: '--configuration [string]',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -128,9 +128,24 @@ async function runOnSimulator(
     throw new CLIError('Could not parse the simulator list output', error);
   }
 
-  const selectedSimulator = findMatchingSimulator(simulators, args.simulator);
+  /**
+   * If no simulator was chosen, try simulators in following order
+   * - iPhone 11
+   * - iPhone X
+   * - iPhone 8
+   */
+  let simulator: string = args.simulator;
+  if (!simulator) {
+    simulator = findMatchingSimulator(simulators, 'iPhone 11')
+      ? 'iPhone 11'
+      : findMatchingSimulator(simulators, 'iPhone X')
+      ? 'iPhone X'
+      : 'iPhone 8';
+  }
+
+  const selectedSimulator = findMatchingSimulator(simulators, simulator);
   if (!selectedSimulator) {
-    throw new CLIError(`Could not find "${args.simulator}" simulator`);
+    throw new CLIError(`Could not find "${simulator}" simulator`);
   }
 
   /**
@@ -492,7 +507,7 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
-      default: 'iPhone X',
+      default: '',
     },
     {
       name: '--configuration [string]',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -142,16 +142,13 @@ async function runOnSimulator(
    * - iPhone X
    * - iPhone 8
    */
+  const defaultSimulators = ['iPhone 11', 'iPhone X', 'iPhone 8'];
   if (!simulator) {
-    selectedSimulator = findMatchingSimulator(simulators, 'iPhone 11');
+    defaultSimulators.some(target => {
+      selectedSimulator = findMatchingSimulator(simulators, target);
+      return selectedSimulator;
+    });
 
-    if (!selectedSimulator) {
-      selectedSimulator = findMatchingSimulator(simulators, 'iPhone X');
-    }
-
-    if (!selectedSimulator) {
-      selectedSimulator = findMatchingSimulator(simulators, 'iPhone 8');
-    }
     if (!selectedSimulator) {
       throw new CLIError(
         'Could not find any of the following simulators: "iPhone 11" "iPhone X "iPhone 8"',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -128,24 +128,40 @@ async function runOnSimulator(
     throw new CLIError('Could not parse the simulator list output', error);
   }
 
+  let simulator: string = args.simulator;
+  let selectedSimulator: {
+    udid: string;
+    name: string;
+    booted: boolean;
+    version: string;
+  } | null = null;
+
   /**
    * If no simulator was chosen, try simulators in following order
    * - iPhone 11
    * - iPhone X
    * - iPhone 8
    */
-  let simulator: string = args.simulator;
   if (!simulator) {
-    simulator = findMatchingSimulator(simulators, 'iPhone 11')
-      ? 'iPhone 11'
-      : findMatchingSimulator(simulators, 'iPhone X')
-      ? 'iPhone X'
-      : 'iPhone 8';
-  }
+    selectedSimulator = findMatchingSimulator(simulators, 'iPhone 11');
 
-  const selectedSimulator = findMatchingSimulator(simulators, simulator);
-  if (!selectedSimulator) {
-    throw new CLIError(`Could not find "${simulator}" simulator`);
+    if (!selectedSimulator) {
+      selectedSimulator = findMatchingSimulator(simulators, 'iPhone X');
+    }
+
+    if (!selectedSimulator) {
+      selectedSimulator = findMatchingSimulator(simulators, 'iPhone 8');
+    }
+    if (!selectedSimulator) {
+      throw new CLIError(
+        'Could not find any of the following simulators: "iPhone 11" "iPhone X "iPhone 8"',
+      );
+    }
+  } else {
+    selectedSimulator = findMatchingSimulator(simulators, simulator);
+    if (!selectedSimulator) {
+      throw new CLIError(`Could not find "${simulator}" simulator`);
+    }
   }
 
   /**


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

This is an attempt to solve problem on #739, based on idea provided at https://github.com/react-native-community/cli/issues/739#issuecomment-533904514

This changes the behavior of runIOS when no simulator argument is provided.

When no simulator argument is provided, the cli will look for simulators in the following order
- `iPhone 11`
- `iPhone X`
- `iPhone 8`

Test Plan:
----------
yarn
yarn test 
yarn lint


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
