### PR TITLE
Remove deprecated lerna field

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.10.6",
   "version": "3.0.0-alpha.7",
   "npmClient": "yarn",
   "useWorkspaces": true


### PR DESCRIPTION
The `lerna` field is no longer in use. It was made obsolete and removed in Lerna v3.

Reference: https://github.com/lerna/lerna#legacy-fields