### PR TITLE
fix: Fix install process for development versions of React Native

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -41,6 +41,28 @@ const templateFiles = [
   'yarn.lock',
 ];
 
+// Files expected in the --version tests
+const versionFiles = [
+  '.buckconfig',
+  '.eslintrc.js',
+  '.flowconfig',
+  '.gitattributes',
+  '.gitignore',
+  '.prettierrc.js',
+  '.watchmanconfig',
+  'App.js',
+  '__tests__',
+  'android',
+  'app.json',
+  'babel.config.js',
+  'index.js',
+  'ios',
+  'metro.config.js',
+  'node_modules',
+  'package.json',
+  'yarn.lock',
+];
+
 test('init --template', () => {
   const {stdout} = run(DIR, [
     'init',
@@ -118,5 +140,44 @@ test('init --template with custom project path', () => {
 
   for (const templateFile of templateFiles) {
     expect(dirFiles.includes(templateFile)).toBe(true);
+  }
+});
+
+test('init --version with version number', () => {
+  const {stdout} = run(DIR, ['init', 'TestInit', '--version', '0.61.5']);
+
+  expect(stdout).toContain('Welcome to React Native!');
+  expect(stdout).toContain('Run instructions');
+
+  // make sure we don't leave garbage
+  expect(fs.readdirSync(DIR)).toEqual(['TestInit']);
+
+  let dirFiles = fs.readdirSync(path.join(DIR, 'TestInit'));
+  expect(dirFiles.length).toEqual(versionFiles.length);
+
+  for (const versionFile of versionFiles) {
+    expect(dirFiles.includes(versionFile)).toBe(true);
+  }
+});
+
+test('init --version with GitHub repo', () => {
+  const {stdout} = run(DIR, [
+    'init',
+    'TestInit',
+    '--version',
+    'https://github.com/facebook/react-native#7bd1abec35f0aff0dddf0c1a68f79da29e00acdb',
+  ]);
+
+  expect(stdout).toContain('Welcome to React Native!');
+  expect(stdout).toContain('Run instructions');
+
+  // make sure we don't leave garbage
+  expect(fs.readdirSync(DIR)).toEqual(['TestInit']);
+
+  let dirFiles = fs.readdirSync(path.join(DIR, 'TestInit'));
+  expect(dirFiles.length).toEqual(versionFiles.length);
+
+  for (const versionFile of versionFiles) {
+    expect(dirFiles.includes(versionFile)).toBe(true);
   }
 });

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -106,3 +106,21 @@ export function changePlaceholderInTemplate({
       processDotfiles(filePath);
     });
 }
+
+export function changeReactNativeVersionInTemplate(newVersion: string) {
+  const packageJsonPath = path.join(process.cwd(), './package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const oldVersion = packageJson.dependencies['react-native'];
+
+  logger.debug(
+    `Changing React Native version in template from ${oldVersion} to ${newVersion}`,
+  );
+
+  packageJson.dependencies['react-native'] = newVersion;
+
+  fs.writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+    'utf8',
+  );
+}

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -17,7 +17,10 @@ import {
   copyTemplate,
   executePostInitScript,
 } from './template';
-import {changePlaceholderInTemplate} from './editTemplate';
+import {
+  changePlaceholderInTemplate,
+  changeReactNativeVersionInTemplate,
+} from './editTemplate';
 import * as PackageManager from '../../tools/packageManager';
 import installPods from '../../tools/installPods';
 import {processTemplateName} from './templateName';
@@ -25,6 +28,7 @@ import banner from './banner';
 import {getLoader} from '../../tools/loader';
 
 const DEFAULT_VERSION = 'latest';
+const DEVELOPMENT_VERSION = /^(file|http|https|git|git\+ssh|git\+file|github|bitbucket)\:/;
 
 type Options = {
   template?: string;
@@ -40,6 +44,7 @@ interface TemplateOptions {
   npm?: boolean;
   directory: string;
   projectTitle?: string;
+  developmentVersion?: string;
 }
 
 function doesDirectoryExist(dir: string) {
@@ -99,6 +104,7 @@ async function createFromTemplate({
   npm,
   directory,
   projectTitle,
+  developmentVersion,
 }: TemplateOptions) {
   logger.debug('Initializing new project');
   logger.log(banner);
@@ -133,6 +139,10 @@ async function createFromTemplate({
       placeholderName: templateConfig.placeholderName,
       placeholderTitle: templateConfig.titlePlaceholder,
     });
+
+    if (developmentVersion) {
+      changeReactNativeVersionInTemplate(developmentVersion);
+    }
 
     loader.succeed();
     const {postInitScript} = templateConfig;
@@ -207,6 +217,7 @@ async function createProject(
     npm: options.npm,
     directory,
     projectTitle: options.title,
+    developmentVersion: DEVELOPMENT_VERSION.test(version) ? version : null,
   });
 }
 


### PR DESCRIPTION
Summary:
---------

This small fix allows for development versions of React Native to be installed from the React Native CLI.

In an older version of the RNCLI, you used to be able to provide a link to a Git URL to the `--version` argument of `init`. This feature was unintentionally supported, because NPM and Yarn support installing packages with the syntax: `my-package@https://github.com/my/package.git`

This mostly works in the current revision, but it ran into a problem during the install process, because the version of development versions of React Native have the version `1000.0.0` in their `package.json`, and Yarn would error out because that is not a real version of React Native.

To fix this, a new build step is added to `createFromTemplate` that updates the "version" of `react-native` in the template's `package.json` to the URL of the development version of React Native, if provided.

Test Plan:
----------

New tests for `init --version` were added to `__e2e__/init.test.ts`.

The following syntax options for `--version` work properly:

```sh
npx react-native init MyApp --version https://github.com/facebook/react-native\#7bd1abec35f0aff0dddf0c1a68f79da29e00acdb
npx react-native init MyApp --version github:microsoft/react-native
```
