### PR TITLE
followup: fix what #1029 broke

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -111,10 +111,6 @@ See [`script_phase` options](https://www.rubydoc.info/gems/cocoapods-core/Pod/Po
 
 A relative path to a folder with Android project (Gradle root project), e.g. `./path/to/custom-android`. By default, CLI searches for `./android` as source dir.
 
-#### platforms.android.appName
-
-A name of the app in the Android `sourceDir`, equivalent to Gradle project name. By default it's `app`.
-
 #### platforms.android.manifestPath
 
 Path to a custom `AndroidManifest.xml`

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -20,7 +20,6 @@ export interface AndroidDependencyConfig {
   folder: string;
   packageImportPath: string;
   packageInstance: string;
-  appName: string;
   manifestPath: string;
   packageName: string;
 }

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -59,7 +59,6 @@ export const dependencyConfig = t
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                appName: t.string(),
               })
               .default({}),
           })
@@ -127,7 +126,6 @@ export const projectConfig = t
                 folder: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                appName: t.string(),
               })
               .allow(null),
           }),
@@ -164,6 +162,7 @@ export const projectConfig = t
             settingsGradlePath: t.string(),
             assetsPath: t.string(),
             buildGradlePath: t.string(),
+            appName: t.string(),
           })
           .default({}),
       })

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -16,8 +16,10 @@ function tryLaunchAppOnDevice(
   adbPath: string,
   args: Flags,
 ) {
-  const appId = args.appId || args.appIdSuffix;
-  const packageNameWithSuffix = appId ? `${packageName}.${appId}` : packageName;
+  const {appId, appIdSuffix} = args;
+  const packageNameWithSuffix = [appId || packageName, appIdSuffix]
+    .filter(Boolean)
+    .join('.');
 
   try {
     const adbArgs = [

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -128,7 +128,6 @@ export function dependencyConfig(
   }
 
   const sourceDir = path.join(root, src);
-  const appName = userConfig.appName || 'app';
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);
@@ -155,5 +154,5 @@ export function dependencyConfig(
   const packageInstance =
     userConfig.packageInstance || `new ${packageClassName}()`;
 
-  return {sourceDir, appName, folder: root, packageImportPath, packageInstance};
+  return {sourceDir, folder: root, packageImportPath, packageInstance};
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -131,7 +131,7 @@ export function dependencyConfig(
   const appName = userConfig.appName || 'app';
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
-    : findManifest(path.join(sourceDir, appName));
+    : findManifest(sourceDir);
 
   if (!manifestPath) {
     return null;


### PR DESCRIPTION
Summary:
---------

#1029 broke Android dependency discovery and `--appId` handling. Fixing it here.

cc @Krizzu

Test Plan:
----------

CI
