### PR TITLE
feat: run `pod repo update` when `pod install` failed

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -159,7 +159,7 @@ async function installDependencies({
   });
 
   if (process.platform === 'darwin') {
-    await installPods({projectName, loader, shouldUpdatePods: false});
+    await installPods({projectName, loader});
   }
 
   loader.succeed();

--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -135,7 +135,9 @@ const getVersionToUpgradeTo = async (
 
   if (!newVersion) {
     logger.error(
-      `Provided version "${argv[0]}" is not allowed. Please pass a valid semver version`,
+      `Provided version "${
+        argv[0]
+      }" is not allowed. Please pass a valid semver version`,
     );
     return null;
   }
@@ -206,7 +208,9 @@ const installCocoaPodsDeps = async (projectDir: string) => {
     } catch (error) {
       if (error.stderr) {
         logger.debug(
-          `"pod install" or "pod repo update" failed. Error output:\n${error.stderr}`,
+          `"pod install" or "pod repo update" failed. Error output:\n${
+            error.stderr
+          }`,
         );
       }
       logger.error(

--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -135,9 +135,7 @@ const getVersionToUpgradeTo = async (
 
   if (!newVersion) {
     logger.error(
-      `Provided version "${
-        argv[0]
-      }" is not allowed. Please pass a valid semver version`,
+      `Provided version "${argv[0]}" is not allowed. Please pass a valid semver version`,
     );
     return null;
   }
@@ -194,10 +192,7 @@ const installDeps = async (root: string, newVersion: string) => {
   }
 };
 
-const installCocoaPodsDeps = async (
-  projectDir: string,
-  thirdPartyIOSDeps: Array<Config['dependencies'][string]>,
-) => {
+const installCocoaPodsDeps = async (projectDir: string) => {
   if (process.platform === 'darwin') {
     try {
       logger.info(
@@ -207,14 +202,11 @@ const installCocoaPodsDeps = async (
       );
       await installPods({
         projectName: projectDir.split('/').pop() || '',
-        shouldUpdatePods: thirdPartyIOSDeps.length > 0,
       });
     } catch (error) {
       if (error.stderr) {
         logger.debug(
-          `"pod install" or "pod repo update" failed. Error output:\n${
-            error.stderr
-          }`,
+          `"pod install" or "pod repo update" failed. Error output:\n${error.stderr}`,
         );
       }
       logger.error(
@@ -323,9 +315,6 @@ async function upgrade(argv: Array<string>, ctx: Config) {
     projectDir,
     'node_modules/react-native/package.json',
   ));
-  const thirdPartyIOSDeps = Object.values(ctx.dependencies).filter(
-    dependency => dependency.platforms.ios,
-  );
 
   const newVersion = await getVersionToUpgradeTo(
     argv,
@@ -346,7 +335,7 @@ async function upgrade(argv: Array<string>, ctx: Config) {
   if (patch === '') {
     logger.info('Diff has no changes to apply, proceeding further');
     await installDeps(projectDir, newVersion);
-    await installCocoaPodsDeps(projectDir, thirdPartyIOSDeps);
+    await installCocoaPodsDeps(projectDir);
 
     logger.success(
       `Upgraded React Native to v${newVersion} 🎉. Now you can review and commit the changes`,
@@ -382,7 +371,7 @@ async function upgrade(argv: Array<string>, ctx: Config) {
       }
     } else {
       await installDeps(projectDir, newVersion);
-      await installCocoaPodsDeps(projectDir, thirdPartyIOSDeps);
+      await installCocoaPodsDeps(projectDir);
       logger.info('Running "git status" to check what changed...');
       await execa('git', ['status'], {stdio: 'inherit'});
     }

--- a/packages/cli/src/tools/installPods.ts
+++ b/packages/cli/src/tools/installPods.ts
@@ -15,7 +15,44 @@ type PromptCocoaPodsInstallation = {
   promptQuestion: string;
 };
 
-async function updatePods(loader: ora.Ora) {
+async function runPodInstall(
+  loader: ora.Ora,
+  projectName: string,
+  shouldHandleRepoUpdate: boolean = true,
+) {
+  try {
+    loader.start(
+      `Installing CocoaPods dependencies ${chalk.dim(
+        '(this may take a few minutes)',
+      )}`,
+    );
+    await execa('pod', ['install']);
+  } catch (error) {
+    // "pod" command outputs errors to stdout (at least some of them)
+    const stderr = error.stderr || error.stdout;
+
+    /**
+     * If CocoaPods failed due to repo being out of date, it will
+     * include the update command in the error message.
+     *
+     * `shouldHandleRepoUpdate` will be set to `false` to
+     * prevent infinite loop (unlikely scenario)
+     */
+    if (stderr.includes('pod repo update') && shouldHandleRepoUpdate) {
+      await runPodUpdate(loader);
+      await runPodInstall(loader, projectName, false);
+    } else {
+      loader.fail();
+      throw new Error(
+        `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${projectName}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
+          'https://cocoapods.org/',
+        )}`,
+      );
+    }
+  }
+}
+
+async function runPodUpdate(loader: ora.Ora) {
   try {
     loader.start(
       `Updating CocoaPods repositories ${chalk.dim(
@@ -127,11 +164,9 @@ async function installCocoaPods(loader: ora.Ora) {
 async function installPods({
   projectName,
   loader,
-  shouldUpdatePods,
 }: {
   projectName: string;
   loader?: ora.Ora;
-  shouldUpdatePods?: boolean;
 }) {
   loader = loader || new NoopLoader();
   try {
@@ -157,27 +192,7 @@ async function installPods({
       await installCocoaPods(loader);
     }
 
-    if (shouldUpdatePods) {
-      await updatePods(loader);
-    }
-
-    try {
-      loader.start(
-        `Installing CocoaPods dependencies ${chalk.dim(
-          '(this may take a few minutes)',
-        )}`,
-      );
-      await execa('pod', ['install']);
-    } catch (error) {
-      // "pod" command outputs errors to stdout (at least some of them)
-      logger.log(error.stderr || error.stdout);
-
-      throw new Error(
-        `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${projectName}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
-          'https://cocoapods.org/',
-        )}`,
-      );
-    }
+    await runPodInstall(loader, projectName);
   } catch (error) {
     throw error;
   } finally {


### PR DESCRIPTION
Summary:
---------

Fixes #1060 

Test Plan:
----------

Run `pod install` on outdated repo. Also includes a mechanism to prevent loops in case `pod repo update` didn't fix the error (e.g. invalid version specified).
