### PR TITLE
fix: scoped packages with `.` produces incorrect package name

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -221,7 +221,7 @@ class ReactNativeModules {
 
         HashMap reactNativeModuleConfig = new HashMap<String, String>()
         reactNativeModuleConfig.put("name", name)
-        reactNativeModuleConfig.put("nameCleansed", replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_'))
+        reactNativeModuleConfig.put("nameCleansed", name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_'))
         reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
         reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -221,7 +221,7 @@ class ReactNativeModules {
 
         HashMap reactNativeModuleConfig = new HashMap<String, String>()
         reactNativeModuleConfig.put("name", name)
-        reactNativeModuleConfig.put("nameCleansed", name.replaceAll('^@([\\w-]+)/', '$1_'))
+        reactNativeModuleConfig.put("nameCleansed", replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_'))
         reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
         reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])


### PR DESCRIPTION
Summary:
---------

This fixes #1031 (a regression introduced with #910). It also makes sure that the package name contains only an allowed chars.

Theoretically NPM scope name can contain only a lowercase url-safe chars (`a-z 0-9 - _ . ! ~ * ' ( )`). But I did not tried to use those chars as the scope name. I mean the validator does not throw an error but I'm not sure if you can save it actually. I've attached some screenshots from npmjs.org:
![Screenshot 2020-03-03 at 17 59 49](https://user-images.githubusercontent.com/16777267/75795620-3e8cd900-5d7b-11ea-9be8-fedac32c4047.png)
![Screenshot 2020-03-03 at 17 59 59](https://user-images.githubusercontent.com/16777267/75795632-42b8f680-5d7b-11ea-862f-53ffdd0f3557.png)

On the other hand package name cannot contain these chars: `/ \ : < > " ? * |`. So we definitely need to replace `*` to be 100% sure that the package name is correct. Also I replaced `~ ! ' ( )` too (or I shouldn't do that?).

Test Plan:
----------

I've tried to add `yarn add @bam.tech/react-native-snap-carousel` and build the app.
The app builds successfully.

Also I've create a small groovy test script as an example:
https://groovyconsole.appspot.com/script/5174010459455488