### PR TITLE
fix: jsAppDir on Windows

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -2,11 +2,7 @@ import groovy.json.JsonSlurper
 import org.gradle.initialization.DefaultSettings
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def sourceFile = buildscript.sourceFile.toString()
-def platformAndroidDir = Os.isFamily(Os.FAMILY_WINDOWS)
-  ? "node_modules\\@react-native-community\\cli-platform-android"
-  : "node_modules/@react-native-community/cli-platform-android"
-def jsAppDir = sourceFile.split(platformAndroidDir)[0]
+def jsAppDir = buildscript.sourceFile.toString().split("node_modules(/|\\\\)@react-native-community(/|\\\\)cli-platform-android")[0]
 def generatedFileName = "PackageList.java"
 def generatedFilePackage = "com.facebook.react"
 def generatedFileContentsTemplate = """

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -2,7 +2,11 @@ import groovy.json.JsonSlurper
 import org.gradle.initialization.DefaultSettings
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def jsAppDir = buildscript.sourceFile.toString().split("node_modules/@react-native-community/cli-platform-android")[0]
+def sourceFile = buildscript.sourceFile.toString()
+def platformAndroidDir = Os.isFamily(Os.FAMILY_WINDOWS)
+  ? "node_modules\\@react-native-community\\cli-platform-android"
+  : "node_modules/@react-native-community/cli-platform-android"
+def jsAppDir = sourceFile.split(platformAndroidDir)[0]
 def generatedFileName = "PackageList.java"
 def generatedFilePackage = "com.facebook.react"
 def generatedFileContentsTemplate = """


### PR DESCRIPTION
Summary:
---------

Apparently Gradle returns backslashes on windows for `buildscript.sourceFile.toString()`: https://github.com/react-native-community/cli/commit/a3a70a19e5b12c009deae5c9993ab0af73511cc2#r35970970. We need to account for that

Test Plan:
----------
Both are supported:
```
/node_modules/@react-native-community/cli-platform-android/
\node_modules\@react-native-community\cli-platform-android\
```