### PR TITLE
chore: remove >=0.60.0-rc.0 restriction for init

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import fs from 'fs-extra';
 import minimist from 'minimist';
 import ora from 'ora';
-import semver from 'semver';
 import mkdirp from 'mkdirp';
 import {validateProjectName} from './validate';
 import DirectoryAlreadyExistsError from './errors/DirectoryAlreadyExistsError';
@@ -172,16 +171,6 @@ async function createProject(
   options: Options,
 ) {
   const templateName = options.template || `react-native@${version}`;
-
-  if (
-    version !== DEFAULT_VERSION &&
-    semver.valid(version) &&
-    !semver.gte(version, '0.60.0-rc.0')
-  ) {
-    throw new Error(
-      'Cannot use React Native CLI to initialize project with version lower than 0.60.0.',
-    );
-  }
 
   return createFromTemplate({
     projectName,


### PR DESCRIPTION
Summary:
---------

We're way past 0.60 now, so this check is not necessary anymore. It also prevents from using nightlies, which are tagged with `0.0.0-commithash`.

Test Plan:
----------

In case someone tries initing older versions of RN, which is still not possible, they'll see this error anyway:

![image](https://user-images.githubusercontent.com/5106466/77529412-d750d900-6e8f-11ea-9786-ffbd16f075ae.png)

cc @alloy @pvinis
