### PR TITLE
fix: pick correct TARGET_BUILD_DIR for run-ios

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -370,9 +370,15 @@ function bootSimulator(selectedSimulator: Device) {
 function getTargetBuildDir(buildSettings: string) {
   const settings = JSON.parse(buildSettings);
 
-  return settings.length > 0
-    ? settings[1].buildSettings.TARGET_BUILD_DIR
-    : settings[0].buildSettings.TARGET_BUILD_DIR;
+  // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
+  for (const i in settings) {
+    const wrapperExtension = settings[i].buildSettings.WRAPPER_EXTENSION;
+    if (wrapperExtension === 'app') {
+      return settings[i].buildSettings.TARGET_BUILD_DIR;
+    }
+  }
+
+  return null;
 }
 
 function getBuildPath(

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -368,10 +368,11 @@ function bootSimulator(selectedSimulator: Device) {
 }
 
 function getTargetBuildDir(buildSettings: string) {
-  const targetBuildMatch = /TARGET_BUILD_DIR = (.+)$/m.exec(buildSettings);
-  return targetBuildMatch && targetBuildMatch[1]
-    ? targetBuildMatch[1].trim()
-    : null;
+  const settings = JSON.parse(buildSettings);
+
+  return settings.length > 0
+    ? settings[1].buildSettings.TARGET_BUILD_DIR
+    : settings[0].buildSettings.TARGET_BUILD_DIR;
 }
 
 function getBuildPath(
@@ -403,6 +404,7 @@ function getBuildPath(
       '-configuration',
       configuration,
       '-showBuildSettings',
+      '-json',
     ],
     {encoding: 'utf8'},
   );


### PR DESCRIPTION
Summary:
---------

Related: https://github.com/facebook/react-native/issues/21303
Related: https://github.com/facebook/react-native/issues/14423


Test Plan:
----------

I'm getting wrong build target because some pods are also specified a target and this was in xcode env. The grep just matches first but not always the right TARGET. So instead of matching use JSON parsing. 
