### PR TITLE
Add react-refresh to collapsed stacktrace frames

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -33,6 +33,7 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
     '/Libraries/LogBox/.+\\.js$',
     '/Libraries/Core/Timers/.+\\.js$',
     '/node_modules/react-devtools-core/.+\\.js$',
+    '/node_modules/react-refresh/.+\\.js$',
     '/node_modules/scheduler/.+\\.js$',
   ].join('|'),
 );


### PR DESCRIPTION
Summary:
---------

This also describes https://github.com/react-native-community/cli/commit/37e5411251fab10eae84a02d001bdc756a9b98bc which was accidently commited already :o

Add react-refresh, the new LogBox, scheduler and RN Timer module to the collapsed stacktraces. Those are all noisy and I think its reasonable to include them here. There is still enough context to know where the error came from without these stack frames. 

Test Plan:
----------

### Some warning in a timeout

Before:

![image](https://user-images.githubusercontent.com/2677334/71025073-55a12080-20d4-11ea-8d9a-2a7a3c11d8aa.png)

After:

![image](https://user-images.githubusercontent.com/2677334/71025262-aa449b80-20d4-11ea-82aa-c00d103283cb.png)

![image](https://user-images.githubusercontent.com/2677334/71025288-bb8da800-20d4-11ea-9b79-426eacb6a9c2.png)

### Crash after fast refresh

Before:

![image](https://user-images.githubusercontent.com/2677334/71025128-710c2b80-20d4-11ea-85ad-3ed0368cd066.png)

After:

![image](https://user-images.githubusercontent.com/2677334/71024826-c5fb7200-20d3-11ea-878a-b4c47ebb50fb.png)

![image](https://user-images.githubusercontent.com/2677334/71024866-ddd2f600-20d3-11ea-83e5-9c5ff9591be1.png)


