### PR TITLE
Backport #758 to v2.x

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -346,9 +346,14 @@ Builds your app and starts it on iOS simulator.
 
 #### `--simulator [simulator_name]`
 
+> default: iPhone 11
+
 Explicitly set the simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version, e.g. `"iPhone 6 (10.0)"`.
 
-Default: `"iPhone X"`
+Notes: If selected simulator does not exist, cli will try to run fallback simulators in following order:
+
+- `iPhone X`
+- `iPhone 8`
 
 Notes: `simulator_name` must be a valid iOS simulator name. If in doubt, open your AwesomeApp/ios/AwesomeApp.xcodeproj folder on XCode and unroll the dropdown menu containing the simulator list. The dropdown menu is situated on the right hand side of the play button (top left corner).
 


### PR DESCRIPTION
## Summary

Backports #758 to v2.x. Prompted by https://github.com/react-native-community/cli/pull/777#pullrequestreview-300530686.

## Test Plan

With Xcode 11.1 and its default set of simulators (which does not include iPhone X):

```console
$ npm install --global react-native-cli
$ react-native init AwesomeProject --version 0.60.6
$ cd AwesomeProject
$ react-native run-ios
error Could not find "iPhone X" simulator. Run CLI with --verbose flag for more details.
$ yarn link @react-native-community/cli-platform-ios
$ react-native run-ios
info Launching iPhone 11 (iOS 13.1)
```