### PR TITLE
Don't use deprecated createBlacklist metro api

### DIFF
--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -3,9 +3,9 @@
  */
 import path from 'path';
 // @ts-ignore - no typed definition for the package
-import {createBlacklist} from 'metro';
-// @ts-ignore - no typed definition for the package
 import {loadConfig} from 'metro-config';
+// @ts-ignore - no typed definition for the package
+import blacklist from 'metro-config/src/defaults/blacklist';
 import {existsSync} from 'fs';
 import {Config} from '@react-native-community/cli-types';
 import findSymlinkedModules from './findSymlinkedModules';
@@ -22,8 +22,7 @@ function getWatchFolders(): string[] {
   return root ? resolveSymlinksForRoots([path.resolve(root)]) : [];
 }
 
-const getBlacklistRE: () => RegExp = () =>
-  createBlacklist([/.*\/__fixtures__\/.*/]);
+const getBlacklistRE: () => RegExp = () => blacklist([/.*\/__fixtures__\/.*/]);
 
 const INTERNAL_CALLSITES_REGEX = new RegExp(
   [


### PR DESCRIPTION
Summary:
---------

Some legacy apis were removed in the latest metro release. The only one that seem to be affecting here is createBlacklist. we import it from the metro-config package instead. See https://github.com/facebook/metro/commit/871cafbd567cdb3bf231270cdbb6c28f6535c2fd#diff-82e93cde29a5080883ceae93070af8feL13

Test Plan:
----------

Tested that running the metro server works with metro 0.58.0