### PR TITLE
chore: update release cycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ _Note: CLI has been extracted from core `react-native` as a part of "[Lean Core]
 
 Our release cycle is independent of `react-native`. We follow semver and here is the compatibility table:
 
-| `@react-native-community/cli`                                    | `react-native`   |
-| ---------------------------------------------------------------- | ---------------- |
-| ^5.0.0 (`next`)                                                  | master           |
-| ^4.0.0                                                           | ^0.62.0          |
-| ^3.0.0                                                           | ^0.61.0          |
-| [^2.0.0](https://github.com/react-native-community/cli/tree/2.x) | ^0.60.0          |
-| [^1.0.0](https://github.com/react-native-community/cli/tree/1.x) | ^0.59.0          |
+| `@react-native-community/cli`                                               | `react-native`   |
+| --------------------------------------------------------------------------- | ---------------- |
+| [^5.0.0 (`next`)](https://github.com/react-native-community/cli/tree/next)  | master           |
+| [^4.0.0 (`master`)](https://github.com/react-native-community/cli/)         | ^0.62.0          |
+| [^3.0.0](https://github.com/react-native-community/cli/tree/2.x)            | ^0.61.0          |
+| [^2.0.0](https://github.com/react-native-community/cli/tree/2.x)            | ^0.60.0          |
+| [^1.0.0](https://github.com/react-native-community/cli/tree/1.x)            | ^0.59.0          |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Our release cycle is independent of `react-native`. We follow semver and here is
 
 | `@react-native-community/cli`                                    | `react-native`   |
 | ---------------------------------------------------------------- | ---------------- |
-| ^4.0.0 (`next`)                                                  | ^0.63.0          |
-| ^3.0.0                                                           | ^0.61.0, ^0.62.0 |
+| ^5.0.0 (`next`)                                                  | master           |
+| ^4.0.0                                                           | ^0.62.0          |
+| ^3.0.0                                                           | ^0.61.0          |
 | [^2.0.0](https://github.com/react-native-community/cli/tree/2.x) | ^0.60.0          |
 | [^1.0.0](https://github.com/react-native-community/cli/tree/1.x) | ^0.59.0          |
 


### PR DESCRIPTION
Updated release cycle.

[3.x](https://github.com/react-native-community/cli/tree/3.x) will stay for React Native 0.61 and will not contain: 
a) Metro bump to 0.57 and 0.58 https://github.com/react-native-community/cli/commit/e496c2a89c06ad5969608e10a749da17edee6375 https://github.com/react-native-community/cli/commit/4f6b28e3e4d8276a0aac4e5a4bd5b08b953da4d5
b) fixed `run-android` with flavor which deprecates `appId` and `applicationId` parameters. This is minor change, but we're sticking to semver which requires us to bump major https://github.com/react-native-community/cli/commit/ada3e497325b5b3d0441f620d6ad276e4d773bd5 https://github.com/react-native-community/cli/commit/c199ecfdd1dcf8602cb10c3cbc55bddc5fc62435

Rather than that, it contains everything that has been released to `master` since then (including `watch` mode).

4.x will stay for React Native 0.62, includes everything that is currently on `master`

Our `next` branch will roll over to 0.63

Thoughts? I am not sure if we should ship Metro 0.58 to 0.61 users too.
