### PR TITLE
fix: correctly resolve cli path in directories containing spaces

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -148,7 +148,7 @@ class ReactNativeModules {
    * Runs a specified command using Runtime exec() in a specified directory.
    * Throws when the command result is empty.
    */
-  String getCommandOutput(String command) {
+  String getCommandOutput(String[] command) {
     try {
       def output = ""
       def cmdProcess = Runtime.getRuntime().exec(command)
@@ -193,12 +193,12 @@ class ReactNativeModules {
      * @todo: `fastlane` has been reported to not work too.
      */
     def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
-    def cliPath = this.getCommandOutput("node -e ${cliResolveScript}")
+    String[] nodeCommand = ["node", "-e", cliResolveScript]
+    def cliPath = this.getCommandOutput(nodeCommand)
 
-    def reactNativeConfigCommand = "node ${cliPath} config"
-
+    String[] reactNativeConfigCommand = ["node", cliPath, "config"]
     def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand)
-    
+
     def json
     try {
       json = new JsonSlurper().parseText(reactNativeConfigOutput)

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -21,7 +21,7 @@ def use_native_modules!(config = nil)
   if (!config)
     json = []
 
-    IO.popen("#{cli_bin} config") do |data|
+    IO.popen(["node", cli_bin, "config"]) do |data|
       while line = data.gets
         json << line
       end
@@ -67,7 +67,7 @@ def use_native_modules!(config = nil)
     end
 
     podspec_dir_path = Pathname.new(File.dirname(podspec_path))
-    
+
     relative_path = podspec_dir_path.relative_path_from project_root
 
     pod spec.name, :path => relative_path.to_path


### PR DESCRIPTION
Summary:
---------

The string versions of `Runtime.exec` on Android and `IO.popen` don't escape spaces, resulting in failing to resolve correct CLI path in directories containing spaces. Using array version instead to fix issues on both platforms.
