### PR TITLE
fix: gracefully handle chmod xsel

### DIFF
--- a/packages/cli/src/commands/server/copyToClipBoard.ts
+++ b/packages/cli/src/commands/server/copyToClipBoard.ts
@@ -8,12 +8,17 @@
  */
 
 import {spawn} from 'child_process';
+import {logger} from '@react-native-community/cli-tools';
 
 import path from 'path';
 import fs from 'fs';
 
 const xsel = path.join(__dirname, 'external/xsel');
-fs.chmodSync(xsel, '0755');
+try {
+  fs.chmodSync(xsel, '0755');
+} catch (e) {
+  logger.warn(`Failed to chmod xsel: ${e.message}`);
+}
 
 /**
  * Copy the content to host system clipboard.


### PR DESCRIPTION
Summary:
---------

When I run "react-native start" chmod always seems to fail for projects located on an NTFS filesystem under macOS:

```
EPERM: operation not permitted, chmod '.../node_modules/@react-native-community/cli/build/commands/server/external/xsel'
```

Here is the relevent code from copyToClipBoard.js:

```
const xsel = path.join(__dirname, 'external/xsel');
fs.chmodSync(xsel, '0755');
```

Without this the app works just fine. I'm not sure what the clipboard is used for. I think that maybe it's better to ignore this error since it's not critical.

Test Plan:
----------

1. Mount an NTFS volume via osxfuse and ntfs-3g as described at https://github.com/osxfuse/osxfuse/wiki/NTFS-3G
2. Create a project on that volume
3. Run `react-native start`

Without this patch, the command will fail immediately with the above mentioned error.