### PR TITLE
fix: Properly handle --host param for remote debugging

### DIFF
--- a/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
@@ -9,8 +9,9 @@ import {logger} from '@react-native-community/cli-tools';
 import {exec} from 'child_process';
 import launchDebugger from '../launchDebugger';
 
-function launchDefaultDebugger(port: number, args = '') {
-  const debuggerURL = `http://localhost:${port}/debugger-ui${args}`;
+function launchDefaultDebugger(host: string, port: number, args = '') {
+  const hostname = host || "localhost";
+  const debuggerURL = `http://${hostname}:${port}/debugger-ui${args}`;
   logger.info('Launching Dev Tools...');
   launchDebugger(debuggerURL);
 }
@@ -20,10 +21,10 @@ function escapePath(pathname: string) {
   return `"${pathname}"`;
 }
 
-type LaunchDevToolsOptions = {port: number; watchFolders: Array<string>};
+type LaunchDevToolsOptions = {host: string, port: number; watchFolders: Array<string>};
 
 function launchDevTools(
-  {port, watchFolders}: LaunchDevToolsOptions,
+  {host, port, watchFolders}: LaunchDevToolsOptions,
   isDebuggerConnected: () => boolean,
 ) {
   // Explicit config always wins
@@ -32,7 +33,7 @@ function launchDevTools(
     startCustomDebugger({watchFolders, customDebugger});
   } else if (!isDebuggerConnected()) {
     // Debugger is not yet open; we need to open a session
-    launchDefaultDebugger(port);
+    launchDefaultDebugger(host, port);
   }
 }
 

--- a/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
@@ -10,7 +10,7 @@ import {exec} from 'child_process';
 import launchDebugger from '../launchDebugger';
 
 function launchDefaultDebugger(host: string, port: number, args = '') {
-  const hostname = host || "localhost";
+  const hostname = host || 'localhost';
   const debuggerURL = `http://${hostname}:${port}/debugger-ui${args}`;
   logger.info('Launching Dev Tools...');
   launchDebugger(debuggerURL);
@@ -21,7 +21,11 @@ function escapePath(pathname: string) {
   return `"${pathname}"`;
 }
 
-type LaunchDevToolsOptions = {host: string, port: number; watchFolders: Array<string>};
+type LaunchDevToolsOptions = {
+  host: string;
+  port: number;
+  watchFolders: Array<string>;
+};
 
 function launchDevTools(
   {host, port, watchFolders}: LaunchDevToolsOptions,


### PR DESCRIPTION
Summary:
---------
When running metro on one machine and a react-native app on another, /launch-js-devtools causes the metro process to launch localhost:8081. However, the hostname can be overridden by the --host parameter to react-native start, which because of the hardcoding of localhost, causes the web debugger to not start, breaking the react-native app.

Test Plan:
----------

Manually verified that the RN app can run when running react-native start with both: no params as well as --host <mymachinename> 