### PR TITLE
feat: cleaned-up `start` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -445,38 +445,6 @@ Starts the server that communicates with connected devices
 
 Specify port to listen on
 
-#### `--projectRoot [path]`
-
-Path to a custom project root
-
-#### `--watchFolders [list]`
-
-Specify any additional folders to be added to the watch list
-
-#### `--assetExts [list]`
-
-Specify any additional asset extensions to be used by the packager
-
-#### `--sourceExts [list]`
-
-Specify any additional source extensions to be used by the packager
-
-#### `--platforms [list]`
-
-Specify any additional platforms to be used by the packager
-
-#### `--providesModuleNodeModules [list]`
-
-Specify any npm packages that import dependencies with providesModule
-
-#### `--max-workers [number]`
-
-Specifies the maximum number of workers the worker-pool will spawn for transforming files. This defaults to the number of the cores available on your machine
-
-#### `--transformer [string]`
-
-Specify a custom transformer to be used
-
 #### `--reset-cache, --resetCache`
 
 Removes cached files
@@ -501,9 +469,9 @@ Path to custom SSL key
 
 Path to custom SSL cert
 
-#### `--config [string]`
+#### `--metroConfig [string]`
 
-Path to the CLI configuration file
+Path to the Metro configuration file (to overwrite the one detected automatically)
 
 ### `uninstall`
 

--- a/packages/cli/src/commands/server/runServer.ts
+++ b/packages/cli/src/commands/server/runServer.ts
@@ -28,7 +28,7 @@ export type Args = {
   port?: number;
   resetCache?: boolean;
   verbose?: boolean;
-  config?: string;
+  metroConfig?: string;
 };
 
 async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
@@ -37,7 +37,8 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
   const reporter = new ReporterImpl(terminal);
 
   const metroConfig = await loadMetroConfig(ctx, {
-    config: args.config,
+    config: args.metroConfig,
+    port: args.port,
     resetCache: args.resetCache,
     reporter,
   });

--- a/packages/cli/src/commands/server/runServer.ts
+++ b/packages/cli/src/commands/server/runServer.ts
@@ -22,12 +22,12 @@ import releaseChecker from '../../tools/releaseChecker';
 export type Args = {
   cert?: string;
   customLogReporterPath?: string;
-  key?: string;
-  config?: string;
   host?: string;
   https?: boolean;
+  key?: string;
   resetCache?: boolean;
   verbose?: boolean;
+  config?: string;
 };
 
 async function runServer(_argv: Array<string>, ctx: Config, args: Args) {

--- a/packages/cli/src/commands/server/runServer.ts
+++ b/packages/cli/src/commands/server/runServer.ts
@@ -20,15 +20,13 @@ import loadMetroConfig from '../../tools/loadMetroConfig';
 import releaseChecker from '../../tools/releaseChecker';
 
 export type Args = {
-  customLogReporterPath?: string;
-  config?: string;
-
   cert?: string;
+  customLogReporterPath?: string;
   key?: string;
+  config?: string;
   host?: string;
   https?: boolean;
   resetCache?: boolean;
-
   verbose?: boolean;
 };
 
@@ -38,8 +36,8 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
   const reporter = new ReporterImpl(terminal);
 
   const metroConfig = await loadMetroConfig(ctx, {
-    resetCache: args.resetCache,
     config: args.config,
+    resetCache: args.resetCache,
     reporter,
   });
 

--- a/packages/cli/src/commands/server/runServer.ts
+++ b/packages/cli/src/commands/server/runServer.ts
@@ -20,22 +20,16 @@ import loadMetroConfig from '../../tools/loadMetroConfig';
 import releaseChecker from '../../tools/releaseChecker';
 
 export type Args = {
-  assetPlugins?: string[];
-  cert?: string;
   customLogReporterPath?: string;
+  config?: string;
+
+  cert?: string;
+  key?: string;
   host?: string;
   https?: boolean;
-  maxWorkers?: number;
-  key?: string;
-  platforms?: string[];
-  port?: number;
   resetCache?: boolean;
-  sourceExts?: string[];
-  transformer?: string;
+
   verbose?: boolean;
-  watchFolders?: string[];
-  config?: string;
-  projectRoot?: string;
 };
 
 async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
@@ -44,21 +38,10 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
   const reporter = new ReporterImpl(terminal);
 
   const metroConfig = await loadMetroConfig(ctx, {
-    config: args.config,
-    maxWorkers: args.maxWorkers,
-    port: args.port,
     resetCache: args.resetCache,
-    watchFolders: args.watchFolders,
-    projectRoot: args.projectRoot,
-    sourceExts: args.sourceExts,
+    config: args.config,
     reporter,
   });
-
-  if (args.assetPlugins) {
-    metroConfig.transformer.assetPlugins = args.assetPlugins.map(plugin =>
-      require.resolve(plugin),
-    );
-  }
 
   const middlewareManager = new MiddlewareManager({
     host: args.host,

--- a/packages/cli/src/commands/server/runServer.ts
+++ b/packages/cli/src/commands/server/runServer.ts
@@ -25,6 +25,7 @@ export type Args = {
   host?: string;
   https?: boolean;
   key?: string;
+  port?: number;
   resetCache?: boolean;
   verbose?: boolean;
   config?: string;

--- a/packages/cli/src/commands/server/server.ts
+++ b/packages/cli/src/commands/server/server.ts
@@ -47,7 +47,7 @@ export default {
       description: 'Path to custom SSL cert',
     },
     {
-      name: '--config [string]',
+      name: '--metroConfig [string]',
       description: 'Path to a custom Metro configuration file',
       parse: (val: string) => path.resolve(val),
     },

--- a/packages/cli/src/commands/server/server.ts
+++ b/packages/cli/src/commands/server/server.ts
@@ -48,7 +48,7 @@ export default {
     },
     {
       name: '--config [string]',
-      description: 'Path to the CLI configuration file',
+      description: 'Path to a custom Metro configuration file',
       parse: (val: string) => path.resolve(val),
     },
   ],

--- a/packages/cli/src/commands/server/server.ts
+++ b/packages/cli/src/commands/server/server.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-
 import path from 'path';
 import runServer from './runServer';
 
@@ -21,60 +20,6 @@ export default {
     {
       name: '--host [string]',
       default: '',
-    },
-    {
-      name: '--projectRoot [path]',
-      description: 'Path to a custom project root',
-      parse: (val: string) => path.resolve(val),
-    },
-    {
-      name: '--watchFolders [list]',
-      description:
-        'Specify any additional folders to be added to the watch list',
-      parse: (val: string) =>
-        val.split(',').map<string>((folder: string) => path.resolve(folder)),
-    },
-    {
-      name: '--assetPlugins [list]',
-      description:
-        'Specify any additional asset plugins to be used by the packager by full filepath',
-      parse: (val: string) => val.split(','),
-    },
-    {
-      name: '--assetExts [list]',
-      description:
-        'Specify any additional asset extensions to be used by the packager',
-      parse: (val: string) => val.split(','),
-    },
-    {
-      name: '--sourceExts [list]',
-      description:
-        'Specify any additional source extensions to be used by the packager',
-      parse: (val: string) => val.split(','),
-    },
-    {
-      name: '--platforms [list]',
-      description:
-        'Specify any additional platforms to be used by the packager',
-      parse: (val: string) => val.split(','),
-    },
-    {
-      name: '--providesModuleNodeModules [list]',
-      description:
-        'Specify any npm packages that import dependencies with providesModule',
-      parse: (val: string) => val.split(','),
-    },
-    {
-      name: '--max-workers [number]',
-      description:
-        'Specifies the maximum number of workers the worker-pool ' +
-        'will spawn for transforming files. This defaults to the number of the ' +
-        'cores available on your machine.',
-      parse: (workers: string) => Number(workers),
-    },
-    {
-      name: '--transformer [string]',
-      description: 'Specify a custom transformer to be used',
     },
     {
       name: '--reset-cache, --resetCache',

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -86,7 +86,6 @@ export const getDefaultConfig = (
   ctx: Config,
   opts: DefaultConfigOptions,
 ): MetroConfig => {
-  const hasteImplPath = path.join(ctx.reactNativePath, 'jest/hasteImpl.js');
   return {
     resolver: {
       resolverMainFields: ['react-native', 'browser', 'main'],

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -62,11 +62,25 @@ export interface MetroConfig {
   reporter?: any;
 }
 
-export interface ConfigOptions {
+/**
+ * Options that can be used to tweak the default configuration
+ * that is later passed to Metro
+ */
+type DefaultConfigOptions = {
+  port?: number;
+  reporter?: any;
+};
+
+/**
+ * Options that change the behaviour of Metro built-in `loadConfig`
+ * function
+ *
+ * Details here: https://github.com/facebook/metro/blob/master/packages/metro-config/src/loadConfig.js#L28-L45
+ */
+export type ConfigOptions = DefaultConfigOptions & {
   resetCache?: boolean;
   config?: string;
-  reporter?: any;
-}
+};
 
 /**
  * Default configuration
@@ -76,7 +90,7 @@ export interface ConfigOptions {
  */
 export const getDefaultConfig = (
   ctx: Config,
-  opts: ConfigOptions,
+  opts: DefaultConfigOptions,
 ): MetroConfig => {
   const hasteImplPath = path.join(ctx.reactNativePath, 'jest/hasteImpl.js');
   return {
@@ -99,7 +113,7 @@ export const getDefaultConfig = (
         require(path.join(ctx.reactNativePath, 'rn-get-polyfills'))(),
     },
     server: {
-      port: Number(process.env.RCT_METRO_PORT) || 8081,
+      port: Number(process.env.RCT_METRO_PORT) || opts.port || 8081,
     },
     symbolicator: {
       customizeFrame: (frame: {file: string | null}) => {

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -9,7 +9,6 @@ import {loadConfig} from 'metro-config';
 import {existsSync} from 'fs';
 import {Config} from '@react-native-community/cli-types';
 import findSymlinkedModules from './findSymlinkedModules';
-import {options} from '@hapi/joi';
 
 function resolveSymlinksForRoots(roots: string[]): string[] {
   return roots.reduce<string[]>(


### PR DESCRIPTION
Summary:
---------

This PR cleans up "start" command by:
- removing extraneous options that were never actually read (e.g. "transformer" was specified as a flag, but never passed to any line of code. "platforms" was defined, but never read. "providesNodeModules" as well). I am not entirely sure how we ended up in such state, but removing them should help with reducing potential confusion when developers are listing down flags that a command accepts
- removing options that are possible to be defined in a regular Metro configuration and there is no need to repeat support for them ("projectRoots", "assetsExts" and more, I have consulted official Metro website for that)
- renamed "config" to "metroConfig"

For use cases when someone wants to customize "react-native start" on per execution basis, they can either edit `metro.config.js` or create a new one and use `--metroConfig` option.

In the follow-up PR, I will be working on improving "MiddlewareManager" to have a smaller API surface and take advantage of the recent developments in Metro.

The goal is to reduce the amount of Metro related code and make Metro versions independent of the CLI. 

Test Plan:
----------

Building and running an app should work.
