### PR TITLE
fix: remove @ character from module names

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -215,7 +215,7 @@ class ReactNativeModules {
 
         HashMap reactNativeModuleConfig = new HashMap<String, String>()
         reactNativeModuleConfig.put("name", name)
-        reactNativeModuleConfig.put("nameCleansed", name.replaceAll('/', '_'))
+        reactNativeModuleConfig.put("nameCleansed", name.replaceAll('^@([\\w-]+)/', '$1_'))
         reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
         reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])


### PR DESCRIPTION
Summary:
---------

The `@` characters from npm scoped packages will cause name conflicts with Kotlin because Kotlin complier will generate `.kotlin_module` files base on module name by default.

For example, we have both `@segment/analytics-react-native` and `@matt-block/react-native-in-app-browser` modules installed. Currently they will be turned into Android modules with name `@segment_analytics-react-native` and `@matt-block_react-native-in-app-browser`. And they will both generate `META-INF/-no-jdk.kotlin_module` file because Kotlin complier failed to parse `@` in module name.

Eventually it causes build to fail with error: 
> More than one file was found with OS independent path 'META-INF/-no-jdk.kotlin_module'

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Tested the code change on our project and it will convert module names into `segment_analytics-react-native` and `matt-block_react-native-in-app-browser`. And Kotlin will generate `segment_analytics-react-native_debug.kotlin_module` and `matt-block_react-native-in-app-browser_debug.kotlin_module` in `META-INF`. Thus the error is resolved.
