### PR TITLE
chore: remove platforms from cli dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ And then:
 
 ```sh
 cd /my/new/react-native/project/
-yarn link "@react-native-community/cli-platform-ios" "@react-native-community/cli-platform-android" "@react-native-community/cli" "@react-native-community/cli-types" "@react-native-community/cli-tools"
+yarn link "@react-native-community/cli-platform-ios" "@react-native-community/cli-platform-android" "@react-native-community/cli" "@react-native-community/cli-types" "@react-native-community/cli-tools" "@react-native-community/cli-debugger-ui"
 
 npx react-native run-android
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,8 +27,6 @@
   },
   "dependencies": {
     "@hapi/joi": "^15.0.3",
-    "@react-native-community/cli-platform-android": "^3.0.0-alpha.7",
-    "@react-native-community/cli-platform-ios": "^3.0.0-alpha.7",
     "@react-native-community/cli-tools": "^3.0.0-alpha.7",
     "@react-native-community/cli-types": "^3.0.0-alpha.7",
     "@react-native-community/cli-debugger-ui": "^3.0.0-alpha.7",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -7,8 +7,6 @@
   "references": [
     {"path": "../tools"},
     {"path": "../cli-types"},
-    {"path": "../platform-ios"},
-    {"path": "../platform-android"},
     {"path": "../debugger-ui"}
   ],
   "include": ["../package.json"]


### PR DESCRIPTION
Summary:
---------

Followup PR to https://github.com/react-native-community/cli/pull/767.
If you're curious, iOS and Android platforms are already shipping with `react-native` as default platforms since 0.60: https://github.com/facebook/react-native/blob/v0.60.0/package.json#L83-L85.

Test Plan:
----------

Green CI
