### PR TITLE
fix: machines where shebang doesnt work

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -195,9 +195,7 @@ class ReactNativeModules {
     def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
     def cliPath = this.getCommandOutput("node -e ${cliResolveScript}")
 
-    def reactNativeConfigCommand = "node ${cliPath} config"
-
-    def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand)
+    def reactNativeConfigOutput = this.getCommandOutput("node ${cliPath} config")
     
     def json
     try {

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -195,7 +195,9 @@ class ReactNativeModules {
     def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
     def cliPath = this.getCommandOutput("node -e ${cliResolveScript}")
 
-    def reactNativeConfigOutput = this.getCommandOutput("node ${cliPath} config")
+    def reactNativeConfigCommand = "node ${cliPath} config"
+
+    def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand)
     
     def json
     try {

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -195,7 +195,7 @@ class ReactNativeModules {
     def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
     def cliPath = this.getCommandOutput("node -e ${cliResolveScript}")
 
-    def reactNativeConfigCommand = "${cliPath} config"
+    def reactNativeConfigCommand = "node ${cliPath} config"
 
     def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand)
     


### PR DESCRIPTION
Summary:
---------

On machines where shebang is not supported, calling `bin.js` directly will not work. There's no reason to not prefix that with `node`.