### PR TITLE
[WIP] Issue 921. Fix `run-android` failing when both build "type" and "flavor" are used in gradle config.

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -32,6 +32,7 @@ export interface Flags {
   tasks?: Array<string>;
   root: string;
   variant: string;
+  flavor :string;
   appFolder: string;
   appId: string;
   appIdSuffix: string;
@@ -201,11 +202,15 @@ function tryInstallAppOnDevice(args: Flags, adbPath: string, device: string) {
     // "app" is usually the default value for Android apps with only 1 app
     const {appFolder} = args;
     const variant = args.variant.toLowerCase();
-    const buildDirectory = `${appFolder}/build/outputs/apk/${variant}`;
+    const flavor = args.flavor.toLowerCase();
+    const buildDirectory = flavor ?
+      `${appFolder}/build/outputs/apk/${flavor}/${variant}`
+      : `${appFolder}/build/outputs/apk/${variant}`;
     const apkFile = getInstallApkName(
       appFolder,
       adbPath,
       variant,
+      flavor,
       device,
       buildDirectory,
     );
@@ -226,6 +231,7 @@ function getInstallApkName(
   appFolder: string,
   adbPath: string,
   variant: string,
+  flavor: string,
   device: string,
   buildDirectory: string,
 ) {
@@ -233,14 +239,18 @@ function getInstallApkName(
 
   // check if there is an apk file like app-armeabi-v7a-debug.apk
   for (const availableCPU of availableCPUs.concat('universal')) {
-    const apkName = `${appFolder}-${availableCPU}-${variant}.apk`;
+    const apkName = flavor ?
+      `${appFolder}-${availableCPU}-${flavor}-${variant}.apk`
+      : `${appFolder}-${availableCPU}-${variant}.apk`;
     if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
       return apkName;
     }
   }
 
   // check if there is a default file like app-debug.apk
-  const apkName = `${appFolder}-${variant}.apk`;
+  const apkName = flavor ?
+    `${appFolder}-${flavor}-${variant}.apk`
+    : `${appFolder}-${variant}.apk`;
   if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
     return apkName;
   }
@@ -383,6 +393,11 @@ export default {
       name: '--variant [string]',
       description: "Specify your app's build variant",
       default: 'debug',
+    },
+    {
+      name: '--flavor [string]',
+      description: "Specify your app's flavor",
+      default: ''
     },
     {
       name: '--appFolder [string]',


### PR DESCRIPTION
Work-in-progress. Opening PR because this is the immediate code that solved my problem and I want to provide it for others' use and get feedback early.

Summary:

The error is:
`npx react-native run-android fails with Not found the correct install APK file! when using flavors.`

It's coming from the following lines in https://github.com/react-native-community/cli/blob/master/packages/platform-android/src/commands/runAndroid/index.ts

The function to get ApkName only checks "type" (debug/release) and not flavor (paid/free, or demo/full, etc...).

What the Android docs refer to as "variant" is actually a combination of a build "type" and "flavor". https://developer.android.com/studio/build/build-variants.

"type" is debug vs release.
"flavor" is free vs paid, or demo vs full.

I think the proper fix would be to deprecate the `--variant` flag. Leave it functioning as-is so we con't break any existing tooling. Add two new flags, `--type` and `--flavor`. Warn of the deprecation and to move to the proper combination of the new flags. Or maybe add some way to parse what's passed to the `--variant` flag, like make it optionally a comma-separated combination of type and flavor.

This is the gradle configuration that I was using when I encountered the error.

```
    productFlavors {
        pro {
            dimension = 'version'
            applicationId = 'com.ezmonic'
            applicationIdSuffix = 'pro'
            resValue "string", "app_name", "Ezmonic"
        }
        free {
            dimension = 'version'
            applicationId = 'com.ezmonic'
            resValue "string", "app_name", "Ezmonic Free"            
        }
    }
    buildTypes {
        debug {
            signingConfig signingConfigs.debug
        }
        release {
            // Caution! In production, you need to generate your own keystore file.
            // see https://facebook.github.io/react-native/docs/signed-apk-android.
            signingConfig signingConfigs.release
            minifyEnabled enableProguardInReleaseBuilds
            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
        }
    }
```
This is the command I ran and the error I saw.
```
$ npx react-native run-android --variant proRelease --deviceId 3434363550553098
info Running jetifier to migrate libraries to AndroidX. You can disable it using "--no-jetifier" flag.
Jetifier found 2465 file(s) to forward-jetify. Using 4 workers...
info JS server already running.
...
BUILD SUCCESSFUL in 3m 49s
284 actionable tasks: 23 executed, 261 up-to-date
info Connecting to the development server...
error Failed to install the app on the device. Run CLI with --verbose flag for more details.
Error: Not found the correct install APK file!
```


Test Plan:
----------

I think the only thing that will need to be tested is that the change doesn't affect the use of `--variant` and that projects with both type and flavor work as well as projects with just a type.
