### PR TITLE
chore: simplify doctor tests

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidHomeEnvVariable.test.ts
@@ -1,5 +1,4 @@
 import androidHomeEnvVariables from '../androidHomeEnvVariable';
-import getEnvironmentInfo from '../../../../tools/envinfo';
 import {NoopLoader} from '../../../../tools/loader';
 
 import * as common from '../common';
@@ -17,29 +16,21 @@ describe('androidHomeEnvVariables', () => {
   it('returns true if no ANDROID_HOME is defined', async () => {
     delete process.env.ANDROID_HOME;
 
-    const environmentInfo = await getEnvironmentInfo();
-    const diagnostics = await androidHomeEnvVariables.getDiagnostics(
-      environmentInfo,
-    );
+    const diagnostics = await androidHomeEnvVariables.getDiagnostics();
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
   it('returns false if ANDROID_HOME is defined', async () => {
     process.env.ANDROID_HOME = '/fake/path/to/android/home';
 
-    const environmentInfo = await getEnvironmentInfo();
-    const diagnostics = await androidHomeEnvVariables.getDiagnostics(
-      environmentInfo,
-    );
+    const diagnostics = await androidHomeEnvVariables.getDiagnostics();
     expect(diagnostics.needsToBeFixed).toBe(false);
   });
 
   it('logs manual installation steps to the screen', async () => {
     const loader = new NoopLoader();
 
-    const environmentInfo = await getEnvironmentInfo();
-
-    androidHomeEnvVariables.runAutomaticFix({loader, environmentInfo});
+    androidHomeEnvVariables.runAutomaticFix({loader});
 
     expect(logSpy).toHaveBeenCalledTimes(1);
   });

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
@@ -8,16 +8,11 @@ import * as common from '../common';
 const logSpy = jest.spyOn(common, 'logManualInstallation');
 
 describe('androidNDK', () => {
-  let initialEnvironmentInfo: EnvironmentInfo;
   let environmentInfo: EnvironmentInfo;
 
   beforeAll(async () => {
-    initialEnvironmentInfo = await getEnvironmentInfo();
-  });
-
-  beforeEach(() => {
-    environmentInfo = initialEnvironmentInfo;
-  });
+    environmentInfo = await getEnvironmentInfo();
+  }, 15000);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -28,16 +28,11 @@ describe('androidSDK', () => {
 
   afterAll(() => cleanup('android/build.gradle'));
 
-  let initialEnvironmentInfo: EnvironmentInfo;
   let environmentInfo: EnvironmentInfo;
 
   beforeAll(async () => {
-    initialEnvironmentInfo = await getEnvironmentInfo();
-  });
-
-  beforeEach(() => {
-    environmentInfo = initialEnvironmentInfo;
-  });
+    environmentInfo = await getEnvironmentInfo();
+  }, 15000);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/cli/src/commands/doctor/types.ts
+++ b/packages/cli/src/commands/doctor/types.ts
@@ -79,7 +79,7 @@ export type Healthchecks = {
 
 export type RunAutomaticFix = (args: {
   loader: Ora;
-  environmentInfo: EnvironmentInfo;
+  environmentInfo?: EnvironmentInfo;
 }) => Promise<void> | void;
 
 export type HealthCheckInterface = {
@@ -88,7 +88,7 @@ export type HealthCheckInterface = {
   isRequired?: boolean;
   description?: string;
   getDiagnostics: (
-    environmentInfo: EnvironmentInfo,
+    environmentInfo?: EnvironmentInfo,
   ) => Promise<{
     version?: string;
     versions?: [string];


### PR DESCRIPTION
Summary:
---------

Noticed that locally doctor tests fail on my machine, because it takes too much time to execute `envinfo` in parallel. To address that, I added a slightly bigger timeout and removed some unnecessary callsites.

Test Plan:
----------

^ Up