### PR TITLE
fix: building TS definitions broken by include package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "dependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/plugin-transform-strict-mode": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-typescript": "^7.3.3",
@@ -34,6 +36,7 @@
     "babel-jest": "^24.6.0",
     "babel-plugin-module-resolver": "^3.2.0",
     "chalk": "^2.4.2",
+    "chokidar": "^3.3.1",
     "eslint": "^5.10.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^1.1.1",
@@ -47,10 +50,5 @@
     "mkdirp": "^0.5.1",
     "string-length": "^2.0.0",
     "typescript": "^3.8.0"
-  },
-  "devDependencies": {
-    "@babel/plugin-proposal-class-properties": "^7.5.5",
-    "@babel/plugin-transform-runtime": "^7.6.2",
-    "chokidar": "^3.3.1"
   }
 }

--- a/packages/cli/src/commands/doctor/doctor.ts
+++ b/packages/cli/src/commands/doctor/doctor.ts
@@ -21,7 +21,15 @@ const printCategory = ({label, key}: {label: string; key: number}) => {
   logger.log(chalk.dim(label));
 };
 
-const printVersions = ({version, versions, versionRange}) => {
+const printVersions = ({
+  version,
+  versions,
+  versionRange,
+}: {
+  version?: 'Not Found' | string;
+  versions?: [string] | string;
+  versionRange: string;
+}) => {
   if (versions) {
     const versionsToShow = Array.isArray(versions)
       ? versions.join(', ')

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -19,15 +19,16 @@ const getBuildToolsVersion = (): string => {
     buildToolsVersionEntry,
   );
 
-  const buildToolsVersion = gradleBuildFile
-    // Get only the portion of the declaration of `buildToolsVersion`
-    .substring(buildToolsVersionIndex)
-    .split('\n')[0]
-    // Get only the the value of `buildToolsVersion`
-    .match(/\d|\../g)
-    .join('');
+  const buildToolsVersion = (
+    gradleBuildFile
+      // Get only the portion of the declaration of `buildToolsVersion`
+      .substring(buildToolsVersionIndex)
+      .split('\n')[0]
+      // Get only the the value of `buildToolsVersion`
+      .match(/\d|\../g) || []
+  ).join('');
 
-  return buildToolsVersion;
+  return buildToolsVersion || 'Not Found';
 };
 
 const installMessage = `Read more about how to update Android SDK at ${chalk.dim(
@@ -39,27 +40,27 @@ export default {
   description: 'Required for building and installing your app on Android',
   getDiagnostics: async ({SDKs}) => {
     const requiredVersion = getBuildToolsVersion();
+    const buildTools =
+      typeof SDKs['Android SDK'] === 'string'
+        ? SDKs['Android SDK']
+        : SDKs['Android SDK']['Build Tools'];
 
     if (!requiredVersion) {
       return {
-        versions: SDKs['Android SDK']['Build Tools'],
+        versions: buildTools,
         versionRange: undefined,
         needsToBeFixed: true,
       };
     }
 
-    const isAndroidSDKInstalled = Array.isArray(
-      SDKs['Android SDK']['Build Tools'],
-    );
+    const isAndroidSDKInstalled = Array.isArray(buildTools);
 
     const isRequiredVersionInstalled = isAndroidSDKInstalled
-      ? SDKs['Android SDK']['Build Tools'].includes(requiredVersion)
+      ? buildTools.includes(requiredVersion)
       : false;
 
     return {
-      versions: isAndroidSDKInstalled
-        ? SDKs['Android SDK']['Build Tools']
-        : SDKs['Android SDK'],
+      versions: isAndroidSDKInstalled ? buildTools : SDKs['Android SDK'],
       versionRange: requiredVersion,
       needsToBeFixed: !isRequiredVersionInstalled,
     };

--- a/packages/cli/src/commands/doctor/types.ts
+++ b/packages/cli/src/commands/doctor/types.ts
@@ -79,7 +79,7 @@ export type Healthchecks = {
 
 export type RunAutomaticFix = (args: {
   loader: Ora;
-  environmentInfo?: EnvironmentInfo;
+  environmentInfo: EnvironmentInfo;
 }) => Promise<void> | void;
 
 export type HealthCheckInterface = {
@@ -88,7 +88,7 @@ export type HealthCheckInterface = {
   isRequired?: boolean;
   description?: string;
   getDiagnostics: (
-    environmentInfo?: EnvironmentInfo,
+    environmentInfo: EnvironmentInfo,
   ) => Promise<{
     version?: string;
     versions?: [string];

--- a/packages/cli/src/commands/server/eventsSocket.ts
+++ b/packages/cli/src/commands/server/eventsSocket.ts
@@ -169,7 +169,7 @@ function attachToServer(
     };
 
     clientWs.onmessage = event => {
-      const message: Command = parseMessage(event.data.toString());
+      const message: Command | undefined = parseMessage(event.data.toString());
       if (message == null) {
         return;
       }

--- a/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
@@ -9,7 +9,11 @@ import {logger} from '@react-native-community/cli-tools';
 import {exec} from 'child_process';
 import launchDebugger from '../launchDebugger';
 
-function launchDefaultDebugger(host: string, port: number, args = '') {
+function launchDefaultDebugger(
+  host: string | undefined,
+  port: number,
+  args = '',
+) {
   const hostname = host || 'localhost';
   const debuggerURL = `http://${hostname}:${port}/debugger-ui${args}`;
   logger.info('Launching Dev Tools...');
@@ -22,7 +26,7 @@ function escapePath(pathname: string) {
 }
 
 type LaunchDevToolsOptions = {
-  host: string;
+  host?: string;
   port: number;
   watchFolders: Array<string>;
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,7 +12,7 @@ import init from './commands/init/initCompat';
 import assertRequiredOptions from './tools/assertRequiredOptions';
 import loadConfig from './tools/config';
 
-import pkgJson from '../package.json';
+const pkgJson = require('../package.json');
 
 commander
   .option('--version', 'Print CLI version')
@@ -85,8 +85,8 @@ function printHelpInformation(
 }
 
 function printUnknownCommand(cmdName: string) {
-  const availableCommands = commander.commands.map(cmd => cmd._name);
-  const suggestion = availableCommands.find(cmd => {
+  const availableCommands = commander.commands.map((cmd: any) => cmd._name);
+  const suggestion = availableCommands.find((cmd: string) => {
     return leven(cmd, cmdName) < cmd.length * 0.4;
   });
   let errorMsg = `Unrecognized command "${chalk.bold(cmdName)}".`;

--- a/packages/cli/src/tools/config/readConfigFromDisk.ts
+++ b/packages/cli/src/tools/config/readConfigFromDisk.ts
@@ -177,6 +177,7 @@ function readLegacyDependencyConfigFromDisk(
         params: [],
       },
       commands: [],
+      // @ts-ignore
       platforms: {},
     };
   }

--- a/packages/cli/src/tools/generator/promptSync.ts
+++ b/packages/cli/src/tools/generator/promptSync.ts
@@ -43,13 +43,13 @@ function create() {
     const echo = opts.echo;
     const masked = 'echo' in opts;
 
-    /*eslint-disable prettier/prettier*/
-    const fd =
-      process.platform === 'win32'
-        // @ts-ignore
-        ? process.stdin.fd
-        : fs.openSync('/dev/tty', 'rs');
-    /*eslint-enable prettier/prettier*/
+    let fd;
+    if (process.platform === 'win32') {
+      // @ts-ignore
+      fd = process.stdin.fd;
+    } else {
+      fd = fs.openSync('/dev/tty', 'rs');
+    }
 
     const wasRaw = process.stdin.isRaw;
     if (!wasRaw && process.stdin.setRawMode) {
@@ -91,7 +91,7 @@ function create() {
         fs.closeSync(fd);
         process.exit(130);
         if (process.stdin.setRawMode) {
-          process.stdin.setRawMode(!!wasRaw);
+          process.stdin.setRawMode!(!!wasRaw);
         }
         return null;
       }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,6 +8,5 @@
     {"path": "../tools"},
     {"path": "../cli-types"},
     {"path": "../debugger-ui"}
-  ],
-  "include": ["../package.json"]
+  ]
 }


### PR DESCRIPTION
Summary:
---------

Noticed that type defs were not built properly for `packages/cli`. The reason was `"include": "../package.json"` in TS config, which resulted in TS happily passing everything. Seems like a bug in TS, present on both 3.7 and 3.8.

Test Plan:
----------

Type defs are there in `build/` dirs
