### PR TITLE
feat: remove assetsDest checking

### DIFF
--- a/packages/cli/src/commands/bundle/saveAssets.ts
+++ b/packages/cli/src/commands/bundle/saveAssets.ts
@@ -30,12 +30,6 @@ function saveAssets(
     return Promise.resolve();
   }
 
-  if (!fs.existsSync(assetsDest)) {
-    throw new CLIError(
-      `The specified assets destination folder "${assetsDest}" does not exist.`,
-    );
-  }
-
   const getAssetDestPath =
     platform === 'android' ? getAssetDestPathAndroid : getAssetDestPathIOS;
 

--- a/packages/cli/src/commands/bundle/saveAssets.ts
+++ b/packages/cli/src/commands/bundle/saveAssets.ts
@@ -13,7 +13,7 @@ import fs from 'fs';
 import filterPlatformAssetScales from './filterPlatformAssetScales';
 import getAssetDestPathAndroid from './getAssetDestPathAndroid';
 import getAssetDestPathIOS from './getAssetDestPathIOS';
-import {logger, CLIError} from '@react-native-community/cli-tools';
+import {logger} from '@react-native-community/cli-tools';
 import {AssetData} from './buildBundle';
 
 interface CopiedFiles {


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
Based on discussion on #609, `assetsDest` checking can be safely removed in favour of `mkdirp` when copying files.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
None.
