### PR TITLE
doctor: change `Android SDK` check to fetch version from `build.gradle`

### DIFF
--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -92,42 +92,40 @@ export default (async (_, __, options) => {
     healthchecks,
   }: HealthCheckCategory): Promise<HealthCheckCategoryResult> => ({
     label,
-    healthchecks: (
-      await Promise.all(
-        healthchecks.map(async healthcheck => {
-          if (healthcheck.visible === false) {
-            return;
-          }
+    healthchecks: (await Promise.all(
+      healthchecks.map(async healthcheck => {
+        if (healthcheck.visible === false) {
+          return;
+        }
 
-          const {
-            needsToBeFixed,
-            version,
-            versions,
-            versionRange,
-          } = await healthcheck.getDiagnostics(environmentInfo);
+        const {
+          needsToBeFixed,
+          version,
+          versions,
+          versionRange,
+        } = await healthcheck.getDiagnostics(environmentInfo);
 
-          // Assume that it's required unless specified otherwise
-          const isRequired = healthcheck.isRequired !== false;
-          const isWarning = needsToBeFixed && !isRequired;
+        // Assume that it's required unless specified otherwise
+        const isRequired = healthcheck.isRequired !== false;
+        const isWarning = needsToBeFixed && !isRequired;
 
-          return {
-            label: healthcheck.label,
-            needsToBeFixed: Boolean(needsToBeFixed),
-            version,
-            versions,
-            versionRange,
-            description: healthcheck.description,
-            runAutomaticFix: healthcheck.runAutomaticFix,
-            isRequired,
-            type: needsToBeFixed
-              ? isWarning
-                ? HEALTHCHECK_TYPES.WARNING
-                : HEALTHCHECK_TYPES.ERROR
-              : undefined,
-          };
-        }),
-      )
-    ).filter(healthcheck => healthcheck !== undefined) as HealthCheckResult[],
+        return {
+          label: healthcheck.label,
+          needsToBeFixed: Boolean(needsToBeFixed),
+          version,
+          versions,
+          versionRange,
+          description: healthcheck.description,
+          runAutomaticFix: healthcheck.runAutomaticFix,
+          isRequired,
+          type: needsToBeFixed
+            ? isWarning
+              ? HEALTHCHECK_TYPES.WARNING
+              : HEALTHCHECK_TYPES.ERROR
+            : undefined,
+        };
+      }),
+    )).filter(healthcheck => healthcheck !== undefined) as HealthCheckResult[],
   });
 
   // Remove all the categories that don't have any healthcheck with
@@ -141,11 +139,9 @@ export default (async (_, __, options) => {
   const iterateOverCategories = (categories: HealthCheckCategory[]) =>
     Promise.all(categories.map(iterateOverHealthChecks));
 
-  const healthchecksPerCategory = await iterateOverCategories(
-    Object.values(getHealthchecks(options)).filter(
-      category => category !== undefined,
-    ) as HealthCheckCategory[],
-  );
+  const healthchecksPerCategory = await iterateOverCategories(Object.values(
+    getHealthchecks(options),
+  ).filter(category => category !== undefined) as HealthCheckCategory[]);
 
   loader.stop();
 

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -1,9 +1,9 @@
 import execa from 'execa';
+import {cleanup, writeFiles} from '../../../../../../../jest/helpers';
 import androidSDK from '../androidSDK';
 import getEnvironmentInfo from '../../../../tools/envinfo';
 import {EnvironmentInfo} from '../../types';
 import {NoopLoader} from '../../../../tools/loader';
-
 import * as common from '../common';
 
 const logSpy = jest.spyOn(common, 'logManualInstallation');
@@ -11,6 +11,23 @@ const logSpy = jest.spyOn(common, 'logManualInstallation');
 jest.mock('execa', () => jest.fn());
 
 describe('androidSDK', () => {
+  beforeEach(() => {
+    writeFiles('', {
+      'android/build.gradle': `
+        buildscript {
+          ext {
+              buildToolsVersion = "28.0.3"
+              minSdkVersion = 16
+              compileSdkVersion = 28
+              targetSdkVersion = 28
+          }
+        }
+      `,
+    });
+  });
+
+  afterAll(() => cleanup('android/build.gradle'));
+
   let initialEnvironmentInfo: EnvironmentInfo;
   let environmentInfo: EnvironmentInfo;
 
@@ -37,10 +54,10 @@ describe('androidSDK', () => {
     // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
-      'Build Tools': [25],
+      'Build Tools': ['25.0.3'],
     };
     ((execa as unknown) as jest.Mock).mockResolvedValue({
-      stdout: 'build-tools;25.0',
+      stdout: 'build-tools;25.0.3',
     });
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(true);
@@ -50,10 +67,10 @@ describe('androidSDK', () => {
     // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
-      'Build Tools': ['26.0'],
+      'Build Tools': ['28.0.3'],
     };
     ((execa as unknown) as jest.Mock).mockResolvedValue({
-      stdout: 'build-tools;26.0',
+      stdout: 'build-tools;28.0.3',
     });
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(false);

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import fs from 'fs';
-import execa from 'execa';
 import {logManualInstallation} from './common';
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
@@ -38,7 +37,7 @@ const installMessage = `Read more about how to update Android SDK at ${chalk.dim
 export default {
   label: 'Android SDK',
   description: 'Required for building and installing your app on Android',
-  getDiagnostics: async ({SDKs}) => {
+  getDiagnostics: async ({}) => {
     // TODO: also check if this version is contained within `SDKs['Android SDK']['Build Tools']
     const version = getBuildToolsVersion();
 

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -47,12 +47,18 @@ export default {
       };
     }
 
-    const isRequiredVersionInstalled = SDKs['Android SDK'][
-      'Build Tools'
-    ].includes(requiredVersion);
+    const isAndroidSDKInstalled = Array.isArray(
+      SDKs['Android SDK']['Build Tools'],
+    );
+
+    const isRequiredVersionInstalled = isAndroidSDKInstalled
+      ? SDKs['Android SDK']['Build Tools'].includes(requiredVersion)
+      : false;
 
     return {
-      versions: SDKs['Android SDK']['Build Tools'],
+      versions: isAndroidSDKInstalled
+        ? SDKs['Android SDK']['Build Tools']
+        : SDKs['Android SDK'],
       versionRange: requiredVersion,
       needsToBeFixed: !isRequiredVersionInstalled,
     };

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -21,11 +21,9 @@ const getBuildToolsVersion = (): string => {
     // Get only the portion of the declaration of `buildToolsVersion`
     .substring(buildToolsVersionIndex)
     .split('\n')[0]
-    // Split the value to only get the version number
-    .split('=')[1]
-    // Clean up
-    .replace(/\"/g, '')
-    .trim();
+    // Get only the the value of `buildToolsVersion`
+    .match(/\d|\../g)
+    .join('');
 
   return buildToolsVersion;
 };
@@ -40,7 +38,7 @@ export default {
   getDiagnostics: async ({}) => {
     // TODO: also check if this version is contained within `SDKs['Android SDK']['Build Tools']
     const version = getBuildToolsVersion();
-
+    console.log(version);
     return {
       version,
       versionRange: versionRanges.ANDROID_SDK,

--- a/packages/cli/src/commands/doctor/types.ts
+++ b/packages/cli/src/commands/doctor/types.ts
@@ -91,6 +91,7 @@ export type HealthCheckInterface = {
     environmentInfo: EnvironmentInfo,
   ) => Promise<{
     version?: string;
+    versions?: [string];
     versionRange?: string;
     needsToBeFixed: boolean | string;
   }>;
@@ -101,6 +102,7 @@ export type HealthCheckResult = {
   label: string;
   needsToBeFixed: boolean;
   version?: 'Not Found' | string;
+  versions?: [string];
   versionRange?: string;
   description: string | undefined;
   runAutomaticFix: RunAutomaticFix;


### PR DESCRIPTION
Summary:
---------

This is an attempt to fix the issues that have been noticed with the Android SDK health check when you have multiple versions of it installed.

The way this works is:

1. Android SDK searches for `android/build.gradle` file;
1. Get the value of `buildToolsVersion`;
1. Check if the value specified on `buildToolsVersion` is returned by `envinfo` as an installed version;
1. If it is, pass;
1. If not, fail the check showing the one (or multiple) version(s) installed along with the one required by the project.

### TODO

- [x] Get the correct path for `android/build.gradle`, ~~[pkg-up](https://github.com/sindresorhus/pkg-up) can help to identify the root folder~~;
- [x] Check that the version declared on `android/build.gradle` exists and is installed, if not, the health check should fail;
- [x] Fix tests 🤓

Fixes #857 
