### PR TITLE
Change iOS default simulator to iPhone 11 Pro Max

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -370,12 +370,13 @@ Builds your app and starts it on iOS simulator.
 
 #### `--simulator [simulator_name]`
 
-> default: iPhone 11
+> default: iPhone 11 Pro Max
 
 Explicitly set the simulator to use. Optionally include iOS version between parenthesis at the end to match an exact version, e.g. `"iPhone 6 (10.0)"`.
 
 Notes: If selected simulator does not exist, cli will try to run fallback simulators in following order:
 
+- `iPhone 11`
 - `iPhone X`
 - `iPhone 8`
 

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -132,11 +132,12 @@ async function runOnSimulator(
 
   /**
    * If provided simulator does not exist, try simulators in following order
+   * - iPhone 11
    * - iPhone X
    * - iPhone 8
    */
 
-  const fallbackSimulators = ['iPhone X', 'iPhone 8'];
+  const fallbackSimulators = ['iPhone 11', 'iPhone X', 'iPhone 8'];
   const selectedSimulator = fallbackSimulators.reduce((simulator, fallback) => {
     return simulator || findMatchingSimulator(simulators, fallback);
   }, findMatchingSimulator(simulators, args.simulator));
@@ -528,7 +529,7 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
-      default: 'iPhone 11',
+      default: 'iPhone 11 Pro Max',
     },
     {
       name: '--configuration [string]',


### PR DESCRIPTION
Summary:
---------
Changing from iPhone 11 to  iPhone 11 Pro Max due to screen resolution. When uploading screenshots to app store you are required to open iPhone 11 Pro Max and take screenshots. So it is better to use iPhone 11 Pro Max from beginning.

Test Plan:
----------

Run `react-native run-ios` and it should start iPhone 11 Pro Max as simulator