### PR TITLE
Fix log-ios on Xcode 11.2

### DIFF
--- a/packages/platform-ios/src/commands/logIOS/index.ts
+++ b/packages/platform-ios/src/commands/logIOS/index.ts
@@ -15,7 +15,7 @@ import {Device} from '../../types';
 function findAvailableDevice(devices: {[index: string]: Array<Device>}) {
   for (const key of Object.keys(devices)) {
     for (const device of devices[key]) {
-      if (device.availability === '(available)' && device.state === 'Booted') {
+      if ((device.availability === '(available)' || device.isAvailable) && device.state === 'Booted') {
         return device;
       }
     }
@@ -38,7 +38,7 @@ async function logIOS() {
   };
 
   const device = findAvailableDevice(devices);
-  if (device === null) {
+  if (!device) {
     logger.error('No active iOS device found');
     return;
   }


### PR DESCRIPTION
Summary:
---------

The way Xcode 11.2 reports device availability has changed. This change adds support for this while maintaining backward compatibility with older Xcode versions.

Also changed how it detects the absence of a device. Previously it would do strict equality check with `undefined` but the problem is that the device was `null`. I think it's fine to simply do `!device` as that will handle both cases.