### PR TITLE
Backport #758 to v1.x

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -35,7 +35,12 @@ Builds your app and starts it on iOS simulator.
 
 Explicitly set the simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version, e.g. `"iPhone 6 (10.0)"`.
 
-Default: `"iPhone X"`
+Default: `"iPhone 11"`
+
+Notes: If selected simulator does not exist, cli will try to run fallback simulators in following order:
+
+- `iPhone X`
+- `iPhone 8`
 
 Notes: `simulator_name` must be a valid iOS simulator name. If in doubt, open your AwesomeApp/ios/AwesomeApp.xcodeproj folder on XCode and unroll the dropdown menu containing the simulator list. The dropdown menu is situated on the right hand side of the play button (top left corner).
 

--- a/packages/cli/src/commands/runIOS/runIOS.js
+++ b/packages/cli/src/commands/runIOS/runIOS.js
@@ -138,7 +138,28 @@ async function runOnSimulator(xcodeProject, args, scheme) {
     throw new Error('Could not parse the simulator list output');
   }
 
-  const selectedSimulator = findMatchingSimulator(simulators, args.simulator);
+  /**
+   * If provided simulator does not exist, try simulators in following order
+   * - iPhone X
+   * - iPhone 8
+   */
+
+  /**
+   * Flow does not properly infer the type of the second argument to reduce().
+   * See https://github.com/facebook/flow/issues/5182.
+   * TODO [flow-bin@>=0.107.0]: Remove workaround.
+   */
+  type ExtractReturnType = <T>(() => T) => T;
+  type ReturnType = $Call<ExtractReturnType, findMatchingSimulator>;
+
+  const fallbackSimulators = ['iPhone X', 'iPhone 8'];
+  const selectedSimulator: ReturnType = fallbackSimulators.reduce(
+    (simulator, fallback) => {
+      return simulator || findMatchingSimulator(simulators, fallback);
+    },
+    findMatchingSimulator(simulators, args.simulator),
+  );
+
   if (!selectedSimulator) {
     throw new Error(`Could not find ${args.simulator} simulator`);
   }
@@ -464,7 +485,7 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
-      default: 'iPhone X',
+      default: 'iPhone 11',
     },
     {
       command: '--configuration [string]',


### PR DESCRIPTION
## Summary

Backports #758 to v1.x.

## Test Plan

With Xcode 11.1 and its default set of simulators (which does not include iPhone X):

```console
$ npm install --global react-native-cli
$ react-native init AwesomeProject --version 0.59.10
$ cd AwesomeProject
$ react-native run-ios
error Could not find iPhone X simulator. Run CLI with --verbose flag for more details.
$ node …/packages/cli/build/index.js run-ios
info Launching iPhone 11 (iOS 13.1)...
```