### PR TITLE
feat: add CocoaPods to `info` command

### DIFF
--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -21,6 +21,7 @@ async function getEnvironmentInfo(
       System: ['OS', 'CPU', 'Memory', 'Shell'],
       Binaries: ['Node', 'Yarn', 'npm', 'Watchman'],
       IDEs: ['Xcode', 'Android Studio'],
+      Managers: ['CocoaPods'],
       Languages: ['Python'],
       SDKs: ['iOS SDK', 'Android SDK'],
       npmPackages: ['react', 'react-native', '@react-native-community/cli'],


### PR DESCRIPTION
Summary:
---------

We are relying quite a lot on CocoaPods so it makes sense to have it when running `react-native info`, will be useful for bug reports.


Test Plan:
----------

1. Run `react-native info`;
1. Be happy 😄