### PR TITLE
chore: use Node 12 on Azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,10 +4,22 @@ trigger:
 pool:
   vmImage: windows-2019
 
+variables:
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
 steps:
+  - task: Cache@2
+    inputs:
+      key: 'yarn | "$(Agent.OS)" | yarn.lock'
+      restoreKeys: |
+        yarn | "$(Agent.OS)"
+        yarn
+      path: $(YARN_CACHE_FOLDER)
+    displayName: Cache Yarn packages
+
   - task: NodeTool@0
     inputs:
-      versionSpec: '13.x'
+      versionSpec: '12.x'
     displayName: Install Node.js
 
   - script: yarn --frozen-lockfile

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,17 +4,29 @@ trigger:
 pool:
   vmImage: 'windows-2019'
 
+variables:
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
 steps:
+  - task: Cache@2
+    inputs:
+      key: 'yarn | "$(Agent.OS)" | yarn.lock'
+      restoreKeys: |
+        yarn | "$(Agent.OS)"
+        yarn
+      path: $(YARN_CACHE_FOLDER)
+    displayName: Cache Yarn packages
+
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
-    displayName: 'Install Node.js'
+      versionSpec: '13.x'
+    displayName: Install Node.js
 
-  - script: yarn install
-    displayName: 'Install dependencies'
+  - script: yarn --frozen-lockfile
+    displayName: Install dependencies
 
   - script: yarn test:ci:unit
-    displayName: 'Unit tests'
+    displayName: Unit tests
 
   - script: yarn test:ci:e2e
-    displayName: 'E2E tests'
+    displayName: E2E tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
   - master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: windows-2019
 
 variables:
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,19 +4,7 @@ trigger:
 pool:
   vmImage: windows-2019
 
-variables:
-  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-
 steps:
-  - task: Cache@2
-    inputs:
-      key: 'yarn | "$(Agent.OS)" | yarn.lock'
-      restoreKeys: |
-        yarn | "$(Agent.OS)"
-        yarn
-      path: $(YARN_CACHE_FOLDER)
-    displayName: Cache Yarn packages
-
   - task: NodeTool@0
     inputs:
       versionSpec: '13.x'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,9 +11,6 @@ steps:
   - task: Cache@2
     inputs:
       key: 'yarn | "$(Agent.OS)" | yarn.lock'
-      restoreKeys: |
-        yarn | "$(Agent.OS)"
-        yarn
       path: $(YARN_CACHE_FOLDER)
     displayName: Cache Yarn packages
 


### PR DESCRIPTION
Summary:
---------

Installing packages takes roughly 2mins, that's slow. Tried adding Yarn cache based on https://docs.microsoft.com/en-us/azure/devops/pipelines/caching/?view=azure-devops#example but it resulted in even slower times, as we constantly hit cache misses. Will leave that for later.
Upgrading Node version, which should contribute to slightly faster test runs.

Test Plan:
----------

Azure
