### PR TITLE
Collapse YellowBox/DevTools frames in Metro config

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -29,6 +29,8 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
   [
     '/Libraries/Renderer/implementations/.+\\.js$',
     '/Libraries/BatchedBridge/MessageQueue\\.js$',
+    '/Libraries/YellowBox/.+\.js$',
+    '/node_modules/react-devtools-core/.+\\.js$',
   ].join('|'),
 );
 

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -29,7 +29,7 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
   [
     '/Libraries/Renderer/implementations/.+\\.js$',
     '/Libraries/BatchedBridge/MessageQueue\\.js$',
-    '/Libraries/YellowBox/.+\.js$',
+    '/Libraries/YellowBox/.+\\.js$',
     '/node_modules/react-devtools-core/.+\\.js$',
   ].join('|'),
 );


### PR DESCRIPTION
Summary:
---------

React Native master (https://github.com/facebook/react-native/commit/cf4d45ec2bcd301be7793d5840de21ec7d02275b) is no longer stripping `YellowBox` and React DevTools stack frames from warnings with the `framesToPop` mechanism, which we will be deprecating and ultimately removing from the default error reporter too. The recommended approach going forward is to rely on Metro's `customizeFrame` for all postprocessing of stack traces.

This commit updates the default Metro config to skip stack frames in `YellowBox` and React DevTools code, thus preserving the old user-visible behaviour. As for compatibility and versioning: It is harmless to run this change against older RN versions, but the next RN release should include this CLI change. (cc @cpojer)

Test Plan:
----------

We've made an identical change to our internal Metro config.