### PR TITLE
chore: upgrade TS to 3.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "micromatch": "^3.1.10",
     "mkdirp": "^0.5.1",
     "string-length": "^2.0.0",
-    "typescript": "^3.7.0"
+    "typescript": "^3.8.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-class-properties": "^7.5.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11833,10 +11833,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^3.7.0:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
-  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
+typescript@^3.8.0:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.2.tgz#91d6868aaead7da74f493c553aeff76c0c0b1d5a"
+  integrity sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
Summary:
---------

https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/

We won't be able to use much of the new syntax (typescript-eslint/typescript-eslint#1465) but the stricter checks etc are 👍


Test Plan:
----------

🍏 
