### PR TITLE
fix: update Xcode version range to >= 10; change wording of supported version

### DIFF
--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
-import semver from 'semver';
 import {getHealthchecks, HEALTHCHECK_TYPES} from './healthchecks';
 import {getLoader} from '../../tools/loader';
 import printFixOptions, {KEYS} from './printFixOptions';
@@ -42,14 +41,11 @@ const printIssue = ({
 
   if (needsToBeFixed && versionRange) {
     const versionToShow = version && version !== 'Not Found' ? version : 'N/A';
-    const cleanedVersionRange = semver.valid(semver.coerce(versionRange)!);
 
-    if (cleanedVersionRange) {
-      logMessage(`- Version found: ${chalk.red(versionToShow)}`);
-      logMessage(`- Version supported: ${chalk.green(cleanedVersionRange)}`);
+    logMessage(`- Version found: ${chalk.red(versionToShow)}`);
+    logMessage(`- Version supported: ${chalk.green(versionRange)}`);
 
-      return;
-    }
+    return;
   }
 };
 

--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -36,7 +36,7 @@ const printIssue = ({
       : chalk.yellow('●')
     : chalk.green('✓');
 
-  const descriptionToShow = description ? `- ${description}` : '';
+  const descriptionToShow = description ? ` - ${description}` : '';
 
   logger.log(` ${symbol} ${label}${descriptionToShow}`);
 
@@ -46,9 +46,7 @@ const printIssue = ({
 
     if (cleanedVersionRange) {
       logMessage(`- Version found: ${chalk.red(versionToShow)}`);
-      logMessage(
-        `- Minimum version required: ${chalk.green(cleanedVersionRange)}`,
-      );
+      logMessage(`- Version supported: ${chalk.green(cleanedVersionRange)}`);
 
       return;
     }

--- a/packages/cli/src/commands/doctor/versionRanges.ts
+++ b/packages/cli/src/commands/doctor/versionRanges.ts
@@ -8,5 +8,5 @@ export default {
   ANDROID_SDK: '>= 26.x',
   ANDROID_NDK: '>= 19.x',
   // iOS
-  XCODE: '10.x',
+  XCODE: '11.x',
 };

--- a/packages/cli/src/commands/doctor/versionRanges.ts
+++ b/packages/cli/src/commands/doctor/versionRanges.ts
@@ -8,5 +8,5 @@ export default {
   ANDROID_SDK: '>= 26.x',
   ANDROID_NDK: '>= 19.x',
   // iOS
-  XCODE: '11.x',
+  XCODE: '>= 10.x',
 };


### PR DESCRIPTION
Summary:
---------

This PR fixes an issue with Xcode being shown as `Minimum required version: 10.0.0` even though we officially support `11.x`.

This issue has been reported through https://twitter.com/chakrihacker/status/1196750533224091648.
