### PR TITLE
fix: resolve CLI through react-native to avoid hoisting issues

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -192,7 +192,7 @@ class ReactNativeModules {
      *
      * @todo: `fastlane` has been reported to not work too.
      */
-    def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
+    def cliResolveScript = "console.log(require('react-native/cli').bin);"
     String[] nodeCommand = ["node", "-e", cliResolveScript]
     def cliPath = this.getCommandOutput(nodeCommand)
 

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -15,7 +15,8 @@ def use_native_modules!(config = nil)
     config = nil;
   end
 
-  cli_resolve_script = "console.log(require('react-native/cli').bin);"
+  # Resolving the path the RN CLI. The `@react-native-community/cli` module may not be there for certain package managers, so we fall back to resolving it through `react-native` package, that's always present in RN projects
+  cli_resolve_script = "try {console.log(require('@react-native-community/cli').bin);} catch (e) {console.log(require('react-native/cli').bin);}"
   cli_bin = Pod::Executable.execute_command("node", ["-e", cli_resolve_script], true).strip
 
   if (!config)

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -15,7 +15,7 @@ def use_native_modules!(config = nil)
     config = nil;
   end
 
-  cli_resolve_script = "console.log(require('@react-native-community/cli').bin);"
+  cli_resolve_script = "console.log(require('react-native/cli').bin);"
   cli_bin = Pod::Executable.execute_command("node", ["-e", cli_resolve_script], true).strip
 
   if (!config)


### PR DESCRIPTION
Summary:
---------

See https://github.com/react-native-community/cli/issues/406#issuecomment-586220725 for explanation what happens.

This PR makes use of a fact, that CLI is available under https://github.com/facebook/react-native/blob/master/cli.js, which works regardless of package manager hoisting strategy. It doesn't make us closer to PnP support because we're making assumption we have `react-native` in the node_modules tree without declaring a dependency, but we can fix that later.

Fixes https://github.com/react-native-community/cli/issues/406


Test Plan:
----------

CLI is properly resolved under `npm`.