### PR TITLE
Fix bundling assets with a path outside of the project root

### DIFF
--- a/packages/cli/src/commands/bundle/__tests__/getAssetDestPathAndroid-test.ts
+++ b/packages/cli/src/commands/bundle/__tests__/getAssetDestPathAndroid-test.ts
@@ -70,4 +70,16 @@ describe('getAssetDestPathAndroid', () => {
       path.normalize('raw/app_test_video.mp4'),
     );
   });
+
+  it('should handle assets with a relative path outside of root', () => {
+    const asset = {
+      name: 'icon',
+      type: 'png',
+      httpServerLocation: '/assets/../../test',
+    };
+
+    expect(getAssetDestPathAndroid(asset, 1)).toBe(
+      path.normalize('drawable-mdpi/__test_icon.png'),
+    );
+  });
 });

--- a/packages/cli/src/commands/bundle/__tests__/getAssetDestPathIOS-test.ts
+++ b/packages/cli/src/commands/bundle/__tests__/getAssetDestPathIOS-test.ts
@@ -41,4 +41,16 @@ describe('getAssetDestPathIOS', () => {
       path.normalize('assets/test/icon@3x.png'),
     );
   });
+
+  it('should handle assets with a relative path outside of root', () => {
+    const asset = {
+      name: 'icon',
+      type: 'png',
+      httpServerLocation: '/assets/../../test',
+    };
+
+    expect(getAssetDestPathIOS(asset, 1)).toBe(
+      path.normalize('assets/__test/icon.png'),
+    );
+  });
 });

--- a/packages/cli/src/commands/bundle/getAssetDestPathIOS.ts
+++ b/packages/cli/src/commands/bundle/getAssetDestPathIOS.ts
@@ -12,7 +12,13 @@ import {PackagerAsset} from './assetPathUtils';
 function getAssetDestPathIOS(asset: PackagerAsset, scale: number): string {
   const suffix = scale === 1 ? '' : `@${scale}x`;
   const fileName = `${asset.name + suffix}.${asset.type}`;
-  return path.join(asset.httpServerLocation.substr(1), fileName);
+  return path.join(
+    // Assets can have relative paths outside of the project root.
+    // Replace `../` with `_` to make sure they don't end up outside of
+    // the expected assets directory.
+    asset.httpServerLocation.substr(1).replace(/\.\.\//g, '_'),
+    fileName,
+  );
 }
 
 export default getAssetDestPathIOS;


### PR DESCRIPTION
Summary:
---------

When an asset is outside of the metro project root, it can lead to relative paths like `/assets/../../node_modules/coolpackage/image.png` as the `httpServerLocation`. This can happen for example when using yarn workspaces with hoisted node_modules.

This causes issues when bundling on iOS since we use this path in the filesystem. To avoid this we replace `../` with `_` to preserve the uniqueness of the path while avoiding these kind of problematic relative paths. The same logic is used when bundling assets in the rn-cli.

RN part of this PR: https://github.com/facebook/react-native/pull/27932

Test Plan:
----------

Tested that an asset in a hoisted node_modules package doesn't show up before this patch and does after in a release build.

