### PR TITLE
docs: add example of dependency-level autolinking customisation

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -62,7 +62,18 @@ On the iOS side, you will need to ensure you have a Podspec to the root of your 
 
 ## How can I customize how autolinking works for my package?
 
-A library can add a `react-native.config.js` configuration file, which will customize the defaults.
+A library can add a `react-native.config.js` configuration file, which will customize the defaults, example:
+
+```js
+// react-native.config.js
+module.exports = {
+  dependency: {
+    platforms: {
+      android: null, // disable Android platform, other platforms will still autolink if provided
+    },
+  },
+};
+```
 
 ## How can I disable autolinking for unsupported library?
 


### PR DESCRIPTION
Summary:
---------

There is currently no documentation of how can a library author customise the auto-linking behaviour. This adds an example for the same.

As per schema mentioned here:
https://github.com/react-native-community/cli/blob/e496c2a89c06ad5969608e10a749da17edee6375/packages/cli/src/tools/config/schema.ts#L41-L47

Test Plan:
----------

This was tested by looking and validating the schema reference.
