### PR TITLE
feat: run npx from JS app dir

### DIFF
--- a/packages/cli/src/tools/config/resolveReactNativePath.ts
+++ b/packages/cli/src/tools/config/resolveReactNativePath.ts
@@ -11,16 +11,14 @@ export default function resolveReactNativePath(root: string) {
     return resolveNodeModuleDir(root, 'react-native');
   } catch (_ignored) {
     throw new CLIError(`
-      Unable to find React Native files. Make sure "react-native" module is installed
+      Unable to find React Native files looking up from ${root}. Make sure "react-native" module is installed
       in your project dependencies.
 
       If you are using React Native from a non-standard location, consider setting:
       {
-        "react-native": {
-          "reactNativePath": "./path/to/react-native"
-        }
+        reactNativePath: "./path/to/react-native"
       }
-      in your \`package.json\`.
+      in your \`react-native.config.js\`.
     `);
   }
 }

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -2,6 +2,7 @@ import groovy.json.JsonSlurper
 import org.gradle.initialization.DefaultSettings
 import org.apache.tools.ant.taskdefs.condition.Os
 
+def jsAppDir = buildscript.getProperties().get("sourceFile").toString().split("node_modules/@react-native-community/cli-platform-android/native_modules.gradle")[0]
 def generatedFileName = "PackageList.java"
 def generatedFilePackage = "com.facebook.react"
 def generatedFileContentsTemplate = """
@@ -71,12 +72,14 @@ public class PackageList {
 class ReactNativeModules {
   private Logger logger
   private String packageName
+  private String jsAppDir
   private ArrayList<HashMap<String, String>> reactNativeModules
 
   private static String LOG_PREFIX = ":ReactNative:"
 
-  ReactNativeModules(Logger logger) {
+  ReactNativeModules(Logger logger, String jsAppDir) {
     this.logger = logger
+    this.jsAppDir = jsAppDir
 
     def (nativeModules, packageName) = this.getReactNativeConfig()
     this.reactNativeModules = nativeModules
@@ -150,13 +153,13 @@ class ReactNativeModules {
     if (this.reactNativeModules != null) return this.reactNativeModules
     ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
 
-    def cmdProcess
     def npx = Os.isFamily(Os.FAMILY_WINDOWS) ? "npx.cmd" : "npx"
-    def command = "${npx} --quiet react-native config"
+    def command = "${npx} --quiet --no-install react-native config"
     def reactNativeConfigOutput = ""
 
     try {
-      cmdProcess = Runtime.getRuntime().exec(command)
+      // When running Gradle from CWD that's outside of JS project, it's necessary to pass a CWD that's close to JS app,// so that npx can resolve to correct local CLI, instead of possibly installed global, corrupting config output
+      def cmdProcess = Runtime.getRuntime().exec(command, null, new File(this.jsAppDir))
       def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
       def buff = ""
       def readBuffer = new StringBuffer()
@@ -164,23 +167,28 @@ class ReactNativeModules {
           readBuffer.append(buff)
       }
       reactNativeConfigOutput = readBuffer.toString()
-    } catch (Exception exception) {
-      this.logger.warn("${LOG_PREFIX}${exception.message}")
-      this.logger.warn("${LOG_PREFIX}Automatic import of native modules failed.")
 
-      def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
-      def buff = ""
-      def readBuffer = new StringBuffer()
-      while ((buff = bufferedErrorReader.readLine()) != null){
-          readBuffer.append(buff)
+      if (!reactNativeConfigOutput) {
+        def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
+        def errBuff = ""
+        def readErrorBuffer = new StringBuffer()
+        while ((errBuff = bufferedErrorReader.readLine()) != null){
+            readErrorBuffer.append(errBuff)
+        }
+        throw new Exception(readErrorBuffer.toString())
       }
-      this.logger.warn("${LOG_PREFIX}${readBuffer.toString()}")
-
-      return reactNativeModules
+    } catch (Exception exception) {
+      this.logger.error("${LOG_PREFIX}Automatic import of native modules failed.")
+      throw exception
     }
 
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
     def dependencies = json["dependencies"]
+    def project = json["project"]["android"]
+
+    if (project == null) {
+      throw new Exception("React Native CLI failed to determine Android project configuration. This is likely due to misconfiguration. Config output:\n${json.toMapString()}")
+    }
 
     dependencies.each { name, value ->
       def platformsConfig = value["platforms"];
@@ -211,7 +219,7 @@ class ReactNativeModules {
  *    Exported Extensions
  * ------------------------ */
 
-def autoModules = new ReactNativeModules(logger)
+def autoModules = new ReactNativeModules(logger, jsAppDir)
 
 ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String root = null ->
   if (root != null) {

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -158,7 +158,9 @@ class ReactNativeModules {
     def reactNativeConfigOutput = ""
 
     try {
-      // When running Gradle from CWD that's outside of JS project, it's necessary to pass a CWD that's close to JS app,// so that npx can resolve to correct local CLI, instead of possibly installed global, corrupting config output
+      // Running npx from the directory of the JS app which holds this script in its node_modules.
+      // We do so, because Gradle may be ran from a different directory, that's outside of JS project,
+      // in which case npx wouldn't resolve correct `react-native` binary
       def cmdProcess = Runtime.getRuntime().exec(command, null, new File(this.jsAppDir))
       def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
       def buff = ""

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -160,7 +160,7 @@ class ReactNativeModules {
       }
       output = readBuffer.toString()
       if (!output) {
-        this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
+        this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command from '${directory}' directory.")
         def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
         def errBuff = ""
         def readErrorBuffer = new StringBuffer()
@@ -171,7 +171,7 @@ class ReactNativeModules {
       }
       return output
     } catch (Exception exception) {
-      this.logger.error("${LOG_PREFIX}Running '${command}' command failed.")
+      this.logger.error("${LOG_PREFIX}Running '${command}' command from '${directory}' directory failed.")
       throw exception
     }
   }
@@ -190,7 +190,13 @@ class ReactNativeModules {
     // in which case npx wouldn't resolve correct `react-native` binary
     def dir = new File(this.jsAppDir)
     def reactNativeConfigOutput = this.getCommandOutput(command, dir)
-    def json = new JsonSlurper().parseText(reactNativeConfigOutput)
+    def json
+    try {
+      json = new JsonSlurper().parseText(reactNativeConfigOutput)
+    } catch (Exception exception) {
+      this.logger.error("${LOG_PREFIX}Failed to parse React Native CLI configuration: ${exception.toString()}")
+      throw new Exception("Failed to parse React Native CLI configuration. Expected running '${command}' command from '${dir}' directory to output valid JSON, but it didn't. This may be caused by npx resolving to a legacy global react-native binary. Please make sure to uninstall any global 'react-native' binaries: 'npm uninstall -g react-native react-native-cli' and try again")
+    }
     def dependencies = json["dependencies"]
     def project = json["project"]["android"]
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -145,45 +145,51 @@ class ReactNativeModules {
   }
 
   /**
-   * Runs a process to call the React Native CLI Config command and parses the output
-   *
-   * @return ArrayList < HashMap < String , String > >
+   * Runs a specified command using Runtime exec() in a specified directory.
+   * Throws when the command result is empty.
    */
-  ArrayList<HashMap<String, String>> getReactNativeConfig() {
-    if (this.reactNativeModules != null) return this.reactNativeModules
-    ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
-
-    def npx = Os.isFamily(Os.FAMILY_WINDOWS) ? "npx.cmd" : "npx"
-    def command = "${npx} --quiet --no-install react-native config"
-    def reactNativeConfigOutput = ""
-
+  String getCommandOutput(String command, File directory = null) {
     try {
-      // Running npx from the directory of the JS app which holds this script in its node_modules.
-      // We do so, because Gradle may be ran from a different directory, that's outside of JS project,
-      // in which case npx wouldn't resolve correct `react-native` binary
-      def cmdProcess = Runtime.getRuntime().exec(command, null, new File(this.jsAppDir))
+      def output = ""
+      def cmdProcess = Runtime.getRuntime().exec(command, null, directory)
       def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
       def buff = ""
       def readBuffer = new StringBuffer()
-      while ((buff = bufferedReader.readLine()) != null){
-          readBuffer.append(buff)
+      while ((buff = bufferedReader.readLine()) != null) {
+        readBuffer.append(buff)
       }
-      reactNativeConfigOutput = readBuffer.toString()
-
-      if (!reactNativeConfigOutput) {
+      output = readBuffer.toString()
+      if (!output) {
+        this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
         def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
         def errBuff = ""
         def readErrorBuffer = new StringBuffer()
-        while ((errBuff = bufferedErrorReader.readLine()) != null){
-            readErrorBuffer.append(errBuff)
+        while ((errBuff = bufferedErrorReader.readLine()) != null) {
+          readErrorBuffer.append(errBuff)
         }
         throw new Exception(readErrorBuffer.toString())
       }
+      return output
     } catch (Exception exception) {
-      this.logger.error("${LOG_PREFIX}Automatic import of native modules failed.")
+      this.logger.error("${LOG_PREFIX}Running '${command}' command failed.")
       throw exception
     }
+  }
 
+  /**
+   * Runs a process to call the React Native CLI Config command and parses the output
+   */
+  ArrayList<HashMap<String, String>> getReactNativeConfig() {
+    if (this.reactNativeModules != null) return this.reactNativeModules
+
+    ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
+    def npx = Os.isFamily(Os.FAMILY_WINDOWS) ? "npx.cmd" : "npx"
+    def command = "${npx} --quiet --no-install react-native config"
+    // Running npx from the directory of the JS app which holds this script in its node_modules.
+    // We do so, because Gradle may be ran from a different directory, that's outside of JS project,
+    // in which case npx wouldn't resolve correct `react-native` binary
+    def dir = new File(this.jsAppDir)
+    def reactNativeConfigOutput = this.getCommandOutput(command, dir)
     def json = new JsonSlurper().parseText(reactNativeConfigOutput)
     def dependencies = json["dependencies"]
     def project = json["project"]["android"]

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -2,7 +2,7 @@ import groovy.json.JsonSlurper
 import org.gradle.initialization.DefaultSettings
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def jsAppDir = buildscript.getProperties().get("sourceFile").toString().split("node_modules/@react-native-community/cli-platform-android/native_modules.gradle")[0]
+def jsAppDir = buildscript.sourceFile.toString().split("node_modules/@react-native-community/cli-platform-android/native_modules.gradle")[0]
 def generatedFileName = "PackageList.java"
 def generatedFilePackage = "com.facebook.react"
 def generatedFileContentsTemplate = """

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -2,7 +2,7 @@ import groovy.json.JsonSlurper
 import org.gradle.initialization.DefaultSettings
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def jsAppDir = buildscript.sourceFile.toString().split("node_modules/@react-native-community/cli-platform-android/native_modules.gradle")[0]
+def jsAppDir = buildscript.sourceFile.toString().split("node_modules/@react-native-community/cli-platform-android")[0]
 def generatedFileName = "PackageList.java"
 def generatedFilePackage = "com.facebook.react"
 def generatedFileContentsTemplate = """
@@ -185,9 +185,11 @@ class ReactNativeModules {
     ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
     def npx = Os.isFamily(Os.FAMILY_WINDOWS) ? "npx.cmd" : "npx"
     def command = "${npx} --quiet --no-install react-native config"
-    // Running npx from the directory of the JS app which holds this script in its node_modules.
-    // We do so, because Gradle may be ran from a different directory, that's outside of JS project,
-    // in which case npx wouldn't resolve correct `react-native` binary
+    /**
+     * Running npx from the directory of the JS app which holds this script in its node_modules.
+     * We do so, because Gradle may be ran with a different directory as CWD, that's outside of JS project
+     * (e.g. when running with -p flag), in which case npx wouldn't resolve correct `react-native` binary.
+     */
     def dir = new File(this.jsAppDir)
     def reactNativeConfigOutput = this.getCommandOutput(command, dir)
     def json


### PR DESCRIPTION
Summary:
---------

Gradle may be run from a driectory that's outside of JS project, with a passed project dir (through `-p` flag) like `path/to/app/android/gradlew bundleRelease -p ../app/android/app`. 

```
project/
  app/ -> js, android, ios files
  scripts/ -> running gradlew from here, e.g. through Fastlane
```

Gradle CWD is usually (maybe always, but they don't give guarantees) set to the directory where it's ran from. This tricks `npx`, which doesn't know where to find `react-native` binary. To account for it, we can spawn `npx` with a CWD passed to it. We don't need an exact path to android project directory, path to the project which holds `@react-native-community/cli` in node_modules is just fine with current config search mechanism.

I'm not 100% sure about this fix, open for discussion.

Fixes #793 
Fixes #804

Test Plan:
----------

I don't have an automated test for this, you'll need to verify on repro provided in #793. 