### PR TITLE
chore: use script to link packages because lerna is buggy

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,10 +1,5 @@
 {
   "version": "4.1.0",
   "npmClient": "yarn",
-  "command": {
-    "publish": {
-      "ignoreChanges": ["**/global-cli/**"]
-    }
-  },
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ext .js,.ts . --cache --report-unused-disable-directives",
     "test:ci:cocoapods": "ruby packages/platform-ios/native_modules.rb",
     "postinstall": "yarn build",
-    "link-packages": "yarn workspaces run link-package",
+    "link-packages": "node ./scripts/linkPackages.js",
     "publish": "yarn build-clean-all && yarn install && lerna publish",
     "publish:next": "yarn build-clean-all && yarn install && lerna publish --dist-tag next"
   },

--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -6,8 +6,5 @@
     "access": "public"
   },
   "types": "build/index.d.ts",
-  "license": "MIT",
-  "scripts": {
-    "link-package": "yarn link"
-  }
+  "license": "MIT"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -87,8 +87,5 @@
     "@types/ws": "^6.0.3",
     "slash": "^3.0.0",
     "snapshot-diff": "^0.5.0"
-  },
-  "scripts": {
-    "link-package": "yarn link"
   }
 }

--- a/packages/debugger-ui/package.json
+++ b/packages/debugger-ui/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "build": "yarn build:ui && yarn build:middleware",
     "build:ui": "parcel build src/ui/index.html --out-dir build/ui --public-url '/debugger-ui'",
-    "build:middleware": "tsc",
-    "link-package": "yarn link"
+    "build:middleware": "tsc"
   },
   "files": [
     "build"

--- a/packages/global-cli/package.json
+++ b/packages/global-cli/package.json
@@ -12,8 +12,7 @@
     "url": "https://github.com/react-native-community/react-native-cli.git"
   },
   "scripts": {
-    "test": "mocha",
-    "link-package": "exit 0"
+    "test": "mocha"
   },
   "bin": {
     "react-native": "index.js"

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -25,8 +25,5 @@
     "@types/fs-extra": "^8.0.0",
     "@types/glob": "^7.1.1",
     "@types/xmldoc": "^1.1.4"
-  },
-  "scripts": {
-    "link-package": "yarn link"
   }
 }

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -20,8 +20,5 @@
   "files": [
     "build",
     "native_modules.rb"
-  ],
-  "scripts": {
-    "link-package": "yarn link"
-  }
+  ]
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -19,8 +19,5 @@
   },
   "files": [
     "build"
-  ],
-  "scripts": {
-    "link-package": "yarn link"
-  }
+  ]
 }

--- a/scripts/linkPackages.js
+++ b/scripts/linkPackages.js
@@ -1,0 +1,15 @@
+const execa = require('execa');
+const chalk = require('chalk');
+const path = require('path');
+const glob = require('glob');
+
+const projects = glob
+  .sync('packages/*/package.json')
+  // We don't want to deal with global-cli at the moment
+  .filter(name => !name.includes('global-cli'));
+
+projects.forEach(project => {
+  const cwd = path.dirname(project);
+  console.log(chalk.dim(`Running "yarn link" in ${cwd}`));
+  execa.sync('yarn', ['link'], {cwd, stdio: 'inherit'});
+});


### PR DESCRIPTION
Summary:
---------

`lerna changed` shows that `global-cli` is ignored, but `lerna publish` ignores it. Falling back to yarn linking with a script then.

Test Plan:
----------

Works for me
