### PR TITLE
chore: refactor envinfo

### DIFF
--- a/packages/cli/src/commands/info/info.ts
+++ b/packages/cli/src/commands/info/info.ts
@@ -6,7 +6,7 @@
  */
 
 // @ts-ignore untyped
-import envinfo from 'envinfo';
+import getEnvironmentInfo from '../../tools/envinfo';
 import {logger} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
 import releaseChecker from '../../tools/releaseChecker';
@@ -14,15 +14,8 @@ import releaseChecker from '../../tools/releaseChecker';
 const info = async function getInfo(_argv: Array<string>, ctx: Config) {
   try {
     logger.info('Fetching system and libraries information...');
-    const output = await envinfo.run({
-      System: ['OS', 'CPU', 'Memory', 'Shell'],
-      Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
-      IDEs: ['Xcode', 'Android Studio'],
-      SDKs: ['iOS SDK', 'Android SDK'],
-      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
-      npmGlobalPackages: '*react-native*',
-    });
-    logger.log(output.trim());
+    const output = await getEnvironmentInfo(false);
+    logger.log(output);
   } catch (err) {
     logger.error(`Unable to print environment info.\n${err}`);
   } finally {

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -2,20 +2,37 @@
 import envinfo from 'envinfo';
 import {EnvironmentInfo} from '../commands/doctor/types';
 
-export default async function getEnvironmentInfo() {
-  return JSON.parse(
-    await envinfo.run(
-      {
-        Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
-        IDEs: ['Xcode', 'Android Studio'],
-        SDKs: ['iOS SDK', 'Android SDK'],
-        npmPackages: ['react', 'react-native', '@react-native-community/cli'],
-        npmGlobalPackages: ['*react-native*'],
-      },
-      {
-        json: true,
-        showNotFound: true,
-      },
-    ),
-  ) as EnvironmentInfo;
+/**
+ * Returns information about the running system.
+ * If `json === true`, or no options are passed,
+ * the return type will be an `EnvironmentInfo`.
+ * If set to `false`, it will be a `string`.
+ */
+async function getEnvironmentInfo(): Promise<EnvironmentInfo>;
+async function getEnvironmentInfo(json: true): Promise<EnvironmentInfo>;
+async function getEnvironmentInfo(json: false): Promise<string>;
+async function getEnvironmentInfo(
+  json = true,
+): Promise<string | EnvironmentInfo> {
+  const options = {json, showNotFound: true};
+
+  const info = (await envinfo.run(
+    {
+      System: ['OS', 'CPU', 'Memory', 'Shell'],
+      Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
+      IDEs: ['Xcode', 'Android Studio'],
+      SDKs: ['iOS SDK', 'Android SDK'],
+      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
+      npmGlobalPackages: ['*react-native*'],
+    },
+    options,
+  )) as string;
+
+  if (options.json) {
+    return JSON.parse(info);
+  }
+
+  return info.trim();
 }
+
+export default getEnvironmentInfo;


### PR DESCRIPTION
Summary:
---------

While working on #976 I saw that I needed to modify the properties requested to `envinfo` and that it was being accessed in a couple different places with different configurations.

This PR changes that to use a single point (and single configuration) to get the info.