### PR TITLE
Add Carthage to excluded directories while finding .xcodeproj

### DIFF
--- a/packages/platform-ios/src/config/findProject.ts
+++ b/packages/platform-ios/src/config/findProject.ts
@@ -27,7 +27,7 @@ const IOS_BASE = 'ios';
 /**
  * These folders will be excluded from search to speed it up
  */
-const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules)/**'];
+const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules|Carthage)/**'];
 
 /**
  * Finds iOS project by looking for all .xcodeproj files


### PR DESCRIPTION
Summary:
---------

Added `Carthage` to excluded directories while finding `.xcodeproj` file.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Add `Carthage/test.xcodeproj` to `ios` directory in example RN (61.4) project and run `pod install` and check if everything is alright.
