### PR TITLE
Check java keywords when init new project

### DIFF
--- a/packages/cli/src/commands/init/validate.ts
+++ b/packages/cli/src/commands/init/validate.ts
@@ -3,13 +3,17 @@ import ReservedNameError from './errors/ReservedNameError';
 import HelloWorldError from './errors/HelloWorldError';
 
 const NAME_REGEX = /^[$A-Z_][0-9A-Z_$]*$/i;
+// ref: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
+const javaKeywords = ["abstract", "continue", "for", "new", "switch", "assert", "default", "goto", "package", "synchronized", "boolean", "do", "if", "private", "this", "break", "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum", "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while"];
+const reservedNames = ['react', 'react-native', ...javaKeywords];
 
 export function validateProjectName(name: string) {
   if (!String(name).match(NAME_REGEX)) {
     throw new InvalidNameError(name);
   }
 
-  if (name === 'React' || name === 'react') {
+  const lowerCaseName = name.toLowerCase();
+  if (reservedNames.includes(lowerCaseName)) {
     throw new ReservedNameError();
   }
 

--- a/packages/cli/src/commands/init/validate.ts
+++ b/packages/cli/src/commands/init/validate.ts
@@ -3,8 +3,61 @@ import ReservedNameError from './errors/ReservedNameError';
 import HelloWorldError from './errors/HelloWorldError';
 
 const NAME_REGEX = /^[$A-Z_][0-9A-Z_$]*$/i;
+
 // ref: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
-const javaKeywords = ["abstract", "continue", "for", "new", "switch", "assert", "default", "goto", "package", "synchronized", "boolean", "do", "if", "private", "this", "break", "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum", "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while"];
+const javaKeywords = [
+  'abstract',
+  'continue',
+  'for',
+  'new',
+  'switch',
+  'assert',
+  'default',
+  'goto',
+  'package',
+  'synchronized',
+  'boolean',
+  'do',
+  'if',
+  'private',
+  'this',
+  'break',
+  'double',
+  'implements',
+  'protected',
+  'throw',
+  'byte',
+  'else',
+  'import',
+  'public',
+  'throws',
+  'case',
+  'enum',
+  'instanceof',
+  'return',
+  'transient',
+  'catch',
+  'extends',
+  'int',
+  'short',
+  'try',
+  'char',
+  'final',
+  'interface',
+  'static',
+  'void',
+  'class',
+  'finally',
+  'long',
+  'strictfp',
+  'volatile',
+  'const',
+  'float',
+  'native',
+  'super',
+  'while',
+];
+
 const reservedNames = ['react', 'react-native', ...javaKeywords];
 
 export function validateProjectName(name: string) {


### PR DESCRIPTION
Summary:
---------
Use java keywords as a project name would get error like `Package 'com.xxxx' from AndroidManifest.xml is not a valid Java package name as 'xxxx' is a Java keyword.`


Test Plan:
----------
Use reserved words to init a new project will fail
