### PR TITLE
Allow the init command to use a forked RN NPM package

### DIFF
--- a/packages/cli/src/commands/init/__tests__/templateName.test.ts
+++ b/packages/cli/src/commands/init/__tests__/templateName.test.ts
@@ -2,6 +2,7 @@ import {processTemplateName} from '../templateName';
 
 const RN_NPM_PACKAGE = 'react-native';
 const ABS_RN_PATH = '/path/to/react-native';
+const RN_NPM_TVOS_PACKAGE = 'react-native@npm:react-native-tvos@latest';
 
 test('supports file protocol with absolute path', async () => {
   if (process.platform === 'win32') {
@@ -25,6 +26,13 @@ test('supports npm packages as template names', async () => {
   expect(await processTemplateName(RN_NPM_PACKAGE)).toEqual({
     uri: RN_NPM_PACKAGE,
     name: RN_NPM_PACKAGE,
+  });
+});
+
+test('supports forked npm package as template name', async () => {
+  expect(await processTemplateName(RN_NPM_TVOS_PACKAGE)).toEqual({
+    uri: RN_NPM_TVOS_PACKAGE,
+    name: RN_NPM_PACKAGE
   });
 });
 

--- a/packages/cli/src/commands/init/__tests__/templateName.test.ts
+++ b/packages/cli/src/commands/init/__tests__/templateName.test.ts
@@ -32,7 +32,7 @@ test('supports npm packages as template names', async () => {
 test('supports forked npm package as template name', async () => {
   expect(await processTemplateName(RN_NPM_TVOS_PACKAGE)).toEqual({
     uri: RN_NPM_TVOS_PACKAGE,
-    name: RN_NPM_PACKAGE
+    name: RN_NPM_PACKAGE,
   });
 });
 

--- a/packages/cli/src/commands/init/templateName.ts
+++ b/packages/cli/src/commands/init/templateName.ts
@@ -11,7 +11,7 @@ function handleNpmProtocol(npmString: string) {
   const npmProtocolMatch = npmString.match(NPM_PROTOCOL);
   return {
     uri: npmString,
-    name: npmProtocolMatch[1]
+    name: npmProtocolMatch[1],
   };
 }
 

--- a/packages/cli/src/commands/init/templateName.ts
+++ b/packages/cli/src/commands/init/templateName.ts
@@ -5,6 +5,14 @@ const FILE_PROTOCOL = /file:/;
 const TARBALL = /\.tgz$/;
 const VERSION_POSTFIX = /(.*)(-\d+\.\d+\.\d+)/;
 const VERSIONED_PACKAGE = /(@?.+)(@)(.+)/;
+const NPM_PROTOCOL = /react-native@npm:(.+)/;
+
+function handleNpmProtocol(npmString: string) {
+  return {
+    uri: npmString,
+    name: 'react-native'
+  };
+}
 
 function handleFileProtocol(filePath: string) {
   let uri = new URL(filePath).pathname;
@@ -47,6 +55,9 @@ function handleVersionedPackage(versionedPackage: string) {
 }
 
 export async function processTemplateName(templateName: string) {
+  if (templateName.match(NPM_PROTOCOL) {
+    return handleNpmProtocol(templateName);
+  }
   if (templateName.match(TARBALL)) {
     return handleTarball(templateName);
   }

--- a/packages/cli/src/commands/init/templateName.ts
+++ b/packages/cli/src/commands/init/templateName.ts
@@ -56,7 +56,7 @@ function handleVersionedPackage(versionedPackage: string) {
 }
 
 export async function processTemplateName(templateName: string) {
-  if (templateName.match(NPM_PROTOCOL) {
+  if (templateName.match(NPM_PROTOCOL)) {
     return handleNpmProtocol(templateName);
   }
   if (templateName.match(TARBALL)) {

--- a/packages/cli/src/commands/init/templateName.ts
+++ b/packages/cli/src/commands/init/templateName.ts
@@ -5,12 +5,13 @@ const FILE_PROTOCOL = /file:/;
 const TARBALL = /\.tgz$/;
 const VERSION_POSTFIX = /(.*)(-\d+\.\d+\.\d+)/;
 const VERSIONED_PACKAGE = /(@?.+)(@)(.+)/;
-const NPM_PROTOCOL = /react-native@npm:(.+)/;
+const NPM_PROTOCOL = /(.*?)@npm:(.+)/;
 
 function handleNpmProtocol(npmString: string) {
+  const npmProtocolMatch = npmString.match(NPM_PROTOCOL);
   return {
     uri: npmString,
-    name: 'react-native'
+    name: npmProtocolMatch[1]
   };
 }
 


### PR DESCRIPTION
Summary:
---------

Add an additional protocol and handler in `templateNames.ts` so that this CLI can be used to init a new project with the `react-native-tvos` package (forked from RN core).  This fixes issue #889.  After this change, the following will work:

```
npx react-native init TestApp --template=react-native@npm:react-native-tvos@latest
```

Test Plan:
----------

- Manual testing to init a new react-native-tvos project and verify that everything works
- Added a unit test for the new handler