### PR TITLE
fix: running CLI from directory with spaces

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -195,7 +195,7 @@ class ReactNativeModules {
     def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
     def cliPath = this.getCommandOutput("node -e ${cliResolveScript}")
 
-    def reactNativeConfigCommand = "node ${cliPath} config"
+    def reactNativeConfigCommand = "node "${cliPath}" config"
 
     def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand)
     

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -195,7 +195,7 @@ class ReactNativeModules {
     def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
     def cliPath = this.getCommandOutput("node -e ${cliResolveScript}")
 
-    def reactNativeConfigCommand = "node "${cliPath}" config"
+    def reactNativeConfigCommand = "node \"${cliPath}\" config"
 
     def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand)
     

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -21,7 +21,7 @@ def use_native_modules!(config = nil)
   if (!config)
     json = []
 
-    IO.popen("#{cli_bin} config") do |data|
+    IO.popen("\"#{cli_bin}\" config") do |data|
       while line = data.gets
         json << line
       end


### PR DESCRIPTION
Autolinking files will not work when directory has space in the name.