### PR TITLE
Open `/events` for locally served javascript files as well

### DIFF
--- a/packages/cli/src/commands/server/eventsSocket.ts
+++ b/packages/cli/src/commands/server/eventsSocket.ts
@@ -125,7 +125,9 @@ function attachToServer(
     verifyClient({origin}: {origin: string}) {
       // This exposes the full JS logs and enables issuing commands like reload
       // so let's make sure only locally running stuff can connect to it
-      return origin.startsWith('http://localhost:');
+      return (
+        origin.startsWith('http://localhost:') || origin.startsWith('file:')
+      );
     },
   });
 


### PR DESCRIPTION
Summary:
---------

When using a production build of flipper, the network requests are made from a pre-bundled javascript file, which results in an origin header based on a local file url. In a future we will make sure that this origin is consistent both in prod- and non-prod builds, but for compatibility reasons making sure it will be compatible with the next react-native CLI version as well

Facebook: this corresponds with diff D20001690

Test Plan:
----------

1. Download the latest public release build of Flipper
2. Before this patch, it won't be able to connect, with this patch, it will be

Before:

<img width="999" alt="Screen Shot 2020-02-24 at 16 33 57" src="https://user-images.githubusercontent.com/1820292/75203730-cd6a7780-5723-11ea-9da7-ceaeffad544f.png">

After:

<img width="997" alt="Screen Shot 2020-02-24 at 16 35 41" src="https://user-images.githubusercontent.com/1820292/75203742-d4918580-5723-11ea-9358-25d15caed141.png">
