### PR TITLE
Create sourcemaps for easier debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 *.tsbuildinfo
 .cache
 .watchmanconfig
+coverage

--- a/babel.config.js
+++ b/babel.config.js
@@ -28,4 +28,5 @@ module.exports = {
       }),
     ],
   ],
+  sourceMaps: true,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,4 +15,5 @@ module.exports = {
       testMatch: ['<rootDir>/**/__tests__/*{.,-}test.[jt]s'],
     },
   ],
+  collectCoverageFrom: ['packages/**/src/**/*.ts'],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,7 +16,9 @@ module.exports = {
     },
   ],
   collectCoverageFrom: [
-    '<rootDir>/packages/**/src/**/*.ts',
-    '<rootDir>/!packages/cli-types/src/**/*.ts',
+    '**/packages/*/**/*.ts',
+    '!**/__mocks__/**',
+    '!**/__tests__/**',
+    '!**/build/**',
   ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,5 +15,8 @@ module.exports = {
       testMatch: ['<rootDir>/**/__tests__/*{.,-}test.[jt]s'],
     },
   ],
-  collectCoverageFrom: ['packages/**/src/**/*.ts'],
+  collectCoverageFrom: [
+    '<rootDir>/packages/**/src/**/*.ts',
+    '<rootDir>/!packages/cli-types/src/**/*.ts',
+  ],
 };

--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -5,6 +5,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "files": [
+    "build",
+    "!build/**/*.map"
+  ],
   "types": "build/index.d.ts",
   "license": "MIT"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "build",
+    "!build/**/*.map",
     "setup_env.sh"
   ],
   "engineStrict": true,

--- a/packages/debugger-ui/package.json
+++ b/packages/debugger-ui/package.json
@@ -9,7 +9,8 @@
     "build:middleware": "tsc"
   },
   "files": [
-    "build"
+    "build",
+    "!build/**/*.map"
   ],
   "devDependencies": {
     "@babel/core": "^7.6.4",

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -17,6 +17,7 @@
   },
   "files": [
     "build",
+    "!build/**/*.map",
     "native_modules.gradle"
   ],
   "devDependencies": {

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "build",
+    "!build/**/*.map",
     "native_modules.rb"
   ]
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -20,8 +20,5 @@
   "files": [
     "build",
     "!build/**/*.map"
-  ],
-  "scripts": {
-    "link-package": "yarn link"
-  }
+  ]
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -18,6 +18,10 @@
     "@types/node-fetch": "^2.3.3"
   },
   "files": [
-    "build"
-  ]
+    "build",
+    "!build/**/*.map"
+  ],
+  "scripts": {
+    "link-package": "yarn link"
+  }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -93,9 +93,17 @@ function buildFile(file, silent) {
       );
   } else {
     const options = Object.assign({}, transformOptions);
-    const transformed = babel.transformFileSync(file, options).code;
+    const filename = path.basename(destPath);
 
-    fs.writeFileSync(destPath, transformed);
+    let {code, map} = babel.transformFileSync(file, options);
+
+    if (!file.endsWith('.d.ts') && map.sources.length > 0) {
+      code = `${code}\n\n//# sourceMappingURL=${filename}.map`;
+      map.sources = [path.relative(path.dirname(destPath), file)];
+      fs.writeFileSync(`${destPath}.map`, JSON.stringify(map));
+    }
+
+    fs.writeFileSync(destPath, code);
 
     silent ||
       process.stdout.write(


### PR DESCRIPTION
Summary:
---------

I really need all the help I can get when coding. Having breakpoints in TypeScript instead of JavaScript is really high on my list. Otherwise I always end up modifying the JS and then erasing all changes in the next build because I was modifying the wrong place 😅

The only way I've found to make this work in this project is by creating sourcemaps.
Here's an example of it running on VS Code:

![TS breakpoints working on the project](https://user-images.githubusercontent.com/606594/74966368-c5c96c80-53cb-11ea-89d0-082d4f3954d7.png)

What it does:

1. Create a valid `.map` for each file in the build process
1. Append `//# sourceMappingURL=FILE.map` to each JS generated file
1. Ignore all `.map` files during the publishing process so the package doesn't increase in size. There were some packages that didn't have a `files` property in `package.json`. I have not ignored in those cases.

To make this work from VS Code you just need a regular node configuration like in the image above or the following:

```json
{
  "version": "0.2.0",
  "configurations": [  
    {
      "type": "node",
      "request": "launch",
      "name": "CLI",
      "skipFiles": ["<node_internals>/**"],
      "program": "${workspaceFolder}/packages/cli/build/bin.js",
      "args": ["doctor"],
      "console": "integratedTerminal",
      "cwd": "${workspaceFolder}"
    }
  ]
}
```

It does not require setting up the `sourceMaps` or `outFiles` properties.

In this case I'm running the CLI package with the `doctor` parameter (`args`). This file is currently ignored by `.gitignore` even though there are some files from `.vscode` that are committed.

Happy to contribute this `launch.json` or try to come up with something more generic if wanted.

Test Plan:
----------

N/A