### PR TITLE
chore: use a better threshold factor to find the closest match

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,7 +87,7 @@ function printHelpInformation(
 function printUnknownCommand(cmdName: string) {
   const availableCommands = commander.commands.map(cmd => cmd._name);
   const suggestion = availableCommands.find(cmd => {
-    return leven(cmd, cmdName) < 3;
+    return leven(cmd, cmdName) < cmd.length * 0.4;
   });
   let errorMsg = `Unrecognized command "${chalk.bold(cmdName)}".`;
   if (suggestion) {


### PR DESCRIPTION
Summary:
---------
Follow up of #960 

```bash
react-native inf
error Unrecognized command "inf". Did you mean "init"?
``` 

Set the threshold to 40% such that `info` shows up instead in the above scenario.