### PR TITLE
chore: fix vscode "run on save" settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,9 @@
     "**/node_modules": true,
     "**/build": true
   },
-  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
   "flow.useNPMPackagedFlow": true,
   "javascript.validate.enable": false,
   "eslint.validate": [


### PR DESCRIPTION
Summary:
---------

Internal only, saving now doesn't conflict with default formatter


