### PR TITLE
fix: do not read configuration outside of the root

### DIFF
--- a/packages/cli/src/tools/config/readConfigFromDisk.ts
+++ b/packages/cli/src/tools/config/readConfigFromDisk.ts
@@ -92,7 +92,10 @@ function readLegacyConfigFromDisk(rootFolder: string): UserConfig | void {
  * workspace.
  */
 export function readConfigFromDisk(rootFolder: string): UserConfig {
-  const explorer = cosmiconfig('react-native', {searchPlaces});
+  const explorer = cosmiconfig('react-native', {
+    searchPlaces,
+    stopDir: rootFolder,
+  });
 
   const {config} = explorer.searchSync(rootFolder) || {
     config: readLegacyConfigFromDisk(rootFolder),


### PR DESCRIPTION
Summary:
---------

Reading configuration outside of the current working directory (in other words, project root), is not supported and can lead to dangerous errors. [I was pretty sure we never supported that](https://github.com/react-native-community/cli/pull/749#issuecomment-537931760), until I've found this out today.

Since I was able to remove this functionality without changing any tests, my recommendation is to not include it until: a) there is such a requirement (validated) from the user-side and that b) we have thoroughly tested this behavior.

Context:
---------

Fixes https://github.com/react-native-community/cli/issues/655).

As per [a comment from the above issue](https://github.com/react-native-community/cli/issues/655#issuecomment-538009106), the configuration is placed at the root of the repository whereas the CLI is run from the root of the project (which is different and resolves to `./packages/mobile`). That tiny difference is crucial and because paths in the configuration are always resolved relative to the root of the project, it creates silent issues that are hard to debug.

I believe it's a good practice to require running the CLI from the root of the mobile project (where `react-native` is defined in the `package.json`, just like Metro already does).

Few workarounds relied on this mechanism to provide support for mono-repos (it was broken anyway). However, the PR #768 is going to address these cases by rolling out a new mechanism for this.
