### PR TITLE
fix: don't log watch mode not supported to stdout (fixes Expo)

### DIFF
--- a/packages/cli/src/commands/server/watchMode.ts
+++ b/packages/cli/src/commands/server/watchMode.ts
@@ -9,15 +9,15 @@ function printWatchModeInstructions() {
 }
 
 function enableWatchMode(messageSocket: any) {
-  readline.emitKeypressEvents(process.stdin);
-
   // We need to set this to true to catch key presses individually.
   // As a result we have to implement our own method for exiting
   // and other commands (e.g. ctrl+c & ctrl+z)
   if (!process.stdin.setRawMode) {
-    logger.log('Watch mode is not supported in this environment');
+    logger.debug('Watch mode is not supported in this environment');
     return;
   }
+
+  readline.emitKeypressEvents(process.stdin);
 
   process.stdin.setRawMode(true);
 


### PR DESCRIPTION
Summary:
---------

Moved "Watch mode is not supported in this environment" log to debug level.

Fixes https://github.com/expo/expo-cli/issues/1589

From my testing, no Expo functionality was affected, as CLI is run as a child process and is not a TTY. However, extra log message may have been confusing for the users.

Also, watch mode can be disabled by passing `--no-interactive` flag to the RN CLI.

cc @brentvatne 

Test Plan:
----------

Tested using both latest Expo and CLI alone