### PR TITLE
feat: install JDK automatically if missing

### DIFF
--- a/packages/cli-types/src/node-stream-zip.d.ts
+++ b/packages/cli-types/src/node-stream-zip.d.ts
@@ -1,0 +1,66 @@
+// https://github.com/antelle/node-stream-zip/issues/36#issuecomment-596249657
+declare module 'node-stream-zip' {
+  import {Stream} from 'stream';
+
+  interface StreamZipOptions {
+    /**
+     * File to read
+     */
+    file: string;
+    /**
+     * You will be able to work with entries inside zip archive, otherwise the only way to access them is entry event
+     *
+     * default: true
+     */
+    storeEntries?: boolean;
+    /**
+     * By default, entry name is checked for malicious characters, like ../ or c:\123, pass this flag to disable validation errors
+     *
+     * default: false
+     */
+    skipEntryNameValidation?: boolean;
+    /**
+     * Undocumented adjustment of chunk size
+     *
+     * default: automatic
+     */
+    chunkSize?: number;
+  }
+
+  class ZipEntry {
+    name: string;
+    isDirectory: boolean;
+    isFile: boolean;
+    comment: string;
+    size: number;
+  }
+
+  class StreamZip {
+    constructor(config: StreamZipOptions);
+
+    on(event: 'ready', handler: () => void): void;
+
+    entry(entry: string): ZipEntry;
+    entries(): ZipEntry[];
+
+    entriesCount: number;
+
+    stream(
+      entry: string,
+      callback: (err: any | null, stream?: Stream) => void,
+    ): void;
+    entryDataSync(entry: string): Buffer;
+    openEntry(
+      entry: string,
+      callback: (err: any | null, entry?: ZipEntry) => void,
+      sync: boolean,
+    ): void;
+    extract(
+      entry: string | null,
+      outPath: string,
+      callback: (err?: any) => void,
+    ): void;
+    close(callback?: (err?: any) => void): void;
+  }
+  export = StreamZip;
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
     "shell-quote": "1.6.1",
     "strip-ansi": "^5.2.0",
     "sudo-prompt": "^9.0.0",
+    "unzipper": "^0.10.10",
     "wcwidth": "^1.0.1",
     "ws": "^1.1.0"
   },
@@ -83,6 +84,7 @@
     "@types/mkdirp": "^0.5.2",
     "@types/pretty-format": "^24.3.0",
     "@types/semver": "^6.0.2",
+    "@types/unzipper": "^0.10.2",
     "@types/wcwidth": "^1.0.0",
     "@types/ws": "^6.0.3",
     "slash": "^3.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -84,7 +84,6 @@
     "@types/mkdirp": "^0.5.2",
     "@types/pretty-format": "^24.3.0",
     "@types/semver": "^6.0.2",
-    "@types/unzipper": "^0.10.2",
     "@types/wcwidth": "^1.0.0",
     "@types/ws": "^6.0.3",
     "slash": "^3.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,6 +55,7 @@
     "metro-react-native-babel-transformer": "^0.58.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "node-stream-zip": "^1.9.1",
     "open": "^6.2.0",
     "ora": "^3.4.0",
     "pretty-format": "^25.2.0",
@@ -63,7 +64,6 @@
     "shell-quote": "1.6.1",
     "strip-ansi": "^5.2.0",
     "sudo-prompt": "^9.0.0",
-    "unzipper": "^0.10.10",
     "wcwidth": "^1.0.1",
     "ws": "^1.1.0"
   },

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
@@ -1,0 +1,81 @@
+import execa from 'execa';
+import jdk from '../jdk';
+import getEnvironmentInfo from '../../../../tools/envinfo';
+import {EnvironmentInfo} from '../../types';
+import {NoopLoader} from '../../../../tools/loader';
+import * as common from '../common';
+import * as u from '../../../../tools/unzip';
+
+jest.mock('execa', () => jest.fn());
+
+const mockFetchToTemp = jest.fn();
+jest.mock('@react-native-community/cli-tools', () => {
+  return {
+    fetchToTemp: mockFetchToTemp,
+  };
+});
+
+const logSpy = jest.spyOn(common, 'logManualInstallation');
+
+describe('jdk', () => {
+  let environmentInfo: EnvironmentInfo;
+
+  beforeAll(async () => {
+    environmentInfo = await getEnvironmentInfo();
+  }, 15000);
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns a message if JDK is not installed', async () => {
+    environmentInfo.Languages.Java = 'Not Found';
+    ((execa as unknown) as jest.Mock).mockResolvedValue({stdout: ''});
+    const diagnostics = await jdk.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(true);
+  });
+
+  it('returns false if JDK version is in range', async () => {
+    // @ts-ignore
+    environmentInfo.Languages.Java = {
+      version: '9',
+    };
+
+    const diagnostics = await jdk.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
+  it('returns true if JDK version is not in range', async () => {
+    // @ts-ignore
+    environmentInfo.Languages.Java = {
+      version: '7',
+    };
+
+    const diagnostics = await jdk.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(true);
+  });
+
+  it('logs manual installation steps to the screen for the default fix', async () => {
+    const loader = new NoopLoader();
+    await jdk.runAutomaticFix({loader, environmentInfo});
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('downloads and unzips JDK on Windows when missing', async () => {
+    const loader = new NoopLoader();
+    const loaderSucceedSpy = jest.spyOn(loader, 'succeed');
+    const loaderFailSpy = jest.spyOn(loader, 'fail');
+    const unzipSpy = jest
+      .spyOn(u, 'unzip')
+      .mockImplementation(() => Promise.resolve());
+
+    await jdk.win32AutomaticFix({loader, environmentInfo});
+
+    expect(loaderFailSpy).toHaveBeenCalledTimes(0);
+    expect(logSpy).toHaveBeenCalledTimes(0);
+    expect(unzipSpy).toBeCalledTimes(1);
+    expect(loaderSucceedSpy).toBeCalledWith(
+      'JDK installed successfully. Please restart your shell to see the changes',
+    );
+  });
+});

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
@@ -4,9 +4,13 @@ import getEnvironmentInfo from '../../../../tools/envinfo';
 import {EnvironmentInfo} from '../../types';
 import {NoopLoader} from '../../../../tools/loader';
 import * as common from '../common';
-import * as u from '../../../../tools/unzip';
+import * as unzip from '../../../../tools/unzip';
+import * as deleteFile from '../../../../tools/deleteFile';
 
 jest.mock('execa', () => jest.fn());
+jest
+  .spyOn(deleteFile, 'deleteFile')
+  .mockImplementation(() => Promise.resolve());
 
 const mockFetchToTemp = jest.fn();
 jest.mock('@react-native-community/cli-tools', () => {
@@ -66,7 +70,7 @@ describe('jdk', () => {
     const loaderSucceedSpy = jest.spyOn(loader, 'succeed');
     const loaderFailSpy = jest.spyOn(loader, 'fail');
     const unzipSpy = jest
-      .spyOn(u, 'unzip')
+      .spyOn(unzip, 'unzip')
       .mockImplementation(() => Promise.resolve());
 
     await jdk.win32AutomaticFix({loader, environmentInfo});

--- a/packages/cli/src/commands/doctor/healthchecks/index.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/index.ts
@@ -1,6 +1,6 @@
 import nodeJS from './nodeJS';
 import {yarn, npm} from './packageManagers';
-import java from './jdk';
+import jdk from './jdk';
 import python from './python';
 import watchman from './watchman';
 import androidHomeEnvVariable from './androidHomeEnvVariable';
@@ -35,7 +35,7 @@ export const getHealthchecks = ({contributor}: Options): Healthchecks => ({
   android: {
     label: 'Android',
     healthchecks: [
-      java,
+      jdk,
       androidHomeEnvVariable,
       androidSDK,
       ...(contributor ? [androidNDK] : []),

--- a/packages/cli/src/commands/doctor/healthchecks/index.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/index.ts
@@ -1,5 +1,6 @@
 import nodeJS from './nodeJS';
 import {yarn, npm} from './packageManagers';
+import java from './jdk';
 import python from './python';
 import watchman from './watchman';
 import androidHomeEnvVariable from './androidHomeEnvVariable';
@@ -34,6 +35,7 @@ export const getHealthchecks = ({contributor}: Options): Healthchecks => ({
   android: {
     label: 'Android',
     healthchecks: [
+      java,
       androidHomeEnvVariable,
       androidSDK,
       ...(contributor ? [androidNDK] : []),

--- a/packages/cli/src/commands/doctor/healthchecks/jdk.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/jdk.ts
@@ -11,6 +11,7 @@ import {
 import {join} from 'path';
 import {Ora} from 'ora';
 import {unzip} from '../../../tools/unzip';
+import {deleteFile} from '../../../tools/deleteFile';
 
 export default {
   label: 'JDK',
@@ -37,7 +38,7 @@ export default {
       const installPath = process.env.LOCALAPPDATA || ''; // The zip is in a folder `jdk-11.02` so it can be unzipped directly there
 
       loader.start(
-        `Downloading JDK 11 from "${installerUrl}" (please be patient)`,
+        `Downloading JDK 11 from "${installerUrl}" (this may take a few minutes)`,
       );
 
       const installer = await fetchToTemp(installerUrl);
@@ -45,6 +46,8 @@ export default {
       loader.text = `Installing JDK in "${installPath}"`;
 
       await unzip(installer, installPath);
+
+      await deleteFile(installer);
 
       loader.text = 'Updating environment variables';
 
@@ -63,7 +66,7 @@ export default {
   runAutomaticFix: async () => {
     logManualInstallation({
       healthcheck: 'JDK',
-      url: 'http://jdk.java.net/11/',
+      url: 'https://openjdk.java.net/',
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/jdk.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/jdk.ts
@@ -1,0 +1,69 @@
+import {fetchToTemp} from '@react-native-community/cli-tools';
+import versionRanges from '../versionRanges';
+import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
+import {logManualInstallation} from './common';
+import {HealthCheckInterface} from '../types';
+
+import {
+  setEnvironment,
+  updateEnvironment,
+} from '../../../tools/environmentVariables';
+import {join} from 'path';
+import {Ora} from 'ora';
+import {unzip} from '../../../tools/unzip';
+
+export default {
+  label: 'JDK',
+  getDiagnostics: async ({Languages}) => ({
+    needsToBeFixed: doesSoftwareNeedToBeFixed({
+      version:
+        typeof Languages.Java === 'string'
+          ? Languages.Java
+          : Languages.Java.version,
+      versionRange: versionRanges.JAVA,
+    }),
+
+    version:
+      typeof Languages.Java === 'string'
+        ? Languages.Java
+        : Languages.Java.version,
+    versionRange: versionRanges.JAVA,
+  }),
+  win32AutomaticFix: async ({loader}: {loader: Ora}) => {
+    try {
+      // Installing JDK 11 because later versions seem to cause issues with gradle at the moment
+      const installerUrl =
+        'https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip';
+      const installPath = process.env.LOCALAPPDATA || ''; // The zip is in a folder `jdk-11.02` so it can be unzipped directly there
+
+      loader.start(
+        `Downloading JDK 11 from "${installerUrl}" (please be patient)`,
+      );
+
+      const installer = await fetchToTemp(installerUrl);
+
+      loader.text = `Installing JDK in "${installPath}"`;
+
+      await unzip(installer, installPath);
+
+      loader.text = 'Updating environment variables';
+
+      const jdkPath = join(installPath, 'jdk-11.0.2');
+
+      await setEnvironment('JAVA_HOME', jdkPath);
+      await updateEnvironment('PATH', join(jdkPath, 'bin'));
+
+      loader.succeed(
+        'JDK installed successfully. Please restart your shell to see the changes',
+      );
+    } catch (e) {
+      loader.fail(e);
+    }
+  },
+  runAutomaticFix: async () => {
+    logManualInstallation({
+      healthcheck: 'JDK',
+      url: 'http://jdk.java.net/11/',
+    });
+  },
+} as HealthCheckInterface;

--- a/packages/cli/src/commands/doctor/healthchecks/jdk.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/jdk.ts
@@ -1,17 +1,15 @@
-import {fetchToTemp} from '@react-native-community/cli-tools';
+import {join} from 'path';
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import {logManualInstallation} from './common';
 import {HealthCheckInterface} from '../types';
 
+import {downloadAndUnzip} from '../../../tools/downloadAndUnzip';
 import {
   setEnvironment,
   updateEnvironment,
 } from '../../../tools/environmentVariables';
-import {join} from 'path';
 import {Ora} from 'ora';
-import {unzip} from '../../../tools/unzip';
-import {deleteFile} from '../../../tools/deleteFile';
 
 export default {
   label: 'JDK',
@@ -37,17 +35,12 @@ export default {
         'https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_windows-x64_bin.zip';
       const installPath = process.env.LOCALAPPDATA || ''; // The zip is in a folder `jdk-11.02` so it can be unzipped directly there
 
-      loader.start(
-        `Downloading JDK 11 from "${installerUrl}" (this may take a few minutes)`,
-      );
-
-      const installer = await fetchToTemp(installerUrl);
-
-      loader.text = `Installing JDK in "${installPath}"`;
-
-      await unzip(installer, installPath);
-
-      await deleteFile(installer);
+      await downloadAndUnzip({
+        loader,
+        downloadUrl: installerUrl,
+        component: 'JDK',
+        installPath,
+      });
 
       loader.text = 'Updating environment variables';
 

--- a/packages/cli/src/commands/doctor/types.ts
+++ b/packages/cli/src/commands/doctor/types.ts
@@ -1,32 +1,25 @@
 import {Ora} from 'ora';
 
+type NotFound = 'Not Found';
+type AvailableInformation = {
+  version: string;
+  path: string;
+};
+
+type Information = AvailableInformation | NotFound;
+
 export type EnvironmentInfo = {
   System: {
     OS: string;
     CPU: string;
     Memory: string;
-    Shell: {
-      version: string;
-      path: string;
-    };
+    Shell: AvailableInformation;
   };
   Binaries: {
-    Node: {
-      version: string;
-      path: string;
-    };
-    Yarn: {
-      version: string;
-      path: string;
-    };
-    npm: {
-      version: string;
-      path: string;
-    };
-    Watchman: {
-      version: string;
-      path: string;
-    };
+    Node: AvailableInformation;
+    Yarn: AvailableInformation;
+    npm: AvailableInformation;
+    Watchman: AvailableInformation;
   };
   SDKs: {
     'iOS SDK': {
@@ -34,43 +27,24 @@ export type EnvironmentInfo = {
     };
     'Android SDK':
       | {
-          'API Levels': string[] | 'Not Found';
-          'Build Tools': string[] | 'Not Found';
-          'System Images': string[] | 'Not Found';
-          'Android NDK': string | 'Not Found';
+          'API Levels': string[] | NotFound;
+          'Build Tools': string[] | NotFound;
+          'System Images': string[] | NotFound;
+          'Android NDK': string | NotFound;
         }
-      | 'Not Found';
+      | NotFound;
   };
   IDEs: {
     'Android Studio': string;
-    Emacs: {
-      version: string;
-      path: string;
-    };
-    Nano: {
-      version: string;
-      path: string;
-    };
-    VSCode: {
-      version: string;
-      path: string;
-    };
-    Vim: {
-      version: string;
-      path: string;
-    };
-    Xcode: {
-      version: string;
-      path: string;
-    };
+    Emacs: AvailableInformation;
+    Nano: AvailableInformation;
+    VSCode: AvailableInformation;
+    Vim: AvailableInformation;
+    Xcode: AvailableInformation;
   };
   Languages: {
-    Python:
-      | {
-          version: string;
-          path: string;
-        }
-      | 'Not Found';
+    Java: Information;
+    Python: Information;
   };
 };
 
@@ -112,7 +86,7 @@ export type HealthCheckInterface = {
 export type HealthCheckResult = {
   label: string;
   needsToBeFixed: boolean;
-  version?: 'Not Found' | string;
+  version?: NotFound | string;
   versions?: [string] | string;
   versionRange?: string;
   description: string | undefined;

--- a/packages/cli/src/commands/doctor/versionRanges.ts
+++ b/packages/cli/src/commands/doctor/versionRanges.ts
@@ -5,6 +5,7 @@ export default {
   NPM: '>= 4.x',
   WATCHMAN: '4.x',
   PYTHON: '>= 2.x < 3',
+  JAVA: '>= 8',
   // Android
   ANDROID_SDK: '>= 26.x',
   ANDROID_NDK: '>= 19.x',

--- a/packages/cli/src/tools/deleteFile.ts
+++ b/packages/cli/src/tools/deleteFile.ts
@@ -1,0 +1,4 @@
+import {unlink} from 'fs';
+import {promisify} from 'util';
+
+export const deleteFile = promisify(unlink);

--- a/packages/cli/src/tools/downloadAndUnzip.ts
+++ b/packages/cli/src/tools/downloadAndUnzip.ts
@@ -26,7 +26,9 @@ export const downloadAndUnzip = async ({
   const installer = await fetchToTemp(downloadUrl);
 
   loader.text = `Installing ${component} in "${installPath}"`;
-  await unzip(installer, installPath);
-
-  await deleteFile(installer);
+  try {
+    await unzip(installer, installPath);
+  } finally {
+    await deleteFile(installer);
+  }
 };

--- a/packages/cli/src/tools/downloadAndUnzip.ts
+++ b/packages/cli/src/tools/downloadAndUnzip.ts
@@ -1,0 +1,32 @@
+import {fetchToTemp} from '@react-native-community/cli-tools';
+
+import * as ora from 'ora';
+import {unzip} from './unzip';
+import {deleteFile} from './deleteFile';
+
+/**
+ * Downloads `downloadUrl` and unzips the contents to `installPath` while
+ * updating the message of `loader` at each step.
+ */
+export const downloadAndUnzip = async ({
+  loader,
+  downloadUrl,
+  component,
+  installPath,
+}: {
+  loader: ora.Ora;
+  component: string;
+  downloadUrl: string;
+  installPath: string;
+}) => {
+  loader.start(
+    `Downloading ${component} from "${downloadUrl}" (this may take a few minutes)`,
+  );
+
+  const installer = await fetchToTemp(downloadUrl);
+
+  loader.text = `Installing ${component} in "${installPath}"`;
+  await unzip(installer, installPath);
+
+  await deleteFile(installer);
+};

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -22,7 +22,7 @@ async function getEnvironmentInfo(
       Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
       IDEs: ['Xcode', 'Android Studio'],
       Managers: ['CocoaPods'],
-      Languages: ['Python'],
+      Languages: ['Java', 'Python'],
       SDKs: ['iOS SDK', 'Android SDK'],
       npmPackages: ['react', 'react-native', '@react-native-community/cli'],
       npmGlobalPackages: ['*react-native*'],

--- a/packages/cli/src/tools/unzip.ts
+++ b/packages/cli/src/tools/unzip.ts
@@ -1,0 +1,17 @@
+import {createReadStream} from 'fs';
+import * as unzipper from 'unzipper';
+
+/**
+ * Unzips the contents of `source` into the `destination`
+ * using streams to deal with large files.
+ */
+const unzip = async (source: string, destination: string): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    createReadStream(source)
+      .pipe(unzipper.Extract({path: destination}))
+      .on('close', resolve)
+      .on('error', reject);
+  });
+};
+
+export {unzip};

--- a/packages/cli/src/tools/unzip.ts
+++ b/packages/cli/src/tools/unzip.ts
@@ -1,16 +1,23 @@
-import {createReadStream} from 'fs';
-import * as unzipper from 'unzipper';
+const StreamZip = require('node-stream-zip');
 
-/**
- * Unzips the contents of `source` into the `destination`
- * using streams to deal with large files.
- */
-const unzip = async (source: string, destination: string): Promise<void> => {
+const unzip = async (source: string, destination: string) => {
   return new Promise((resolve, reject) => {
-    createReadStream(source)
-      .pipe(unzipper.Extract({path: destination}))
-      .on('close', resolve)
-      .on('error', reject);
+    const zip = new StreamZip({
+      file: source,
+      storeEntries: true,
+    });
+
+    zip.on('ready', () => {
+      zip.extract(null, destination, (err: Error | null) => {
+        zip.close();
+
+        if (err) {
+          return reject(err);
+        }
+
+        resolve();
+      });
+    });
   });
 };
 

--- a/packages/tools/src/fetch.ts
+++ b/packages/tools/src/fetch.ts
@@ -25,7 +25,7 @@ async function unwrapFetchResult(response: Response) {
  * Downloads the given `url` to the OS's temp folder and
  * returns the path to it.
  */
-const fetchToTemp = (url: string) => {
+const fetchToTemp = (url: string): Promise<string> => {
   try {
     return new Promise((resolve, reject) => {
       const fileName = path.basename(url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,6 +2397,13 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/unzipper@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@types/unzipper/-/unzipper-0.10.2.tgz#35c2da714d406b2cd7ada5006e1e206bdd0eb2f4"
+  integrity sha512-VgYoNEyj8xkz9I+RTWD00iB9JVViK/RBteNDjOIV3/kdCUPaskka7xAZfFlIxRwKGSPf77F8yje5bJt2PefofQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/wcwidth@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/wcwidth/-/wcwidth-1.0.0.tgz#a58f4673050f98c46ae8f852340889343b21a1f5"
@@ -3044,7 +3051,7 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-big-integer@^1.6.44:
+big-integer@^1.6.17, big-integer@^1.6.44:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
@@ -3059,6 +3066,14 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+binary@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
+  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
+  dependencies:
+    buffers "~0.1.1"
+    chainsaw "~0.1.0"
+
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -3070,6 +3085,11 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+
+bluebird@~3.4.1:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
+  integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -3258,6 +3278,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-indexof-polyfill@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
+  integrity sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=
+
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -3271,6 +3296,11 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffers@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
+  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -3425,6 +3455,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chainsaw@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
+  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
+  dependencies:
+    traverse ">=0.3.0 <0.4"
 
 chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -5431,6 +5468,16 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
 
+fstream@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
+  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -6011,7 +6058,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7278,6 +7325,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+listenercount@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
+  integrity sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -8034,7 +8086,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+mkdirp@*, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
   integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
@@ -10139,17 +10191,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@2, rimraf@2.x.x, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@2.x.x, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -10341,7 +10393,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4, setimmediate@^1.0.5, setimmediate@~1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -11234,6 +11286,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+"traverse@>=0.3.0 <0.4":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
+
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -11479,6 +11536,22 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+unzipper@^0.10.10:
+  version "0.10.10"
+  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.10.tgz#d82d41fbdfa1f0731123eb11c2cfc028b45d3d42"
+  integrity sha512-wEgtqtrnJ/9zIBsQb8UIxOhAH1eTHfi7D/xvmrUoMEePeI6u24nq1wigazbIFtHt6ANYXdEVTvc8XYNlTurs7A==
+  dependencies:
+    big-integer "^1.6.17"
+    binary "~0.3.0"
+    bluebird "~3.4.1"
+    buffer-indexof-polyfill "~1.0.0"
+    duplexer2 "~0.1.4"
+    fstream "^1.0.12"
+    graceful-fs "^4.2.2"
+    listenercount "~1.0.1"
+    readable-stream "~2.3.6"
+    setimmediate "~1.0.4"
 
 upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,13 +2397,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/unzipper@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@types/unzipper/-/unzipper-0.10.2.tgz#35c2da714d406b2cd7ada5006e1e206bdd0eb2f4"
-  integrity sha512-VgYoNEyj8xkz9I+RTWD00iB9JVViK/RBteNDjOIV3/kdCUPaskka7xAZfFlIxRwKGSPf77F8yje5bJt2PefofQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/wcwidth@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/wcwidth/-/wcwidth-1.0.0.tgz#a58f4673050f98c46ae8f852340889343b21a1f5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3051,7 +3051,7 @@ before-after-hook@^2.0.0:
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.1.0.tgz#b6c03487f44e24200dd30ca5e6a1979c5d2fb635"
   integrity sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==
 
-big-integer@^1.6.17, big-integer@^1.6.44:
+big-integer@^1.6.44:
   version "1.6.48"
   resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
   integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
@@ -3066,14 +3066,6 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
-binary@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/binary/-/binary-0.3.0.tgz#9f60553bc5ce8c3386f3b553cff47462adecaa79"
-  integrity sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=
-  dependencies:
-    buffers "~0.1.1"
-    chainsaw "~0.1.0"
-
 bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -3085,11 +3077,6 @@ bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
-
-bluebird@~3.4.1:
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
-  integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -3278,11 +3265,6 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
-buffer-indexof-polyfill@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
-  integrity sha1-qfuAbOgUXVQoUQznLyeLs2OmOL8=
-
 buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
@@ -3296,11 +3278,6 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-buffers@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
-  integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -3455,13 +3432,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-chainsaw@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/chainsaw/-/chainsaw-0.1.0.tgz#5eab50b28afe58074d0d58291388828b5e5fbc98"
-  integrity sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=
-  dependencies:
-    traverse ">=0.3.0 <0.4"
 
 chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -5468,16 +5438,6 @@ fsevents@^2.1.2, fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
 
-fstream@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
-  integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
-  dependencies:
-    graceful-fs "^4.1.2"
-    inherits "~2.0.0"
-    mkdirp ">=0.5 0"
-    rimraf "2"
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -6058,7 +6018,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -7325,11 +7285,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-listenercount@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
-  integrity sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=
-
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -8086,7 +8041,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
+mkdirp@*, mkdirp@0.x.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
   integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
@@ -8313,6 +8268,11 @@ node-releases@^1.1.52:
   integrity sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==
   dependencies:
     semver "^6.3.0"
+
+node-stream-zip@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.9.1.tgz#66d210204da7c60e2d6d685eb21a11d016981fd0"
+  integrity sha512-7/Xs9gkuYF0WBimz5OrSc6UVKLDTxvBG2yLGtEK8PSx94d86o/6iQLvIe/140ATz35JDqHKWIxh3GcA3u5hB0w==
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -10191,17 +10151,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@2, rimraf@2.x.x, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@2.x.x, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -10393,7 +10353,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5, setimmediate@~1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -11286,11 +11246,6 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-"traverse@>=0.3.0 <0.4":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
-  integrity sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=
-
 trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
@@ -11536,22 +11491,6 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
-
-unzipper@^0.10.10:
-  version "0.10.10"
-  resolved "https://registry.yarnpkg.com/unzipper/-/unzipper-0.10.10.tgz#d82d41fbdfa1f0731123eb11c2cfc028b45d3d42"
-  integrity sha512-wEgtqtrnJ/9zIBsQb8UIxOhAH1eTHfi7D/xvmrUoMEePeI6u24nq1wigazbIFtHt6ANYXdEVTvc8XYNlTurs7A==
-  dependencies:
-    big-integer "^1.6.17"
-    binary "~0.3.0"
-    bluebird "~3.4.1"
-    buffer-indexof-polyfill "~1.0.0"
-    duplexer2 "~0.1.4"
-    fstream "^1.0.12"
-    graceful-fs "^4.2.2"
-    listenercount "~1.0.1"
-    readable-stream "~2.3.6"
-    setimmediate "~1.0.4"
 
 upath@^1.1.1, upath@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Summary:
---------

Install JDK@11 on Windows if missing. I went with 11 because from my tests it was the latest one that was working with Gradle. After it they were all giving me problems.
The documentation mentions that is has to be 8 or later and with that version local installation for the user is painful as there is not a .zip available.

I tried to install it on mac as well but all the options I found in homebrew prompted for a password 😔

You can see it in action (+ python) in this video:

[![YouTube vide to JDK installation](https://user-images.githubusercontent.com/606594/77324576-30740d80-6cd4-11ea-84b3-806f0489e0da.png)](https://youtu.be/tRtBRMxLh6s)


Fix #980