### PR TITLE
chore: update RN docs links to reactnative.dev

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -79,7 +79,7 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android SDK',
-      url: 'https://facebook.github.io/react-native/docs/getting-started',
+      url: 'https://reactnative.dev/docs/getting-started',
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli/src/commands/server/middleware/index.html
+++ b/packages/cli/src/commands/server/middleware/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <title>React Native</title>
-</head>
-<body>
-  <p>React Native packager is running.</p>
-  <p><a href="http://facebook.github.io/react-native/">Visit documentation</a></p>
-</body>
+  <head>
+    <title>React Native</title>
+  </head>
+  <body>
+    <p>React Native packager is running.</p>
+    <p><a href="https://reactnative.dev">Visit documentation</a></p>
+  </body>
 </html>

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -87,7 +87,7 @@ async function runOnAllDevices(
 function createInstallError(error: Error & {stderr: string}) {
   const stderr = (error.stderr || '').toString();
   const docs =
-    'https://facebook.github.io/react-native/docs/getting-started.html#android-development-environment';
+    'https://reactnative.dev/docs/getting-started.html#android-development-environment';
   let message = `Make sure you have the Android development environment set up: ${chalk.underline.dim(
     docs,
   )}`;


### PR DESCRIPTION
Summary:
---------

https://reactnative.dev is up, so why not


Test Plan:
----------

Checked that links work
