### PR TITLE
feat: support run-ios on Mac target (Catalyst)

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
@@ -30,6 +30,10 @@ describe('parseIOSDevicesList', () => {
 
     expect(devices).toEqual([
       {
+        name: 'Maxs MacBook Pro',
+        udid: '11111111-1111-1111-1111-111111111111',
+      },
+      {
         name: "Max's iPhone",
         udid: '11111111111111111111aaaaaaaaaaaaaaaaaaaa',
         version: '9.2',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -83,7 +83,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     }),
   );
 
-  // first device is usually a host Mac
+  // first device is always the host Mac
   if (devices.length <= 1) {
     return logger.error('No iOS devices connected.');
   }

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -83,9 +83,6 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     }),
   );
 
-  if (devices.length === 0) {
-    return logger.error('No Mac or iOS devices connected.'); // which should never happen when running on Mac
-  }
   if (devices.length === 1) {
     return logger.error('No iOS devices connected.');
   }

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -83,7 +83,8 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     }),
   );
 
-  if (devices.length === 1) {
+  // first device is usually a host Mac
+  if (devices.length <= 1) {
     return logger.error('No iOS devices connected.');
   }
 

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -84,6 +84,9 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   );
 
   if (devices.length === 0) {
+    return logger.error('No Mac or iOS devices connected.'); // which should never happen when running on Mac
+  }
+  if (devices.length === 1) {
     return logger.error('No iOS devices connected.');
   }
 

--- a/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
+++ b/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
@@ -13,9 +13,22 @@ import {Device} from '../../types';
 function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];
 
-  text.split('\n').forEach(line => {
+  text.split('\n').forEach((line, index) => {
     const device = line.match(/(.*?) \((.*?)\) \[(.*?)\]/);
     const noSimulator = line.match(/(.*?) \((.*?)\) \[(.*?)\] \((.*?)\)/);
+
+    if (index === 1) {
+      const myMac = line.match(/(.*?) \[(.*?)\]/);
+      if (myMac) {
+        const name = myMac[1];
+        const udid = myMac[2];
+        devices.push({
+          udid,
+          name,
+        });
+      }
+    }
+
     if (device != null && noSimulator == null) {
       const name = device[1];
       const version = device[2];

--- a/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
+++ b/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
@@ -9,6 +9,10 @@ import {Device} from '../../types';
 
 /**
  * Parses the output of `xcrun simctl list devices` command
+ * Expected text looks roughly like this:
+ * Known Devices:
+ * this-mac-device [ID]
+ * Some Apple Simulator (Version) [ID]
  */
 function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];


### PR DESCRIPTION
Summary:
---------

Close https://github.com/react-native-community/cli/issues/998

Since Mac Catalyst won't be popular for RN projects anytime soon (I assume), I only changed the code to make it work when specifying a device name. If not, `run-ios` will still fall back to the default iOS simulator.

It seems that Mac will always be the first in the `xcrun` listed devices.

Test Plan:
----------

1. Run `react-native run-ios --device "Rui’s Mac"`
2. Now it does not return "No iOS devices connected" anymore