### PR TITLE
fix(android): Looking for `react-native/cli` sometimes returns `undefined`

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -217,7 +217,7 @@ class ReactNativeModules {
      *
      * @todo: `fastlane` has been reported to not work too.
      */
-    def cliResolveScript = "console.log(require('react-native/cli').bin);"
+    def cliResolveScript = "console.log(require.resolve('react-native/cli'));"
     String[] nodeCommand = ["node", "-e", cliResolveScript]
     def cliPath = this.getCommandOutput(nodeCommand, this.root)
 


### PR DESCRIPTION
Summary:
---------

`require('react-native/cli').bin` returns `undefined` on certain setups:

```
% node -e "console.log(require('react-native/cli').bin);"
undefined

% node -e "console.log(require.resolve('react-native/cli'));"
/~/node_modules/react-native/cli.js
```

Test Plan:
----------

All current tests should still pass.