### PR TITLE
Added interactivity for launching emulators and app on devices

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/adb.ts
+++ b/packages/platform-android/src/commands/runAndroid/adb.ts
@@ -22,7 +22,7 @@ function parseDevicesResult(result: string): Array<string> {
   for (let i = 0; i < lines.length; i++) {
     const words = lines[i].split(/[ ,\t]+/).filter(w => w !== '');
 
-    if (words[1] === 'device') {
+    if (words[1] === 'device' && words[0] !== '') {
       devices.push(words[0]);
     }
   }

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -41,6 +41,7 @@ export interface Flags {
   port: number;
   terminal: string;
   jetifier: boolean;
+  interactive: boolean;
 }
 
 /**
@@ -263,6 +264,7 @@ function installAndLaunchOnDevice(
     packageName,
     adbPath,
     args.mainActivity,
+    args.interactive,
   );
 }
 
@@ -435,6 +437,12 @@ export default {
       name: '--no-jetifier',
       description:
         'Do not run "jetifier" – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that don\'t support AndroidX yet. See more at: https://www.npmjs.com/package/jetifier.',
+      default: false,
+    },
+    {
+      name: '--no-interactive',
+      description:
+        'Do not prompt the user for choices if applicable, choose the default value.',
       default: false,
     },
   ],

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -89,15 +89,11 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
     // result == 'not_running'
     logger.info('Starting JS server...');
     try {
-      startServerInNewWindow(
-        args.port,
-        args.terminal,
-        config.reactNativePath,
-      );
+      startServerInNewWindow(args.port, args.terminal, config.reactNativePath);
     } catch (error) {
       logger.warn(
         `Failed to automatically start the packager server. Please run "react-native start" manually. Error details: ${
-        error.message
+          error.message
         }`,
       );
     }
@@ -145,11 +141,16 @@ async function buildAndRun(args: Flags) {
     devices = adb.getDevices(adbPath);
   }
 
-  if (devices && devices.length > 1 && devices.filter(Boolean).length > 1 && args.interactive) {
+  if (
+    devices &&
+    devices.length > 1 &&
+    devices.filter(Boolean).length > 1 &&
+    args.interactive
+  ) {
     devices = await chooseDevice(devices);
   }
 
-  if (args.deviceId || devices && devices.length === 1) {
+  if (args.deviceId || (devices && devices.length === 1)) {
     return runOnSpecificDevice(
       args,
       cmd,
@@ -170,18 +171,14 @@ async function buildAndRun(args: Flags) {
   }
 }
 
-async function chooseDevice(
-  devices: Array<string>
-) {
+async function chooseDevice(devices: Array<string>) {
   const {chosenDevice} = await inquirer.prompt([
     {
       type: 'list',
       name: 'chosenDevice',
-      message: 'On which device would you like to launch the app?\n(This behaviour can be avoided using the --no-interactive flag)',
-      choices: [
-        ...devices,
-        'All of them',
-      ]
+      message:
+        'On which device would you like to launch the app?\n(This behaviour can be avoided using the --no-interactive flag)',
+      choices: [...devices, 'All of them'],
     },
   ]);
 

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -149,7 +149,7 @@ async function buildAndRun(args: Flags) {
     devices = await chooseDevice(devices);
   }
 
-  if (args.deviceId || devices.length === 1) {
+  if (args.deviceId || devices && devices.length === 1) {
     return runOnSpecificDevice(
       args,
       cmd,
@@ -158,7 +158,7 @@ async function buildAndRun(args: Flags) {
       adbPath,
       devices,
     );
-  } else {
+  } else if (devices && devices.length > 1) {
     return runOnAllDevices(
       args,
       cmd,
@@ -198,9 +198,13 @@ function runOnSpecificDevice(
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
-  devices: Array<string>,
+  devices: Array<string> | undefined,
 ) {
   const {deviceId} = args;
+
+  if (!devices) {
+    devices = [];
+  }
 
   if (devices.length > 0 && deviceId) {
     if (devices.indexOf(deviceId) !== -1) {

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -36,7 +36,7 @@ async function runOnAllDevices(
   adbPath: string,
   devices: Array<string>,
 ) {
-  if (devices.length === 0) {
+  if (devices && devices.length === 0) {
     logger.info('Launching emulator(s)...');
     const result = await tryLaunchEmulator(adbPath, args.interactive);
     if (result.success) {
@@ -70,7 +70,7 @@ async function runOnAllDevices(
     throw createInstallError(error);
   }
 
-  if (devices.length > 0) {
+  if (devices && devices.length > 0) {
     for (let i = 0; i < devices.length; i++) {
       const device = devices[i];
       tryRunAdbReverse(args.port, device);

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -34,7 +34,7 @@ async function runOnAllDevices(
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
-  devices: Array<string | void>,
+  devices: Array<string>,
 ) {
   if (devices.length === 0) {
     logger.info('Launching emulator(s)...');

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -78,7 +78,7 @@ function checkUsers(
     let end = false;
 
     while (!end && stdout) {
-      const result = regex.exec(stdout);
+      const result = regex.exec(stdout.toString());
 
       if (!result) {
         end = true;

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -7,14 +7,17 @@
  */
 
 import {spawnSync} from 'child_process';
+// @ts-ignore untyped
+import inquirer from 'inquirer';
 import {logger, CLIError} from '@react-native-community/cli-tools';
 
-function tryLaunchAppOnDevice(
+async function tryLaunchAppOnDevice(
   device: string | void,
   packageNameWithSuffix: string,
   packageName: string,
   adbPath: string,
   mainActivity: string,
+  interactive: boolean,
 ) {
   try {
     const adbArgs = [
@@ -30,11 +33,88 @@ function tryLaunchAppOnDevice(
     } else {
       logger.info('Starting the app...');
     }
+
+    // Skip even checking the users if not interactive
+    if (interactive) {
+      const users = checkUsers(device, adbPath);
+
+      if (users && users.length > 1) {
+        const user = await chooseUser(users);
+
+        if (user) {
+          // Push '--user USER_ID' after 'start'
+          adbArgs.splice(adbArgs.indexOf('start') + 1, 0, '--user', user);
+        }
+      }
+    }
+
     logger.debug(`Running command "${adbPath} ${adbArgs.join(' ')}"`);
     spawnSync(adbPath, adbArgs, {stdio: 'inherit'});
   } catch (error) {
     throw new CLIError('Failed to start the app.', error);
   }
+}
+
+function checkUsers(
+  device: string | void,
+  adbPath: string,
+) {
+  try {
+    const adbArgs = [
+      'shell',
+      'pm',
+      'list',
+      'users',
+    ];
+
+    if (device) {
+      adbArgs.splice(0, 0, '-s', device);
+    }
+
+    logger.info(`Checking users on "${device}"...`);
+    const {stdout} = spawnSync(adbPath, adbArgs, {encoding: 'utf-8'});
+    const regex = new RegExp(/UserInfo{([0-9]*):([^:]*):[0-9]*}/, 'g');
+    const users = [];
+    let end = false;
+
+    while (!end && stdout) {
+      const result = regex.exec(stdout);
+
+      if (!result) {
+        end = true;
+      } else {
+        users.push({
+          id: result[1],
+          name: result[2],
+        });
+      }
+    }
+
+    if (users.length > 1) {
+      logger.info(`Available users are:\n${users.map((user) => `${user.name} - ${user.id}`).join('\n')}`);
+    }
+
+    return users;
+  } catch (error) {
+    logger.error('Failed to check users of device.', error);
+    return [];
+  }
+}
+
+async function chooseUser(
+  users: Array<{id: string, name: string}>
+) {
+  const {chosenUserName} = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'chosenUserName',
+      message: 'Which profile would you like to launch your app into?\n(This behaviour can be avoided using the --no-interactive flag)',
+      choices: users,
+    },
+  ]);
+  const chosenUser = users.find((user) => user.name === chosenUserName);
+
+  return chosenUser && chosenUser.id;
 }
 
 export default tryLaunchAppOnDevice;

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -55,17 +55,9 @@ async function tryLaunchAppOnDevice(
   }
 }
 
-function checkUsers(
-  device: string | void,
-  adbPath: string,
-) {
+function checkUsers(device: string | void, adbPath: string) {
   try {
-    const adbArgs = [
-      'shell',
-      'pm',
-      'list',
-      'users',
-    ];
+    const adbArgs = ['shell', 'pm', 'list', 'users'];
 
     if (device) {
       adbArgs.splice(0, 0, '-s', device);
@@ -91,7 +83,11 @@ function checkUsers(
     }
 
     if (users.length > 1) {
-      logger.info(`Available users are:\n${users.map((user) => `${user.name} - ${user.id}`).join('\n')}`);
+      logger.info(
+        `Available users are:\n${users
+          .map(user => `${user.name} - ${user.id}`)
+          .join('\n')}`,
+      );
     }
 
     return users;
@@ -101,18 +97,17 @@ function checkUsers(
   }
 }
 
-async function chooseUser(
-  users: Array<{id: string, name: string}>
-) {
+async function chooseUser(users: Array<{id: string; name: string}>) {
   const {chosenUserName} = await inquirer.prompt([
     {
       type: 'list',
       name: 'chosenUserName',
-      message: 'Which profile would you like to launch your app into?\n(This behaviour can be avoided using the --no-interactive flag)',
+      message:
+        'Which profile would you like to launch your app into?\n(This behaviour can be avoided using the --no-interactive flag)',
       choices: users,
     },
   ]);
-  const chosenUser = users.find((user) => user.name === chosenUserName);
+  const chosenUser = users.find(user => user.name === chosenUserName);
 
   return chosenUser && chosenUser.id;
 }

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -55,18 +55,14 @@ const launchEmulator = async (emulatorName: string, adbPath: string) => {
   });
 };
 
-async function chooseEmulator(
-  emulators: Array<string>
-) {
+async function chooseEmulator(emulators: Array<string>) {
   const {chosenEmulator} = await inquirer.prompt([
     {
       type: 'list',
       name: 'chosenEmulator',
-      message: 'Which emulator would you like to launch?\n(This behaviour can be avoided using the --no-interactive flag)',
-      choices: [
-        ...emulators,
-        'All of them'
-      ],
+      message:
+        'Which emulator would you like to launch?\n(This behaviour can be avoided using the --no-interactive flag)',
+      choices: [...emulators, 'All of them'],
     },
   ]);
 
@@ -92,7 +88,9 @@ export default async function tryLaunchEmulator(
       }
 
       if (Array.isArray(emulatorOrEmulators)) {
-        const promises = emulatorOrEmulators.map((emulator) => launchEmulator(emulator, adbPath));
+        const promises = emulatorOrEmulators.map(emulator =>
+          launchEmulator(emulator, adbPath),
+        );
 
         await Promise.all(promises);
       } else {


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Motivation is explained in https://github.com/react-native-community/cli/issues/765

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Environment: 
* MacOS Mojave (10.14.6)
* node v8.16.0
* Android Debug Bridge version 1.0.41 / Version 29.0.2-5738569
* With a project started with RN 0.61.2

For each configuration hereafter, I ran :
  * `npx react-native run-android`
  * `npx react-native run-android --no-interactive`

Tried the change with several configurations :
* No device connected, no emulator started  (2 exist on my machine)
* No device, two emulators started
* One device (Galaxy s8 - Android 9), no emulator started
* One device (Galaxy s8 - Android 9), two emulators started
* Two devices  (Galaxy s8 - Android 9/One Plus 6 - Android 9), two emulators started

Both devices have a work profile and a normal profile.

For starting the emulators, when prompted which one to choose (case where no emulator started & no device connected) : 
* Tried starting the first one
* Tried starting the second one
* Tried starting all

When launching the application when several devices/emulators are connected/running:
* Tried launching on each one individually
* Tried launching on all

When choosing the profile to launch the app on:
* Tried the normal profile
* And the work profile

With one phone being in french and the other in english.