### PR TITLE
fix: script to link all packages

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "npmClient": "yarn",
   "command": {
     "publish": {
-      "ignoreChanges": ["global-cli"]
+      "ignoreChanges": ["**/global-cli/**"]
     }
   },
   "useWorkspaces": true

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,10 @@
 {
   "version": "4.1.0",
   "npmClient": "yarn",
+  "command": {
+    "publish": {
+      "ignoreChanges": ["global-cli"]
+    }
+  },
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ext .js,.ts . --cache --report-unused-disable-directives",
     "test:ci:cocoapods": "ruby packages/platform-ios/native_modules.rb",
     "postinstall": "yarn build",
-    "link-packages": "PACKAGES=('tools' 'platform-ios' 'platform-android' 'cli' 'cli-types' 'debugger-ui') && cd packages && for PACKAGE in \"${PACKAGES[@]}\"; do cd $PACKAGE && yarn link && cd ..; done",
+    "link-packages": "yarn workspaces run link-package",
     "publish": "yarn build-clean-all && yarn install && lerna publish",
     "publish:next": "yarn build-clean-all && yarn install && lerna publish --dist-tag next"
   },

--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -6,5 +6,8 @@
     "access": "public"
   },
   "types": "build/index.d.ts",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "link-package": "yarn link"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -87,5 +87,8 @@
     "@types/ws": "^6.0.3",
     "slash": "^3.0.0",
     "snapshot-diff": "^0.5.0"
+  },
+  "scripts": {
+    "link-package": "yarn link"
   }
 }

--- a/packages/debugger-ui/package.json
+++ b/packages/debugger-ui/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "yarn build:ui && yarn build:middleware",
     "build:ui": "parcel build src/ui/index.html --out-dir build/ui --public-url '/debugger-ui'",
-    "build:middleware": "tsc"
+    "build:middleware": "tsc",
+    "link-package": "yarn link"
   },
   "files": [
     "build"

--- a/packages/global-cli/package.json
+++ b/packages/global-cli/package.json
@@ -12,7 +12,8 @@
     "url": "https://github.com/react-native-community/react-native-cli.git"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "link-package": "exit 0"
   },
   "bin": {
     "react-native": "index.js"

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -25,5 +25,8 @@
     "@types/fs-extra": "^8.0.0",
     "@types/glob": "^7.1.1",
     "@types/xmldoc": "^1.1.4"
+  },
+  "scripts": {
+    "link-package": "yarn link"
   }
 }

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -20,5 +20,8 @@
   "files": [
     "build",
     "native_modules.rb"
-  ]
+  ],
+  "scripts": {
+    "link-package": "yarn link"
+  }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -19,5 +19,8 @@
   },
   "files": [
     "build"
-  ]
+  ],
+  "scripts": {
+    "link-package": "yarn link"
+  }
 }


### PR DESCRIPTION
Summary:
---------

Per #978, running `yarn link-packages` was failing with the following output:

```
yarn run v1.21.1
$ PACKAGES=('tools' 'platform-ios' 'platform-android' 'cli' 'cli-types' 'debugger-ui') && cd packages && for PACKAGE in "${PACKAGES[@]}"; do cd $PACKAGE && yarn link && cd ..; done
/bin/sh: 1: Syntax error: "(" unexpected
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

This PR fixes that using [`yarn workspaces run`](https://classic.yarnpkg.com/en/docs/cli/workspaces#toc-yarn-workspaces-run)

The output now is:

```
$ yarn link-packages
yarn run v1.21.1
$ yarn workspaces run link

> @react-native-community/cli-types
success Registered "@react-native-community/cli-types".
info You can now run `yarn link "@react-native-community/cli-types"` in the projects where you want to use this package and it will be used instead.

> @react-native-community/cli
success Registered "@react-native-community/cli".
info You can now run `yarn link "@react-native-community/cli"` in the projects where you want to use this package and it will be used instead.

> @react-native-community/cli-debugger-ui
success Registered "@react-native-community/cli-debugger-ui".
info You can now run `yarn link "@react-native-community/cli-debugger-ui"` in the projects where you want to use this package and it will be used instead.

> react-native-cli
success Registered "react-native-cli".
info You can now run `yarn link "react-native-cli"` in the projects where you want to use this package and it will be used instead.

> @react-native-community/cli-platform-android
success Registered "@react-native-community/cli-platform-android".
info You can now run `yarn link "@react-native-community/cli-platform-android"` in the projects where you want to use this package and it will be used instead.

> @react-native-community/cli-platform-ios
success Registered "@react-native-community/cli-platform-ios".
info You can now run `yarn link "@react-native-community/cli-platform-ios"` in the projects where you want to use this package and it will be used instead.

> @react-native-community/cli-tools
success Registered "@react-native-community/cli-tools".
info You can now run `yarn link "@react-native-community/cli-tools"` in the projects where you want to use this package and it will be used instead.
Done in 3.29s.
```

Test Plan:
----------

N/A


Also I did the PR to next because that's where I was working. Happy to cherry pick and do it to master if that's the preferred way.

Fixes #978 