### PR TITLE
fix: avoid crashing if build.gradle is missing

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -79,4 +79,20 @@ describe('androidSDK', () => {
     androidSDK.runAutomaticFix({loader, environmentInfo});
     expect(logSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('returns true if a build.gradle is not found', async () => {
+    // To avoid having to provide fake versions for all the Android SDK tools
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Build Tools': ['28.0.3'],
+    };
+    ((execa as unknown) as jest.Mock).mockResolvedValue({
+      stdout: 'build-tools;28.0.3',
+    });
+
+    cleanup('android/build.gradle');
+
+    const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidSDK.ts
@@ -12,6 +12,10 @@ const getBuildToolsVersion = (): string => {
 
   const buildToolsVersionEntry = 'buildToolsVersion';
 
+  if (!fs.existsSync(gradleBuildFilePath)) {
+    return 'Not Found';
+  }
+
   // Read the content of the `build.gradle` file
   const gradleBuildFile = fs.readFileSync(gradleBuildFilePath, 'utf-8');
 
@@ -44,14 +48,6 @@ export default {
       typeof SDKs['Android SDK'] === 'string'
         ? SDKs['Android SDK']
         : SDKs['Android SDK']['Build Tools'];
-
-    if (!requiredVersion) {
-      return {
-        versions: buildTools,
-        versionRange: undefined,
-        needsToBeFixed: true,
-      };
-    }
 
     const isAndroidSDKInstalled = Array.isArray(buildTools);
 


### PR DESCRIPTION
Summary:
---------

Working on #976 I had some issues making the CLI crash when  `build.gradle` is missing.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
