### PR TITLE
fix(ios): skip script phases on abstract targets

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -184,6 +184,10 @@ if $0 == __FILE__
       target_definition.singleton_class.send(:define_method, :dependencies) do
         current_target_definition_dependencies
       end
+      
+      target_definition.singleton_class.send(:define_method, :abstract?) do
+        false
+      end
 
       podfile.singleton_class.send(:define_method, :current_target_definition) do
         target_definition

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -73,7 +73,7 @@ def use_native_modules!(config = nil)
 
     pod spec.name, :path => relative_path.to_path
 
-    if package_config["scriptPhases"]
+    if package_config["scriptPhases"] && !this_target.abstract
       # Can be either an object, or an array of objects
       Array(package_config["scriptPhases"]).each do |phase|
         # see https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -73,7 +73,7 @@ def use_native_modules!(config = nil)
 
     pod spec.name, :path => relative_path.to_path
 
-    if package_config["scriptPhases"] && !this_target.abstract
+    if package_config["scriptPhases"] && !this_target.abstract?
       # Can be either an object, or an array of objects
       Array(package_config["scriptPhases"]).each do |phase|
         # see https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method


### PR DESCRIPTION
Summary:
---------

Abstract targets [don't support script phases](https://github.com/CocoaPods/Core/blob/master/lib/cocoapods-core/podfile/dsl.rb#L432), this change skips adding script phases if the current target is abstract.

**Fixes** https://github.com/invertase/react-native-firebase/issues/2800

cc @orta / @alloy for review please, thanks!

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

@gabrielbull would you be able to patch package this change in and confirm it now works? https://github.com/invertase/react-native-firebase/issues/2800

---

**script phases continue to work on non abstract targets**:
![image](https://user-images.githubusercontent.com/5347038/74610863-e608db00-50ee-11ea-9eb4-9b1235c025f2.png)
