### PR TITLE
feat: replace {{ packageName }} in deps' configuration

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -119,15 +119,9 @@ Path to a custom `AndroidManifest.xml`
 
 Custom package import. For example: `import com.acme.AwesomePackage;`.
 
-`{{ packageName }}` will be replaced with the package of `MainApplication`, so you can eg.
-import application's `BuildConfig` class by writing `import {{ packageName }}.BuildConfig;`.
-
 #### platforms.android.packageInstance
 
 Custom syntax to instantiate a package. By default, it's a `new AwesomePackage()`. It can be useful when your package requires additional arguments while initializing.
-
-`{{ packageName }}` will be replaced with the package of `MainApplication`, so you can eg.
-import application's `R` class by writing `new AwesomePackage({{ packageName }}.R.string.key)`.
 
 For settings applicable on other platforms, please consult their respective documentation.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -91,7 +91,7 @@ An array of iOS script phases to add to the project. Specifying a `path` propert
 module.exports = {
   dependency: {
     platforms: {
-     ios: {
+      ios: {
         scriptPhases: [
           {
             name: '[MY DEPENDENCY] My Script',
@@ -119,9 +119,15 @@ Path to a custom `AndroidManifest.xml`
 
 Custom package import. For example: `import com.acme.AwesomePackage;`.
 
+`{{ packageName }}` will be replaced with the package of `MainApplication`, so you can eg.
+import application's `BuildConfig` class by writing `import {{ packageName }}.BuildConfig;`.
+
 #### platforms.android.packageInstance
 
 Custom syntax to instantiate a package. By default, it's a `new AwesomePackage()`. It can be useful when your package requires additional arguments while initializing.
+
+`{{ packageName }}` will be replaced with the package of `MainApplication`, so you can eg.
+import application's `R` class by writing `new AwesomePackage({{ packageName }}.R.string.key)`.
 
 For settings applicable on other platforms, please consult their respective documentation.
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -126,9 +126,11 @@ class ReactNativeModules {
     String packageClassInstances = ""
 
     if (packages.size() > 0) {
+      def interpolateDynamicValues = {
+        it.replace("{{ packageName }}", packageName)
+      }
       packageImports = packageImports + packages.collect {
-        String interpolatedPackageImportPath = it.packageImportPath.replace("{{ packageName }}", packageName)
-        "// ${it.name}\n${interpolatedPackageImportPath}"
+        "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
       }.join('\n')
       packageClassInstances = ",\n      " + packages.collect { it.packageInstance }.join(",\n      ")
     }

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -134,22 +134,22 @@ class ReactNativeModules {
                 // let's prefix all non-FQDN references to those classes with
                 // the package name.
                 //
-                // We want to match:
+                // We want to match "R" or "BuildConfig":
                 //  - new Package(R.string…),
                 //  - Module.configure(BuildConfig);
                 //    ^ hence including (BuildConfig|R)
-                // but we don't want to match:
+                // but we don't want to match "R":
                 //  - new Package(getResources…),
                 //  - new PackageR…,
                 //  - new Royal…,
                 //    ^ hence excluding \w before and after matches
-                //  - Module.configure({{ packageName }}.BuildConfig);
+                // and "BuildConfig" that has FQDN reference:
+                //  - Module.configure(com.acme.BuildConfig);
                 //    ^ hence excluding . before the match.
                 .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
                   wholeString, prefix, className, suffix ->
-                    "${prefix}{{ packageName }}.${className}${suffix}"
+                    "${prefix}packageName.${className}${suffix}"
                 })
-                .replace("{{ packageName }}", packageName)
       }
       packageImports = packages.collect {
         "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -128,11 +128,11 @@ class ReactNativeModules {
     if (packages.size() > 0) {
       def interpolateDynamicValues = {
         it
-                // Before adding the {{ packageName }} replacement mechanism,
+                // Before adding the package replacement mechanism,
                 // BuildConfig and R classes were imported automatically
-                // into the scope of the file. In order to be backwards-compatible
-                // let's prefix all non-FQDN references to those classes with
-                // the package name.
+                // into the scope of the file. We want to replace all
+                // non-FQDN references to those classes with the package name 
+                // of the MainApplication.
                 //
                 // We want to match "R" or "BuildConfig":
                 //  - new Package(R.string…),
@@ -148,7 +148,7 @@ class ReactNativeModules {
                 //    ^ hence excluding . before the match.
                 .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
                   wholeString, prefix, className, suffix ->
-                    "${prefix}packageName.${className}${suffix}"
+                    "${prefix}${packageName}.${className}${suffix}"
                 })
       }
       packageImports = packages.collect {

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -127,7 +127,29 @@ class ReactNativeModules {
 
     if (packages.size() > 0) {
       def interpolateDynamicValues = {
-        it.replace("{{ packageName }}", packageName)
+        it
+                // Before adding the {{ packageName }} replacement mechanism,
+                // BuildConfig and R classes were imported automatically
+                // into the scope of the file. In order to be backwards-compatible
+                // let's prefix all non-FQDN references to those classes with
+                // the package name.
+                //
+                // We want to match:
+                //  - new Package(R.string…),
+                //  - Module.configure(BuildConfig);
+                //    ^ hence including (BuildConfig|R)
+                // but we don't want to match:
+                //  - new Package(getResources…),
+                //  - new PackageR…,
+                //  - new Royal…,
+                //    ^ hence excluding \w before and after matches
+                //  - Module.configure({{ packageName }}.BuildConfig);
+                //    ^ hence excluding . before the match.
+                .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
+                  wholeString, prefix, className, suffix ->
+                    "${prefix}{{ packageName }}.${className}${suffix}"
+                })
+                .replace("{{ packageName }}", packageName)
       }
       packageImports = packages.collect {
         "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -129,7 +129,7 @@ class ReactNativeModules {
       def interpolateDynamicValues = {
         it.replace("{{ packageName }}", packageName)
       }
-      packageImports = packageImports + packages.collect {
+       packageImports = packages.collect {
         "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
       }.join('\n')
       packageClassInstances = ",\n      " + packages.collect {

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -132,7 +132,9 @@ class ReactNativeModules {
       packageImports = packageImports + packages.collect {
         "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
       }.join('\n')
-      packageClassInstances = ",\n      " + packages.collect { it.packageInstance }.join(",\n      ")
+      packageClassInstances = ",\n      " + packages.collect {
+        interpolateDynamicValues(it.packageInstance)
+      }.join(",\n      ")
     }
 
     String generatedFileContents = generatedFileContentsTemplate

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -126,9 +126,9 @@ class ReactNativeModules {
     String packageClassInstances = ""
 
     if (packages.size() > 0) {
-      packageImports = "import ${packageName}.BuildConfig;\nimport ${packageName}.R;\n\n"
       packageImports = packageImports + packages.collect {
-        "// ${it.name}\n${it.packageImportPath}"
+        String interpolatedPackageImportPath = it.packageImportPath.replace("{{ packageName }}", packageName)
+        "// ${it.name}\n${interpolatedPackageImportPath}"
       }.join('\n')
       packageClassInstances = ",\n      " + packages.collect { it.packageInstance }.join(",\n      ")
     }

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -129,7 +129,7 @@ class ReactNativeModules {
       def interpolateDynamicValues = {
         it.replace("{{ packageName }}", packageName)
       }
-       packageImports = packages.collect {
+      packageImports = packages.collect {
         "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
       }.join('\n')
       packageClassInstances = ",\n      " + packages.collect {


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Hard importing `${packageName}.R` and `${packageName}.BuildConfig` helps to install React Native modules which use `R` and `BuildConfig` without package prefix (eg. `react-native-code-push`, see https://github.com/react-native-community/cli/pull/435 fixing  https://github.com/react-native-community/cli/issues/434.) `BuildConfig` import has been introduced in https://github.com/react-native-community/cli/pull/258, so right from the beginning (specific commit: https://github.com/react-native-community/cli/commit/64f3f5a3db137c5cee4bbe26b18b26a7c55a205e).

This pull request:
- adds support for interpolating `{{ packageName }}` in `packageImportPath` and `packageInstance`
- adds support for `generatePackageList` task to libraries (imagine a project where its the submodule (`:app` depends on ➡️ `:library`) which depends on autolinked React Native modules)


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I introduced these changes to my project, added to `react-native-maps`' `react-native.config.js`

```diff
 module.exports = {
   dependency: {
     platforms: {
       android: {
         sourceDir: './lib/android',
+        packageInstance: 'new MapsPackage({{ packageName }}.BuildConfig)',
+        packageImportPath: 'import {{ packageName }}.R;\nimport com.maps;'
       },
     },
   },
 };
```

started the app, and `PackageList.java` contained

```java
// react-native-maps
import host.exp.exponent.R;
import com.maps;
```

and

```java
new MapsPackage(host.exp.exponent.BuildConfig),
```