### PR TITLE
fix: yarn/npm init before install template (#1603)

### DIFF
--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -14,12 +14,19 @@ export type TemplateConfig = {
   titlePlaceholder?: string;
 };
 
-export function installTemplatePackage(
+export async function installTemplatePackage(
   templateName: string,
   root: string,
   npm?: boolean,
 ) {
   logger.debug(`Installing template from ${templateName}`);
+
+  await PackageManager.init({
+    preferYarn: !npm,
+    silent: true,
+    root,
+  });
+
   return PackageManager.install([templateName], {
     preferYarn: !npm,
     silent: true,

--- a/packages/cli/src/tools/packageManager.ts
+++ b/packages/cli/src/tools/packageManager.ts
@@ -10,12 +10,14 @@ type Options = {
 
 const packageManagers = {
   yarn: {
+    init: ['init', '-y'],
     install: ['add'],
     installDev: ['add', '-D'],
     uninstall: ['remove'],
     installAll: ['install'],
   },
   npm: {
+    init: ['init', '-y'],
     install: ['install', '--save', '--save-exact'],
     installDev: ['install', '--save-dev', '--save-exact'],
     uninstall: ['uninstall', '--save'],
@@ -25,7 +27,7 @@ const packageManagers = {
 
 function configurePackageManager(
   packageNames: Array<string>,
-  action: 'install' | 'installDev' | 'installAll' | 'uninstall',
+  action: 'init' | 'install' | 'installDev' | 'installAll' | 'uninstall',
   options: Options,
 ) {
   const pm = shouldUseYarn(options) ? 'yarn' : 'npm';
@@ -51,6 +53,10 @@ function shouldUseYarn(options: Options) {
   }
 
   return isProjectUsingYarn(options.root) && getYarnVersionIfAvailable();
+}
+
+export function init(options: Options) {
+  return configurePackageManager([], 'init', options);
 }
 
 export function install(packageNames: Array<string>, options: Options) {


### PR DESCRIPTION
Summary:
---------
When creating a new project with `npx react-native init MyApp`, the template installation step fails because there is no `package.json` inside the temp folder. This PR fixes that by running `yarn/npm init -y` before the template installation.

Fixes #1075 

Test Plan:
----------
CI passes