### PR TITLE
[hold] fix: pass watch: false to metro for offline bundles

### DIFF
--- a/packages/cli/src/commands/bundle/buildBundle.ts
+++ b/packages/cli/src/commands/bundle/buildBundle.ts
@@ -50,6 +50,9 @@ async function buildBundle(
     config: args.config,
   });
 
+  // Don't need file watcher for building offline bundle
+  config.watch = false;
+
   if (config.resolver.platforms.indexOf(args.platform) === -1) {
     logger.error(
       `Invalid platform ${

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -59,6 +59,7 @@ export interface MetroConfig {
     assetPlugins?: Array<string>;
   };
   watchFolders: string[];
+  watch: boolean;
   reporter?: any;
 }
 
@@ -110,6 +111,7 @@ export const getDefaultConfig = (ctx: Config): MetroConfig => {
       ),
     },
     watchFolders: getWatchFolders(),
+    watch: true,
   };
 };
 
@@ -122,6 +124,7 @@ export interface ConfigOptionsT {
   sourceExts?: string[];
   reporter?: any;
   config?: string;
+  watch?: boolean;
 }
 
 /**


### PR DESCRIPTION
Summary:
---------

**Note:** This PR cannot land until the corresponding PR in metro is released. This PR will be updated once that happens.

This PR goes along with a corresponding change in https://github.com/facebook/metro/pull/491, in which I'm adding a new flag to metro config which allows me to configure the `watch` flag that it passes to `JestHasteMap`. I need this capability because having `watch` always set to `true` causes failures on some internal build machines, due to the high number of file watchers required.

More specifically, this sets the `watch` flag to false on the metro config when invoking metro via `react-native bundle`.

Test Plan:
----------

Using the corresponding local change in `metro` (via npm link):

Ran `react-native start`
- Observed that the `watch` flag in `metro` was true

Ran `react-native bundle`
- Observed that `watch` in `metro` was set to `false`

Observations were captured via `console.log` statements in metro.

If there are any other test cases you would like me to run, please let me know!