### PR TITLE
fix(cli-types): publish declaration files in npm package

### DIFF
--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -7,7 +7,6 @@
   },
   "files": [
     "build",
-    "!*.d.ts",
     "!*.map"
   ],
   "types": "build/index.d.ts",


### PR DESCRIPTION
Summary:
---------

Currently external plugin authors using TS cannot access the `cli-types` declaration files as they're not published to NPM. This change removes the file exclusion allowing them to be published.

cc @thymikee as discussed on Discord
