### PR TITLE
feat: allow selection of iOS sim with `--udid`

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator.test.ts
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/findMatchingSimulator.test.ts
@@ -17,7 +17,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -51,7 +51,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6',
+        {simulator: 'iPhone 6'},
       ),
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
@@ -66,7 +66,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 12.1': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-1': [
               {
                 state: 'Shutdown',
                 isAvailable: true,
@@ -103,7 +103,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6',
+        {simulator: 'iPhone 6'},
       ),
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
@@ -118,7 +118,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -152,7 +152,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6',
+        {simulator: 'iPhone 6'},
       ),
     ).toEqual(null);
   });
@@ -162,7 +162,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -211,7 +211,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -243,7 +243,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 10.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-10-0': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -286,7 +286,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -335,7 +335,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -369,7 +369,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6',
+        {simulator: 'iPhone 6'},
       ),
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
@@ -384,7 +384,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -416,7 +416,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 10.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-10-0': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -459,7 +459,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -491,7 +491,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 10.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-10-0': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -519,7 +519,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6s',
+        {simulator: 'iPhone 6s'},
       ),
     ).toEqual({
       udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
@@ -534,7 +534,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -566,7 +566,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 10.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-10-0': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -594,7 +594,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6s (10.0)',
+        {simulator: 'iPhone 6s (10.0)'},
       ),
     ).toEqual({
       udid: 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22',
@@ -609,7 +609,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 9.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-9-2': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -641,7 +641,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 10.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-10-0': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -663,7 +663,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPhone 6s (10.0)',
+        {simulator: 'iPhone 6s (10.0)'},
       ),
     ).toEqual(null);
   });
@@ -673,7 +673,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 12.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-0': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -711,7 +711,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
               },
             ],
-            'iOS 12.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-2': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -733,7 +733,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPad Pro (9.7-inch)',
+        {simulator: 'iPad Pro (9.7-inch)'},
       ),
     ).toEqual({
       udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
@@ -748,7 +748,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 12.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-0': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -780,7 +780,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 12.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-2': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -808,7 +808,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPad Pro (9.7-inch) (12.2)',
+        {simulator: 'iPad Pro (9.7-inch) (12.2)'},
       ),
     ).toEqual({
       udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
@@ -823,7 +823,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'iOS 12.0': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-0': [
               {
                 state: 'Shutdown',
                 availability: '(unavailable, runtime profile not found)',
@@ -855,7 +855,7 @@ describe('findMatchingSimulator', () => {
                 udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
               },
             ],
-            'iOS 12.2': [
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-2': [
               {
                 state: 'Shutdown',
                 availability: '(available)',
@@ -883,7 +883,7 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'iPad Pro (9.7-inch) (12.0)',
+        {simulator: 'iPad Pro (9.7-inch) (12.0)'},
       ),
     ).toEqual(null);
   });
@@ -893,7 +893,7 @@ describe('findMatchingSimulator', () => {
       findMatchingSimulator(
         {
           devices: {
-            'tvOS 11.2': [
+            'com.apple.CoreSimulator.SimRuntime.tvOS-11-2': [
               {
                 state: 'Booted',
                 availability: '(available)',
@@ -915,13 +915,65 @@ describe('findMatchingSimulator', () => {
             ],
           },
         },
-        'Apple TV',
+        {simulator: 'Apple TV'},
       ),
     ).toEqual({
       udid: '816C30EA-38EA-41AC-BFDA-96FB632D522E',
       name: 'Apple TV',
       booted: true,
       version: 'tvOS 11.2',
+    });
+  });
+
+  it('should return a simulator by UDID', () => {
+    expect(
+      findMatchingSimulator(
+        {
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.iOS-12-1': [
+              {
+                state: 'Shutdown',
+                isAvailable: true,
+                name: 'iPhone 6s',
+                udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: true,
+                name: 'iPhone 6',
+                udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: true,
+                name: 'iPhone XS Max',
+                udid: 'B9B5E161-416B-43C4-A78F-729CB96CC8C6',
+                availabilityError: '',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: true,
+                name: 'iPad Air',
+                udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
+                availabilityError: '',
+              },
+              {
+                state: 'Shutdown',
+                isAvailable: true,
+                name: 'iPad (5th generation)',
+                udid: '9564ABEE-9EC2-4B4A-B443-D3710929A45A',
+                availabilityError: '',
+              },
+            ],
+          },
+        },
+        {udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C'},
+      ),
+    ).toEqual({
+      udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
+      name: 'iPhone 6',
+      booted: false,
+      version: 'iOS 12.1',
     });
   });
 });

--- a/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
@@ -17,6 +17,7 @@ describe('parseIOSDevicesList', () => {
         'Known Devices:',
         'Maxs MacBook Pro [11111111-1111-1111-1111-111111111111]',
         "Max's iPhone (9.2) [00008030-000D19512210802E]",
+        'other-iphone (9.2) [72a186ccfd93472a186ccfd934]',
         'iPad 2 (9.3) [07538CE4-675B-4EDA-90F2-3DD3CD93309D] (Simulator)',
         'iPad Air (9.3) [0745F6D1-6DC5-4427-B9A6-6FBA327ED65A] (Simulator)',
         'iPhone 6s (9.3) [3DBE4ECF-9A86-469E-921B-EE0F9C9AB8F4] (Simulator)',
@@ -39,6 +40,12 @@ describe('parseIOSDevicesList', () => {
         udid: '00008030-000D19512210802E',
         version: '9.2',
         type: 'device',
+      },
+      {
+        name: 'other-iphone',
+        type: 'device',
+        udid: '72a186ccfd93472a186ccfd934',
+        version: '9.2',
       },
       {
         name: 'iPad 2',

--- a/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
@@ -30,28 +30,33 @@ describe('parseIOSDevicesList', () => {
 
     expect(devices).toEqual([
       {
+        name: 'Maxs MacBook Pro',
+        udid: '11111111-1111-1111-1111-111111111111',
+        type: 'catalyst',
+      },
+      {
         name: "Max's iPhone",
         udid: '00008030-000D19512210802E',
         version: '9.2',
-        isSimulator: false,
+        type: 'device',
       },
       {
         name: 'iPad 2',
         udid: '07538CE4-675B-4EDA-90F2-3DD3CD93309D',
         version: '9.3',
-        isSimulator: true,
+        type: 'simulator',
       },
       {
         name: 'iPad Air',
         udid: '0745F6D1-6DC5-4427-B9A6-6FBA327ED65A',
         version: '9.3',
-        isSimulator: true,
+        type: 'simulator',
       },
       {
         name: 'iPhone 6s',
         udid: '3DBE4ECF-9A86-469E-921B-EE0F9C9AB8F4',
         version: '9.3',
-        isSimulator: true,
+        type: 'simulator',
       },
     ]);
   });

--- a/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
+++ b/packages/platform-ios/src/commands/runIOS/__tests__/parseIOSDevicesList.test.ts
@@ -16,7 +16,7 @@ describe('parseIOSDevicesList', () => {
       [
         'Known Devices:',
         'Maxs MacBook Pro [11111111-1111-1111-1111-111111111111]',
-        "Max's iPhone (9.2) [11111111111111111111aaaaaaaaaaaaaaaaaaaa]",
+        "Max's iPhone (9.2) [00008030-000D19512210802E]",
         'iPad 2 (9.3) [07538CE4-675B-4EDA-90F2-3DD3CD93309D] (Simulator)',
         'iPad Air (9.3) [0745F6D1-6DC5-4427-B9A6-6FBA327ED65A] (Simulator)',
         'iPhone 6s (9.3) [3DBE4ECF-9A86-469E-921B-EE0F9C9AB8F4] (Simulator)',
@@ -30,13 +30,28 @@ describe('parseIOSDevicesList', () => {
 
     expect(devices).toEqual([
       {
-        name: 'Maxs MacBook Pro',
-        udid: '11111111-1111-1111-1111-111111111111',
+        name: "Max's iPhone",
+        udid: '00008030-000D19512210802E',
+        version: '9.2',
+        isSimulator: false,
       },
       {
-        name: "Max's iPhone",
-        udid: '11111111111111111111aaaaaaaaaaaaaaaaaaaa',
-        version: '9.2',
+        name: 'iPad 2',
+        udid: '07538CE4-675B-4EDA-90F2-3DD3CD93309D',
+        version: '9.3',
+        isSimulator: true,
+      },
+      {
+        name: 'iPad Air',
+        udid: '0745F6D1-6DC5-4427-B9A6-6FBA327ED65A',
+        version: '9.3',
+        isSimulator: true,
+      },
+      {
+        name: 'iPhone 6s',
+        udid: '3DBE4ECF-9A86-469E-921B-EE0F9C9AB8F4',
+        version: '9.3',
+        isSimulator: true,
       },
     ]);
   });

--- a/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
+++ b/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
@@ -8,36 +8,24 @@
 import {Device} from '../../types';
 
 /**
- * Parses the output of `xcrun simctl list devices` command
+ * Parses the output of `xcrun instruments -s` command
  * Expected text looks roughly like this:
+ *
  * Known Devices:
- * this-mac-device [ID]
- * Some Apple Simulator (Version) [ID]
+ * this-mac-device [UDID]
+ * A Physical Device (OS Version) [UDID]
+ * A Simulator Device (OS Version) [UDID] (Simulator)
  */
 function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];
 
-  text.split('\n').forEach((line, index) => {
-    const device = line.match(/(.*?) \((.*?)\) \[(.*?)\]/);
-    const noSimulator = line.match(/(.*?) \((.*?)\) \[(.*?)\] \((.*?)\)/);
-
-    if (index === 1) {
-      const myMac = line.match(/(.*?) \[(.*?)\]/);
-      if (myMac) {
-        const name = myMac[1];
-        const udid = myMac[2];
-        devices.push({
-          udid,
-          name,
-        });
-      }
-    }
-
-    if (device != null && noSimulator == null) {
-      const name = device[1];
-      const version = device[2];
-      const udid = device[3];
-      devices.push({udid, name, version});
+  text.split('\n').forEach(line => {
+    const device = line.match(
+      /(.*?) \(([0-9\.]+)\) \[([0-9A-F-]+)\]( \(Simulator\))?/,
+    );
+    if (device) {
+      const {[1]: name, [2]: version, [3]: udid, [4]: isSimulator} = device;
+      devices.push({name, version, udid, isSimulator: !!isSimulator});
     }
   });
 

--- a/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
+++ b/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
@@ -26,7 +26,7 @@ function parseIOSDevicesList(text: string): Array<Device> {
 
   text.split('\n').forEach(line => {
     const device = line.match(
-      /(.*?) (\(([0-9\.]+)\) )?\[([0-9A-F-]+)\]( \(Simulator\))?/,
+      /(.*?) (\(([0-9\.]+)\) )?\[([0-9A-F-]+)\]( \(Simulator\))?/i,
     );
     if (device) {
       const [, name, , version, udid, isSimulator] = device;

--- a/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
+++ b/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
@@ -8,24 +8,36 @@
 import {Device} from '../../types';
 
 /**
- * Parses the output of `xcrun instruments -s` command
+ * Parses the output of the `xcrun instruments -s` command and returns metadata
+ * about available iOS simulators and physical devices, as well as host Mac for
+ * Catalyst purposes.
+ *
  * Expected text looks roughly like this:
  *
+ * ```
  * Known Devices:
  * this-mac-device [UDID]
  * A Physical Device (OS Version) [UDID]
  * A Simulator Device (OS Version) [UDID] (Simulator)
+ * ```
  */
 function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];
 
   text.split('\n').forEach(line => {
     const device = line.match(
-      /(.*?) \(([0-9\.]+)\) \[([0-9A-F-]+)\]( \(Simulator\))?/,
+      /(.*?) (\(([0-9\.]+)\) )?\[([0-9A-F-]+)\]( \(Simulator\))?/,
     );
     if (device) {
-      const {[1]: name, [2]: version, [3]: udid, [4]: isSimulator} = device;
-      devices.push({name, version, udid, isSimulator: !!isSimulator});
+      const [, name, , version, udid, isSimulator] = device;
+      const metadata: Device = {name, udid};
+      if (version) {
+        metadata.version = version;
+        metadata.type = isSimulator ? 'simulator' : 'device';
+      } else {
+        metadata.type = 'catalyst';
+      }
+      devices.push(metadata);
     }
   });
 

--- a/packages/platform-ios/src/types.ts
+++ b/packages/platform-ios/src/types.ts
@@ -6,4 +6,6 @@ export interface Device {
   udid: string;
   version?: string;
   availabilityError?: string;
+  isSimulator?: boolean;
+  booted?: boolean;
 }

--- a/packages/platform-ios/src/types.ts
+++ b/packages/platform-ios/src/types.ts
@@ -6,6 +6,6 @@ export interface Device {
   udid: string;
   version?: string;
   availabilityError?: string;
-  isSimulator?: boolean;
+  type?: 'simulator' | 'device' | 'catalyst';
   booted?: boolean;
 }


### PR DESCRIPTION
Summary:
---------

This makes it possible to be very specific about what simulator to use in the same way you’d interact with tooling such as `simctl`.

Fixes https://github.com/react-native-community/cli/issues/1078

Test Plan:
----------

Given a device list like:

```
/t/RNTestProject » xcrun instruments -s
Known Devices:
Eloy’s iMac [E163381F-C94E-5B5E-922E-DBB59B685FA6]
Eloy’s iPhone (13.3.1) [00008030-000D19512210802E]
iPhone 11 (13.3) [60E7F277-DC13-46B8-ADFB-7C5C9BC01274] (Simulator)
iPhone 8 (12.4) [0F518318-4C9B-49BA-89B9-1D0E325681BB] (Simulator)
```

## Simulator

### Default

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios
info Found Xcode workspace "RNTestProject.xcworkspace"
info Launching iPhone 11 (iOS 13.3)
info Building (using "xcodebuild -workspace RNTestProject.xcworkspace -configuration Debug -scheme RNTestProject -destination id=60E7F277-DC13-46B8-ADFB-7C5C9BC01274")
```

### By UDID

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios --udid 0F518318-4C9B-49BA-89B9-1D0E325681BB
info Found Xcode workspace "RNTestProject.xcworkspace"
info Launching iPhone 8 (iOS 12.4)
info Building (using "xcodebuild -workspace RNTestProject.xcworkspace -configuration Debug -scheme RNTestProject -destination id=0F518318-4C9B-49BA-89B9-1D0E325681BB")
```

## Device

### Default without iOS device connected

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios --device
info Found Xcode workspace "RN062rc3.xcworkspace"
error No iOS devices connected.
```

### Default with iOS device connected

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios --device
info Found Xcode workspace "RNTestProject.xcworkspace"
info Using first available device named "Eloy’s iPhone" due to lack of name supplied.
info Building (using "xcodebuild -workspace RNTestProject.xcworkspace -configuration Debug -scheme RNTestProject -destination id=00008030-000D19512210802E")
```

### By UDID

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios --udid 00008030-000D19512210802E
info Found Xcode workspace "RNTestProject.xcworkspace"
info Building (using "xcodebuild -workspace RNTestProject.xcworkspace -configuration Debug -scheme RNTestProject -destination id=00008030-000D19512210802E")
```

## Catalyst

### By name

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios --device 'Eloy’s iMac'
info Found Xcode workspace "RN062rc3.xcworkspace"
info Building (using "xcodebuild -workspace RN062rc3.xcworkspace -configuration Debug -scheme RN062rc3 -destination id=E163381F-C94E-5B5E-922E-DBB59B685FA6")
```

### By UDID

```
/t/RNTestProject » ./node_modules/.bin/react-native run-ios --udid E163381F-C94E-5B5E-922E-DBB59B685FA6
info Found Xcode workspace "RN062rc3.xcworkspace"
info Building (using "xcodebuild -workspace RN062rc3.xcworkspace -configuration Debug -scheme RN062rc3 -destination id=E163381F-C94E-5B5E-922E-DBB59B685FA6")
```