### PR TITLE
chore: fix windows sdk test

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -10,16 +10,19 @@ const logSpy = jest.spyOn(common, 'logManualInstallation');
 
 jest.mock('execa', () => jest.fn());
 
+// TODO remove when androidSDK starts getting gradle.build path from config
+jest.mock('../../../../tools/config/findProjectRoot', () => () => '.');
+
 describe('androidSDK', () => {
   beforeEach(() => {
     writeFiles('', {
       'android/build.gradle': `
         buildscript {
           ext {
-              buildToolsVersion = "28.0.3"
-              minSdkVersion = 16
-              compileSdkVersion = 28
-              targetSdkVersion = 28
+            buildToolsVersion = "28.0.3"
+            minSdkVersion = 16
+            compileSdkVersion = 28
+            targetSdkVersion = 28
           }
         }
       `,

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -6,6 +6,7 @@ import {HealthCheckInterface} from '../types';
 import findProjectRoot from '../../../tools/config/findProjectRoot';
 
 const getBuildToolsVersion = (): string => {
+  // TODO use config
   const projectRoot = findProjectRoot();
   const gradleBuildFilePath = path.join(projectRoot, 'android/build.gradle');
 

--- a/packages/cli/src/tools/config/findProjectRoot.ts
+++ b/packages/cli/src/tools/config/findProjectRoot.ts
@@ -7,7 +7,6 @@ import {CLIError} from '@react-native-community/cli-tools';
  */
 export default function findProjectRoot(cwd = process.cwd()): string {
   const packageLocation = findUp.sync('package.json', {cwd});
-
   /**
    * It is possible that `package.json` doesn't exist
    * in the tree. In that case, we want to throw an error.


### PR DESCRIPTION
Summary:
---------

Windows CI sets `$CWD` to `D:\`, which is not where the project exists. To not alter the source code too much, I mocked the `findProjectRoot` so that it returns a local path. A proper fix would be reading the root (and, in turn, gradle.build path) from the config passed to the command. See #791 for reference

Test Plan:
----------

Green windows CI
