### PR TITLE
feat: use config inside run-android

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "redhat.vscode-yaml",
-    "flowtype.flow-for-vscode",
     "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
     "**/node_modules": true,
     "**/build": true
   },
-  "editor.formatOnSave": true,
-  "flow.useNPMPackagedFlow": true,
-  "javascript.validate.enable": false,
+  "eslint.autoFixOnSave": true,
   "eslint.validate": [
     "javascript",
     "javascriptreact",

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -267,10 +267,6 @@ Builds your app and starts it on a connected Android emulator or device.
 
 #### Options
 
-#### `--root [string]`
-
-Override the root directory for the Android build (which contains the android directory)'.
-
 #### `--variant [string]`
 
 > default: 'debug'

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -273,16 +273,6 @@ Builds your app and starts it on a connected Android emulator or device.
 
 Specify your app's build variant.
 
-#### `--appFolder [string]`
-
-> default: 'app'
-
-Specify a different application folder name for the Android source. If not, we assume is "app".
-
-#### `--appId [string]`
-
-Specify an `applicationId` to launch after build.
-
 #### `--appIdSuffix [string]`
 
 Specify an `applicationIdSuffix` to launch after build.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -63,7 +63,6 @@ interface AndroidDependencyParams {
   packageName?: string;
   sourceDir?: string;
   manifestPath?: string;
-
   packageImportPath?: string;
   packageInstance?: string;
 }
@@ -106,7 +105,7 @@ See [`script_phase` options](https://www.rubydoc.info/gems/cocoapods-core/Pod/Po
 
 #### platforms.android.sourceDir
 
-A relative path to a folder with source files. E.g. `custom-android`, or `custom-android/app`. By default, CLI searches for `android` and `android/app` as source dirs.
+A relative path to a folder with Android project (Gradle root project), e.g. `./path/to/custom-android`. By default, CLI searches for `./android` as source dir.
 
 #### platforms.android.packageName
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -62,6 +62,7 @@ interface IOSDependencyParams {
 interface AndroidDependencyParams {
   packageName?: string;
   sourceDir?: string;
+  appName?: string;
   manifestPath?: string;
   packageImportPath?: string;
   packageInstance?: string;
@@ -106,6 +107,10 @@ See [`script_phase` options](https://www.rubydoc.info/gems/cocoapods-core/Pod/Po
 #### platforms.android.sourceDir
 
 A relative path to a folder with Android project (Gradle root project), e.g. `./path/to/custom-android`. By default, CLI searches for `./android` as source dir.
+
+#### platforms.android.appName
+
+A name of the app in the Android `sourceDir`, equivalent to Gradle project name. By default it's `app`.
 
 #### platforms.android.packageName
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -64,6 +64,7 @@ The following settings are available on iOS and Android:
 ```ts
 interface AndroidProjectParams {
   sourceDir?: string;
+  appName?: string;
   manifestPath?: string;
   packageName?: string;
 }

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -1,5 +1,6 @@
 export interface AndroidProjectConfig {
   sourceDir: string;
+  appName: string;
   packageName: string;
   manifestPath: string;
 }
@@ -8,6 +9,7 @@ export type AndroidProjectParams = Partial<AndroidProjectConfig>;
 
 export interface AndroidDependencyConfig {
   sourceDir: string;
+  appName: string;
   packageName: string;
   manifestPath: string;
   packageImportPath: string;

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -1,27 +1,17 @@
 export interface AndroidProjectConfig {
   sourceDir: string;
   packageName: string;
+  manifestPath: string;
 }
 
-export interface AndroidProjectParams {
-  sourceDir?: string;
-  manifestPath?: string;
-  packageName?: string;
-}
+export type AndroidProjectParams = Partial<AndroidProjectConfig>;
 
 export interface AndroidDependencyConfig {
   sourceDir: string;
   packageName: string;
-
+  manifestPath: string;
   packageImportPath: string;
   packageInstance: string;
 }
 
-export interface AndroidDependencyParams {
-  packageName?: string;
-  sourceDir?: string;
-  manifestPath?: string;
-
-  packageImportPath?: string;
-  packageInstance?: string;
-}
+export type AndroidDependencyParams = Partial<AndroidDependencyConfig>;

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -56,6 +56,7 @@ export const dependencyConfig = t
               // AndroidDependencyParams
               .object({
                 sourceDir: t.string(),
+                appName: t.string(),
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
@@ -130,6 +131,7 @@ export const projectConfig = t
           // AndroidProjectParams
           .object({
             sourceDir: t.string(),
+            appName: t.string(),
             manifestPath: t.string(),
             packageName: t.string(),
           })

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -7,15 +7,11 @@
  */
 
 import runOnAllDevices from '../runOnAllDevices';
+import execa from 'execa';
 
-jest.mock('child_process', () => ({
-  execFileSync: jest.fn(),
-  spawnSync: jest.fn(),
-}));
-
+jest.mock('execa');
 jest.mock('../getAdbPath');
 jest.mock('../tryLaunchEmulator');
-const {execFileSync} = require('child_process');
 
 describe('--appFolder', () => {
   beforeEach(() => {
@@ -27,7 +23,9 @@ describe('--appFolder', () => {
     await runOnAllDevices({
       variant: 'debug',
     });
-    expect(execFileSync.mock.calls[0][1]).toContain('installDebug');
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
+      'installDebug',
+    );
   });
 
   it('uses appFolder and default variant', async () => {
@@ -37,7 +35,9 @@ describe('--appFolder', () => {
       variant: 'debug',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('someApp:installDebug');
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
+      'someApp:installDebug',
+    );
   });
 
   it('uses appFolder and custom variant', async () => {
@@ -47,7 +47,7 @@ describe('--appFolder', () => {
       variant: 'staging',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain(
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'anotherApp:installStaging',
     );
   });
@@ -59,7 +59,9 @@ describe('--appFolder', () => {
       variant: 'debug',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('someTask');
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
+      'someTask',
+    );
   });
 
   it('uses appFolder and custom task argument', async () => {
@@ -70,7 +72,9 @@ describe('--appFolder', () => {
       variant: 'debug',
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain('anotherApp:someTask');
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
+      'anotherApp:someTask',
+    );
   });
 
   it('uses multiple tasks', async () => {
@@ -80,7 +84,7 @@ describe('--appFolder', () => {
       tasks: ['clean', 'someTask'],
     });
 
-    expect(execFileSync.mock.calls[0][1]).toContain(
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'app:clean',
       // @ts-ignore
       'app:someTask',

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -13,39 +13,63 @@ jest.mock('execa');
 jest.mock('../getAdbPath');
 jest.mock('../tryLaunchEmulator');
 
-describe('--appFolder', () => {
+describe('runOnAllDevices', () => {
+  const args = {
+    tasks: undefined,
+    variant: 'debug',
+    appIdSuffix: '',
+    mainActivity: 'MainActivity',
+    deviceId: undefined,
+    packager: true,
+    port: 8081,
+    terminal: 'iTerm2',
+    jetifier: true,
+  };
+  const androidProject = {
+    manifestPath: '/android/app/src/main/AndroidManifest.xml',
+    appName: 'app',
+    packageName: 'com.test',
+    sourceDir: '/android',
+  };
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it('uses task "install[Variant]" as default task', async () => {
-    // @ts-ignore
-    await runOnAllDevices({
-      variant: 'debug',
-    });
+    await runOnAllDevices(
+      {...args, variant: 'debug'},
+      './gradlew',
+      'com.test',
+      'adb',
+      androidProject,
+    );
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
-      'installDebug',
+      'app:installDebug',
     );
   });
 
-  it('uses appFolder and default variant', async () => {
-    // @ts-ignore
-    await runOnAllDevices({
-      appFolder: 'someApp',
-      variant: 'debug',
-    });
+  it('uses appName and default variant', async () => {
+    await runOnAllDevices(
+      {...args, variant: 'debug'},
+      './gradlew',
+      'com.test',
+      'adb',
+      {...androidProject, appName: 'someApp'},
+    );
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'someApp:installDebug',
     );
   });
 
-  it('uses appFolder and custom variant', async () => {
-    // @ts-ignore
-    await runOnAllDevices({
-      appFolder: 'anotherApp',
-      variant: 'staging',
-    });
+  it('uses appName and custom variant', async () => {
+    await runOnAllDevices(
+      {...args, variant: 'staging'},
+      './gradlew',
+      'com.test',
+      'adb',
+      {...androidProject, appName: 'anotherApp'},
+    );
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'anotherApp:installStaging',
@@ -53,24 +77,27 @@ describe('--appFolder', () => {
   });
 
   it('uses only task argument', async () => {
-    // @ts-ignore
-    await runOnAllDevices({
-      tasks: ['someTask'],
-      variant: 'debug',
-    });
+    await runOnAllDevices(
+      {...args, tasks: ['someTask']},
+      './gradlew',
+      'com.test',
+      'adb',
+      androidProject,
+    );
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
-      'someTask',
+      'app:someTask',
     );
   });
 
-  it('uses appFolder and custom task argument', async () => {
-    // @ts-ignore
-    await runOnAllDevices({
-      appFolder: 'anotherApp',
-      tasks: ['someTask'],
-      variant: 'debug',
-    });
+  it('uses appName and custom task argument', async () => {
+    await runOnAllDevices(
+      {...args, tasks: ['someTask']},
+      './gradlew',
+      'com.test',
+      'adb',
+      {...androidProject, appName: 'anotherApp'},
+    );
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'anotherApp:someTask',
@@ -78,11 +105,13 @@ describe('--appFolder', () => {
   });
 
   it('uses multiple tasks', async () => {
-    // @ts-ignore
-    await runOnAllDevices({
-      appFolder: 'app',
-      tasks: ['clean', 'someTask'],
-    });
+    await runOnAllDevices(
+      {...args, tasks: ['clean', 'someTask']},
+      './gradlew',
+      'com.test',
+      'adb',
+      androidProject,
+    );
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'app:clean',

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -39,7 +39,6 @@ describe('runOnAllDevices', () => {
     await runOnAllDevices(
       {...args, variant: 'debug'},
       './gradlew',
-      'com.test',
       'adb',
       androidProject,
     );
@@ -49,13 +48,10 @@ describe('runOnAllDevices', () => {
   });
 
   it('uses appName and default variant', async () => {
-    await runOnAllDevices(
-      {...args, variant: 'debug'},
-      './gradlew',
-      'com.test',
-      'adb',
-      {...androidProject, appName: 'someApp'},
-    );
+    await runOnAllDevices({...args, variant: 'debug'}, './gradlew', 'adb', {
+      ...androidProject,
+      appName: 'someApp',
+    });
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'someApp:installDebug',
@@ -63,13 +59,10 @@ describe('runOnAllDevices', () => {
   });
 
   it('uses appName and custom variant', async () => {
-    await runOnAllDevices(
-      {...args, variant: 'staging'},
-      './gradlew',
-      'com.test',
-      'adb',
-      {...androidProject, appName: 'anotherApp'},
-    );
+    await runOnAllDevices({...args, variant: 'staging'}, './gradlew', 'adb', {
+      ...androidProject,
+      appName: 'anotherApp',
+    });
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'anotherApp:installStaging',
@@ -80,7 +73,6 @@ describe('runOnAllDevices', () => {
     await runOnAllDevices(
       {...args, tasks: ['someTask']},
       './gradlew',
-      'com.test',
       'adb',
       androidProject,
     );
@@ -91,13 +83,10 @@ describe('runOnAllDevices', () => {
   });
 
   it('uses appName and custom task argument', async () => {
-    await runOnAllDevices(
-      {...args, tasks: ['someTask']},
-      './gradlew',
-      'com.test',
-      'adb',
-      {...androidProject, appName: 'anotherApp'},
-    );
+    await runOnAllDevices({...args, tasks: ['someTask']}, './gradlew', 'adb', {
+      ...androidProject,
+      appName: 'anotherApp',
+    });
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'anotherApp:someTask',
@@ -108,15 +97,14 @@ describe('runOnAllDevices', () => {
     await runOnAllDevices(
       {...args, tasks: ['clean', 'someTask']},
       './gradlew',
-      'com.test',
       'adb',
       androidProject,
     );
 
-    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
+    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toEqual([
       'app:clean',
-      // @ts-ignore
       'app:someTask',
-    );
+      '-PreactNativeDevServerPort=8081',
+    ]);
   });
 });

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -40,7 +40,8 @@ export interface Flags {
  * Starts the app on a connected Android emulator or device.
  */
 async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
-  if (!config.project.android) {
+  const androidProject = config.project.android;
+  if (!androidProject) {
     logger.error(
       'Android project not found. Are you sure this is a React Native project?',
     );
@@ -64,7 +65,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
   }
 
   if (!args.packager) {
-    return buildAndRun(args, config);
+    return buildAndRun(args, androidProject);
   }
 
   return isPackagerRunning(args.port).then(result => {
@@ -89,7 +90,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
         );
       }
     }
-    return buildAndRun(args, config);
+    return buildAndRun(args, androidProject);
   });
 }
 
@@ -109,11 +110,10 @@ function getPackageNameWithSuffix(
 }
 
 // Builds the app and runs it on a connected emulator / device.
-function buildAndRun(args: Flags, config: Config) {
-  const androidConfig = config.project.android;
-  if (!androidConfig) {
-    return;
-  }
+function buildAndRun(
+  args: Flags,
+  androidConfig: NonNullable<Config['project']['android']>,
+) {
   process.chdir(androidConfig.sourceDir);
 
   const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -42,10 +42,12 @@ export interface Flags {
 async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
   const androidProject = config.project.android;
   if (!androidProject) {
-    logger.error(
-      'Android project not found. Are you sure this is a React Native project?',
-    );
-    return;
+    throw new CLIError(`
+  Android project not found. Are you sure this is a React Native project?
+
+  If your Android files are located in a non-standard location (e.g. not inside \'android\' folder), consider setting
+  \`project.android.sourceDir\` option to point to a new location.
+`);
   }
 
   if (args.jetifier) {

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -115,11 +115,12 @@ function buildAndRun(args: Flags, config: Config) {
     return;
   }
   process.chdir(androidConfig.sourceDir);
-  const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
-  const {appFolder} = args;
+
+  const gradlew = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+
   // @ts-ignore
   const packageName = fs
-    .readFileSync(`${appFolder}/src/main/AndroidManifest.xml`, 'utf8')
+    .readFileSync(`${args.appFolder}/src/main/AndroidManifest.xml`, 'utf8')
     .match(/package="(.+?)"/)[1];
 
   const packageNameWithSuffix = getPackageNameWithSuffix(
@@ -131,7 +132,7 @@ function buildAndRun(args: Flags, config: Config) {
   if (args.deviceId) {
     return runOnSpecificDevice(
       args,
-      cmd,
+      gradlew,
       packageNameWithSuffix,
       packageName,
       adbPath,
@@ -139,7 +140,7 @@ function buildAndRun(args: Flags, config: Config) {
   } else {
     return runOnAllDevices(
       args,
-      cmd,
+      gradlew,
       packageNameWithSuffix,
       packageName,
       adbPath,

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -86,7 +86,9 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
         );
       } catch (error) {
         logger.warn(
-          `Failed to automatically start the packager server. Please run "react-native start" manually. Error details: ${error.message}`,
+          `Failed to automatically start the packager server. Please run "react-native start" manually. Error details: ${
+            error.message
+          }`,
         );
       }
     }

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -86,9 +86,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
         );
       } catch (error) {
         logger.warn(
-          `Failed to automatically start the packager server. Please run "react-native start" manually. Error details: ${
-            error.message
-          }`,
+          `Failed to automatically start the packager server. Please run "react-native start" manually. Error details: ${error.message}`,
         );
       }
     }
@@ -102,28 +100,15 @@ function buildAndRun(args: Flags, androidProject: AndroidProject) {
 
   const adbPath = getAdbPath();
   if (args.deviceId) {
-    return runOnSpecificDevice(
-      args,
-      gradlew,
-      androidProject.packageName,
-      adbPath,
-      androidProject,
-    );
+    return runOnSpecificDevice(args, gradlew, adbPath, androidProject);
   } else {
-    return runOnAllDevices(
-      args,
-      gradlew,
-      androidProject.packageName,
-      adbPath,
-      androidProject,
-    );
+    return runOnAllDevices(args, gradlew, adbPath, androidProject);
   }
 }
 
 function runOnSpecificDevice(
   args: Flags,
   gradlew: 'gradlew.bat' | './gradlew',
-  packageName: string,
   adbPath: string,
   androidProject: AndroidProject,
 ) {
@@ -132,13 +117,7 @@ function runOnSpecificDevice(
   if (devices.length > 0 && deviceId) {
     if (devices.indexOf(deviceId) !== -1) {
       buildApk(gradlew, androidProject.sourceDir);
-      installAndLaunchOnDevice(
-        args,
-        deviceId,
-        packageName,
-        adbPath,
-        androidProject,
-      );
+      installAndLaunchOnDevice(args, deviceId, adbPath, androidProject);
     } else {
       logger.error(
         `Could not find device with the id: "${deviceId}". Please choose one of the following:`,
@@ -222,13 +201,17 @@ function getInstallApkName(
 function installAndLaunchOnDevice(
   args: Flags,
   selectedDevice: string,
-  packageName: string,
   adbPath: string,
   androidProject: AndroidProject,
 ) {
   tryRunAdbReverse(args.port, selectedDevice);
   tryInstallAppOnDevice(args, adbPath, selectedDevice, androidProject);
-  tryLaunchAppOnDevice(selectedDevice, packageName, adbPath, args);
+  tryLaunchAppOnDevice(
+    selectedDevice,
+    androidProject.packageName,
+    adbPath,
+    args,
+  );
 }
 
 function startServerInNewWindow(

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -7,7 +7,7 @@
  */
 
 import chalk from 'chalk';
-import {execFileSync} from 'child_process';
+import execa from 'execa';
 import {logger, CLIError} from '@react-native-community/cli-tools';
 import adb from './adb';
 import tryRunAdbReverse from './tryRunAdbReverse';
@@ -34,6 +34,7 @@ async function runOnAllDevices(
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
+  sourceDir: string,
 ) {
   let devices = adb.getDevices(adbPath);
   if (devices.length === 0) {
@@ -65,7 +66,10 @@ async function runOnAllDevices(
       `Running command "cd android && ${cmd} ${gradleArgs.join(' ')}"`,
     );
 
-    execFileSync(cmd, gradleArgs, {stdio: ['inherit', 'inherit', 'pipe']});
+    await execa(cmd, gradleArgs, {
+      stdio: ['inherit', 'inherit', 'pipe'],
+      cwd: sourceDir,
+    });
   } catch (error) {
     throw createInstallError(error);
   }

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -29,7 +29,6 @@ type AndroidProject = NonNullable<Config['project']['android']>;
 async function runOnAllDevices(
   args: Flags,
   cmd: string,
-  packageName: string,
   adbPath: string,
   androidProject: AndroidProject,
 ) {
@@ -74,9 +73,9 @@ async function runOnAllDevices(
   }
 
   (devices.length > 0 ? devices : [undefined]).forEach(
-    async (device: string | void) => {
+    (device: string | void) => {
       tryRunAdbReverse(args.port, device);
-      await tryLaunchAppOnDevice(device, packageName, adbPath, args);
+      tryLaunchAppOnDevice(device, androidProject.packageName, adbPath, args);
     },
   );
 }

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import {spawnSync} from 'child_process';
 import {logger, CLIError} from '@react-native-community/cli-tools';
+import execa from 'execa';
 
 function tryLaunchAppOnDevice(
   device: string | void,
@@ -31,7 +31,7 @@ function tryLaunchAppOnDevice(
       logger.info('Starting the app...');
     }
     logger.debug(`Running command "${adbPath} ${adbArgs.join(' ')}"`);
-    spawnSync(adbPath, adbArgs, {stdio: 'inherit'});
+    execa.sync(adbPath, adbArgs, {stdio: 'inherit'});
   } catch (error) {
     throw new CLIError('Failed to start the app.', error);
   }

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -8,21 +8,25 @@
 
 import {logger, CLIError} from '@react-native-community/cli-tools';
 import execa from 'execa';
+import {Flags} from '.';
 
 function tryLaunchAppOnDevice(
   device: string | void,
-  packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
-  mainActivity: string,
+  args: Flags,
 ) {
+  const packageNameWithSuffix = args.appIdSuffix
+    ? `${packageName}.${args.appIdSuffix}`
+    : packageName;
+
   try {
     const adbArgs = [
       'shell',
       'am',
       'start',
       '-n',
-      `${packageNameWithSuffix}/${packageName}.${mainActivity}`,
+      `${packageNameWithSuffix}/${packageName}.${args.mainActivity}`,
     ];
     if (device) {
       adbArgs.unshift('-s', device);

--- a/packages/platform-android/src/config/__tests__/findAndroidAppFolder.test.ts
+++ b/packages/platform-android/src/config/__tests__/findAndroidAppFolder.test.ts
@@ -18,23 +18,17 @@ describe('android::findAndroidAppFolder', () => {
   beforeAll(() => {
     fs.__setMockFilesystem({
       empty: {},
-      nested: {
-        android: {
-          app: mocks.valid,
-        },
-      },
       flat: {
         android: mocks.valid,
       },
     });
   });
 
-  it('returns an android app folder if it exists in the given folder', () => {
+  it('returns an android folder if it exists in the given folder', () => {
     expect(findAndroidAppFolder('/flat')).toBe('android');
-    expect(findAndroidAppFolder('/nested')).toBe('android/app');
   });
 
-  it('returns `null` if there is no android app folder', () => {
+  it('returns null if there is no android folder', () => {
     expect(findAndroidAppFolder('/empty')).toBeNull();
   });
 });

--- a/packages/platform-android/src/config/__tests__/findAndroidDir.test.ts
+++ b/packages/platform-android/src/config/__tests__/findAndroidDir.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import findAndroidAppFolder from '../findAndroidAppFolder';
+import findAndroidDir from '../findAndroidDir';
 import * as mocks from '../__fixtures__/android';
 
 jest.mock('path');
@@ -14,7 +14,7 @@ jest.mock('fs');
 
 const fs = require('fs');
 
-describe('android::findAndroidAppFolder', () => {
+describe('android::findAndroidDir', () => {
   beforeAll(() => {
     fs.__setMockFilesystem({
       empty: {},
@@ -25,10 +25,10 @@ describe('android::findAndroidAppFolder', () => {
   });
 
   it('returns an android folder if it exists in the given folder', () => {
-    expect(findAndroidAppFolder('/flat')).toBe('android');
+    expect(findAndroidDir('/flat')).toBe('android');
   });
 
   it('returns null if there is no android folder', () => {
-    expect(findAndroidAppFolder('/empty')).toBeNull();
+    expect(findAndroidDir('/empty')).toBeNull();
   });
 });

--- a/packages/platform-android/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/platform-android/src/config/__tests__/getProjectConfig.test.ts
@@ -55,16 +55,26 @@ describe('android::getProjectConfig', () => {
       const userConfig = {};
       const folder = '/nested';
 
-      expect(getProjectConfig(folder, userConfig)).not.toBeNull();
-      expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
+      const config = getProjectConfig(folder, userConfig);
+      expect(config).toMatchObject({
+        sourceDir: '/nested/android',
+        appName: 'app',
+        packageName: 'com.some.example',
+        manifestPath: '/nested/android/app/src/AndroidManifest.xml',
+      });
     });
 
     it('flat structure', () => {
       const userConfig = {};
       const folder = '/flat';
 
-      expect(getProjectConfig(folder, userConfig)).not.toBeNull();
-      expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
+      const config = getProjectConfig(folder, userConfig);
+      expect(config).toMatchObject({
+        sourceDir: '/flat/android',
+        appName: '',
+        packageName: 'com.some.example',
+        manifestPath: '/flat/android/src/AndroidManifest.xml',
+      });
     });
 
     it('multiple', () => {
@@ -73,8 +83,13 @@ describe('android::getProjectConfig', () => {
       };
       const folder = '/multiple';
 
-      expect(getProjectConfig(folder, userConfig)).not.toBeNull();
-      expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
+      const config = getProjectConfig(folder, userConfig);
+      expect(config).toMatchObject({
+        sourceDir: '/multiple/android',
+        appName: '',
+        packageName: 'com.some.example',
+        manifestPath: '/multiple/android/src/main/AndroidManifest.xml',
+      });
     });
   });
 

--- a/packages/platform-android/src/config/findAndroidAppFolder.ts
+++ b/packages/platform-android/src/config/findAndroidAppFolder.ts
@@ -9,16 +9,9 @@
 import fs from 'fs';
 import path from 'path';
 
-export default function findAndroidAppFolder(folder: string) {
-  const flat = 'android';
-  const nested = path.join('android', 'app');
-
-  if (fs.existsSync(path.join(folder, nested))) {
-    return nested;
-  }
-
-  if (fs.existsSync(path.join(folder, flat))) {
-    return flat;
+export default function findAndroidAppFolder(root: string) {
+  if (fs.existsSync(path.join(root, 'android'))) {
+    return 'android';
   }
 
   return null;

--- a/packages/platform-android/src/config/findAndroidDir.ts
+++ b/packages/platform-android/src/config/findAndroidDir.ts
@@ -9,7 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 
-export default function findAndroidAppFolder(root: string) {
+export default function findAndroidDir(root: string) {
   if (fs.existsSync(path.join(root, 'android'))) {
     return 'android';
   }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -7,7 +7,7 @@
  */
 
 import path from 'path';
-import findAndroidAppFolder from './findAndroidAppFolder';
+import findAndroidDir from './findAndroidDir';
 import findManifest from './findManifest';
 import findPackageClassName from './findPackageClassName';
 import readManifest from './readManifest';
@@ -24,16 +24,17 @@ export function projectConfig(
   root: string,
   userConfig: AndroidProjectParams = {},
 ): AndroidProjectConfig | null {
-  const src = userConfig.sourceDir || findAndroidAppFolder(root);
+  const src = userConfig.sourceDir || findAndroidDir(root);
 
   if (!src) {
     return null;
   }
 
   const sourceDir = path.join(root, src);
+  const appName = userConfig.appName || 'app';
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
-    : findManifest(sourceDir);
+    : findManifest(path.join(sourceDir, appName));
 
   if (!manifestPath) {
     return null;
@@ -49,6 +50,7 @@ export function projectConfig(
 
   return {
     sourceDir,
+    appName,
     packageName,
     manifestPath,
   };
@@ -58,16 +60,17 @@ export function dependencyConfig(
   root: string,
   userConfig: AndroidDependencyParams = {},
 ) {
-  const src = userConfig.sourceDir || findAndroidAppFolder(root);
+  const src = userConfig.sourceDir || findAndroidDir(root);
 
   if (!src) {
     return null;
   }
 
   const sourceDir = path.join(root, src);
+  const appName = userConfig.appName || 'app';
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
-    : findManifest(sourceDir);
+    : findManifest(path.join(sourceDir, appName));
 
   if (!manifestPath) {
     return null;
@@ -91,5 +94,5 @@ export function dependencyConfig(
   const packageInstance =
     userConfig.packageInstance || `new ${packageClassName}()`;
 
-  return {sourceDir, packageName, packageImportPath, packageInstance};
+  return {sourceDir, appName, packageName, packageImportPath, packageInstance};
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -14,22 +14,23 @@ import readManifest from './readManifest';
 import {
   AndroidProjectParams,
   AndroidDependencyParams,
+  AndroidProjectConfig,
 } from '@react-native-community/cli-types';
 import {XmlDocument} from 'xmldoc';
 
 const getPackageName = (manifest: XmlDocument) => manifest.attr.package;
 
 export function projectConfig(
-  folder: string,
+  root: string,
   userConfig: AndroidProjectParams = {},
-) {
-  const src = userConfig.sourceDir || findAndroidAppFolder(folder);
+): AndroidProjectConfig | null {
+  const src = userConfig.sourceDir || findAndroidAppFolder(root);
 
   if (!src) {
     return null;
   }
 
-  const sourceDir = path.join(folder, src);
+  const sourceDir = path.join(root, src);
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);
@@ -49,20 +50,21 @@ export function projectConfig(
   return {
     sourceDir,
     packageName,
+    manifestPath,
   };
 }
 
 export function dependencyConfig(
-  folder: string,
+  root: string,
   userConfig: AndroidDependencyParams = {},
 ) {
-  const src = userConfig.sourceDir || findAndroidAppFolder(folder);
+  const src = userConfig.sourceDir || findAndroidAppFolder(root);
 
   if (!src) {
     return null;
   }
 
-  const sourceDir = path.join(folder, src);
+  const sourceDir = path.join(root, src);
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -7,6 +7,7 @@
  */
 
 import path from 'path';
+import fs from 'fs';
 import findAndroidDir from './findAndroidDir';
 import findManifest from './findManifest';
 import findPackageClassName from './findPackageClassName';
@@ -31,7 +32,8 @@ export function projectConfig(
   }
 
   const sourceDir = path.join(root, src);
-  const appName = userConfig.appName || 'app';
+  const appName = getAppName(sourceDir, userConfig.appName);
+
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(path.join(sourceDir, appName));
@@ -54,6 +56,19 @@ export function projectConfig(
     packageName,
     manifestPath,
   };
+}
+
+function getAppName(sourceDir: string, userConfigAppName: string | undefined) {
+  let appName = '';
+  if (
+    typeof userConfigAppName === 'string' &&
+    fs.existsSync(path.join(sourceDir, userConfigAppName))
+  ) {
+    appName = userConfigAppName;
+  } else if (fs.existsSync(path.join(sourceDir, 'app'))) {
+    appName = 'app';
+  }
+  return appName;
 }
 
 export function dependencyConfig(


### PR DESCRIPTION
Summary:
---------

Defer reading as much as possible from the shared config.
Details:
- removed `root` option in favor of deriving it from config. 
- (**possibly breaking**) changed `sourceDir` to only look for `android/` directory, which is a Gradle root project – this aligns `sourceDir` to iOS and allows for greater flexibility, because `android/app` was a hardcoded name for a default `appFolder`, which would likely break stuff when somebody started using `appFolder` flag
- remove `--appFolder` and `--appId` flags
- add `android.project.appName` to compensate for `appFolder`
- fix running app with `appIdSuffix`, when app uses flavors

Fixes #781. 

Test Plan:
----------

Updated tests. 
