### PR TITLE
fix: added quotes for run instructions

### DIFF
--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -26,14 +26,14 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
   logger.log(`
   ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-    • cd ${projectDir} && npx react-native run-ios
+    • cd "${projectDir}" && npx react-native run-ios
     ${chalk.dim('- or -')}
     • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
     • Hit the Run button
 
   ${chalk.green(`Run instructions for ${chalk.bold('Android')}`)}:
     • Have an Android emulator running (quickest way to get started), or a device connected.
-    • cd ${projectDir} && npx react-native run-android
+    • cd "${projectDir}" && npx react-native run-android
 `);
 }
 


### PR DESCRIPTION
Summary:
---------
When initializing a project in a folder with spaces in the name, the commandline output showed a command which is not working for these folders. In general it is not recommended to create folders with spaces but in a Windows Environment it is quite common e.g. if the username is "John Doe" and you want to initialize a react-native project in a subfolder of the home directory.

To provide a working command id added quotes around the projectDir variable, so the command can be Copy & Pasted.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

1. Create a directory with spaces in the name: `mkdir "my repositories"`
2. Switch to this directory `cd "my repositories"`
3. Run `react-native init testproject`
4. Before this change the following output was generated:
[...]
 ```
Run instructions for iOS:
    • cd /home/johndoe/my repositories/testproject && npx react-native run-ios
    - or -
    • Open testproject/ios/testproject.xcodeproj in Xcode or run "xed -b ios"
    • Hit the Run button

  Run instructions for Android:
    • Have an Android emulator running (quickest way to get started), or a device connected.
    • cd /home/johndoe/my repositories/testproject && npx react-native run-android
```
5. Copy & Paste the command and run it ` cd /home/johndoe/my repositories/testproject && npx react-native run-android`
6. Following error message occurs: `-bash: cd: too many arguments`

With this Pull Request the project directory is surrounded by quotes and a copy & paste of the command will work.
