### PR TITLE
fix null podspecPath if autolinking is disabled

### DIFF
--- a/packages/platform-ios/src/link/warnAboutPodInstall.ts
+++ b/packages/platform-ios/src/link/warnAboutPodInstall.ts
@@ -12,7 +12,7 @@ export default function warnAboutPodInstall(config: Config) {
     .map(depName => {
       const dependency = config.dependencies[depName].platforms.ios;
       return dependency && dependency.podspecPath
-        ? path.basename(dependency.podspecPath).replace(/\.podspec/, '')
+        ? path.basename(dependency.podspecPath || '').replace(/\.podspec/, '')
         : '';
     })
     .filter(Boolean);


### PR DESCRIPTION
Summary:
---------

if autolink is disabled and dependency.podspecPath is null run command fails with:

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received type object
    at validateString (internal/validators.js:125:11)
    at Object.basename (path.js:1289:5)

Test Plan:
----------

this affects projects with dependency of 
`"@react-native-community/cli-platform-ios": "3.0.0-alpha.6",`



- Create new project
- update Podfile by removing auto linking code

```
# require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
```

and

```
 use_native_modules!()
```

`react-native run-ios`


NOTE:

`"@react-native-community/cli-platform-ios": "3.0.0-alpha.2",`

works fine