### PR TITLE
fix: podfile parsing on invalid yaml

### DIFF
--- a/packages/platform-ios/src/link-pods/__fixtures__/PodfileWithInvalidKey.lock
+++ b/packages/platform-ios/src/link-pods/__fixtures__/PodfileWithInvalidKey.lock
@@ -1,0 +1,16 @@
+PODS:
+  - MyPackage (1.0.0)
+
+EXTERNAL SOURCES:
+  ExternalInterface:
+    :path: !ruby/object:Pathname
+    path: "../node_modules/MyOtherPackage/ios"
+
+SPEC CHECKSUMS:
+  MyPackage: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
+  MyOtherPackage: a9bb76128853e98a9ef6d12b0c8c91debc9bc475
+
+
+PODFILE CHECKSUM: a8110dc7c367fc529b8b6a1084258784444d62ec
+
+COCOAPODS: 1.7.5

--- a/packages/platform-ios/src/link-pods/__tests__/getDependenciesFromPodfileLock.test.ts
+++ b/packages/platform-ios/src/link-pods/__tests__/getDependenciesFromPodfileLock.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import getDependenciesFromPodfileLock from '../getDependenciesFromPodfileLock';
+
+const path = require('path');
+
+const PODFILES_PATH = path.join(__dirname, '../__fixtures__/');
+
+describe('pods::getDependenciesFromPodfileLock', () => {
+  it('only parses parts of the lock file that are valid yaml', () => {
+    const podfileDeps = getDependenciesFromPodfileLock(
+      path.join(PODFILES_PATH, 'PodfileWithInvalidKey.lock'),
+    );
+    expect(podfileDeps).toEqual(['MyPackage', 'MyOtherPackage']);
+  });
+});

--- a/packages/platform-ios/src/link-pods/getDependenciesFromPodfileLock.ts
+++ b/packages/platform-ios/src/link-pods/getDependenciesFromPodfileLock.ts
@@ -3,6 +3,8 @@ import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 import {safeLoad} from 'js-yaml';
 
+const CHECKSUM_KEY = 'SPEC CHECKSUMS';
+
 export default function getDependenciesFromPodfileLock(
   podfileLockPath: string,
 ) {
@@ -18,5 +20,11 @@ export default function getDependenciesFromPodfileLock(
     );
     return [];
   }
-  return Object.keys(safeLoad(fileContent)['SPEC CHECKSUMS'] || {});
+
+  // Previous portions of the lock file could be invalid yaml.
+  // Only parse parts that are valid
+  const tail = fileContent.split(CHECKSUM_KEY).slice(1);
+  const checksumTail = CHECKSUM_KEY + tail;
+
+  return Object.keys(safeLoad(checksumTail)[CHECKSUM_KEY] || {});
 }


### PR DESCRIPTION
Summary:
---------
This PR fixes the issue described at https://github.com/react-native-community/cli/issues/805 where when `Podfile.lock` is an invalid yaml file, the `react-native run ios` command would fail.

To achieve this, I only parse parts of the Podfile we need, which are valid yaml.

Fixes #805


Test Plan:
----------
Unit test insures that error no longer happens and output is correct.
