### PR TITLE
feat: bail out when initializing new project to pre-existing directories

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -44,14 +44,14 @@ function doesDirectoryExist(dir: string) {
   return fs.existsSync(dir);
 }
 
-async function setProjectDirectory(projectPath: string) {
-  if (doesDirectoryExist(projectPath)) {
-    throw new DirectoryAlreadyExistsError(projectPath);
+async function setProjectDirectory(directory: string) {
+  if (doesDirectoryExist(directory)) {
+    throw new DirectoryAlreadyExistsError(directory);
   }
 
   try {
-    mkdirp.sync(projectPath);
-    process.chdir(projectPath);
+    mkdirp.sync(directory);
+    process.chdir(directory);
   } catch (error) {
     throw new CLIError(
       'Error occurred while trying to create project directory.',

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -4,8 +4,6 @@ import fs from 'fs-extra';
 import minimist from 'minimist';
 import ora from 'ora';
 import semver from 'semver';
-// @ts-ignore untyped
-import inquirer from 'inquirer';
 import mkdirp from 'mkdirp';
 import {validateProjectName} from './validate';
 import DirectoryAlreadyExistsError from './errors/DirectoryAlreadyExistsError';
@@ -42,8 +40,8 @@ interface TemplateOptions {
   projectTitle?: string;
 }
 
-function doesDirectoryExist(path: string) {
-  return fs.existsSync(path);
+function doesDirectoryExist(dir: string) {
+  return fs.existsSync(dir);
 }
 
 async function setProjectDirectory(projectPath: string) {
@@ -56,7 +54,7 @@ async function setProjectDirectory(projectPath: string) {
     process.chdir(projectPath);
   } catch (error) {
     throw new CLIError(
-      `Error occurred while trying to create project directory.`,
+      'Error occurred while trying to create project directory.',
       error,
     );
   }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -42,37 +42,21 @@ interface TemplateOptions {
   projectTitle?: string;
 }
 
-function doesDirectoryExist(dir: string) {
-  return fs.existsSync(dir);
+function doesDirectoryExist(path: string) {
+  return fs.existsSync(path);
 }
 
-async function setProjectDirectory(directory: string) {
-  const directoryExists = doesDirectoryExist(directory);
-  if (directoryExists) {
-    const {shouldReplaceprojectDirectory} = await inquirer.prompt([
-      {
-        type: 'confirm',
-        name: 'shouldReplaceprojectDirectory',
-        message: `Directory "${directory}" already exists, do you want to replace it?`,
-        default: false,
-      },
-    ]);
-
-    if (!shouldReplaceprojectDirectory) {
-      throw new DirectoryAlreadyExistsError(directory);
-    }
-
-    fs.emptyDirSync(directory);
+async function setProjectDirectory(projectPath: string) {
+  if (doesDirectoryExist(projectPath)) {
+    throw new DirectoryAlreadyExistsError(projectPath);
   }
 
   try {
-    mkdirp.sync(directory);
-    process.chdir(directory);
+    mkdirp.sync(projectPath);
+    process.chdir(projectPath);
   } catch (error) {
     throw new CLIError(
-      `Error occurred while trying to ${
-        directoryExists ? 'replace' : 'create'
-      } project directory.`,
+      `Error occurred while trying to create project directory.`,
       error,
     );
   }
@@ -224,13 +208,12 @@ export default (async function initialize(
    */
   const version: string = minimist(process.argv).version || DEFAULT_VERSION;
 
-  const directoryName = path.resolve(root, options.directory || projectName);
+  const projectPath = path.resolve(root, options.directory || projectName);
 
   try {
-    await createProject(projectName, directoryName, version, options);
+    await createProject(projectName, projectPath, version, options);
 
-    const projectFolder = path.join(root, directoryName);
-    printRunInstructions(projectFolder, projectName);
+    printRunInstructions(projectPath, projectName);
   } catch (e) {
     logger.error(e.message);
   }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -206,12 +206,13 @@ export default (async function initialize(
    */
   const version: string = minimist(process.argv).version || DEFAULT_VERSION;
 
-  const projectPath = path.resolve(root, options.directory || projectName);
+  const directoryName = path.relative(root, options.directory || projectName);
 
   try {
-    await createProject(projectName, projectPath, version, options);
+    await createProject(projectName, directoryName, version, options);
 
-    printRunInstructions(projectPath, projectName);
+    const projectFolder = path.join(root, directoryName);
+    printRunInstructions(projectFolder, projectName);
   } catch (e) {
     logger.error(e.message);
   }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -224,7 +224,7 @@ export default (async function initialize(
    */
   const version: string = minimist(process.argv).version || DEFAULT_VERSION;
 
-  const directoryName = path.relative(root, options.directory || projectName);
+  const directoryName = path.resolve(root, options.directory || projectName);
 
   try {
     await createProject(projectName, directoryName, version, options);


### PR DESCRIPTION
Summary:
---------

Initializing to the pre-existing directory was all about removing all the files in that directory. This approach doesn't make much sense from user perspective as it might lead to unexpected/accidental removals (even though we ask). From now on, we just fail when the directory exists and we leave it up to the user what to do with that.
