### PR TITLE
fix: android config returns incorrect paths

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -102,6 +102,8 @@ type ProjectConfigAndroidT = {
   assetsPath: string;
   mainFilePath: string;
   packageName: string;
+  packageFolder: string;
+  appName: string;
 };
 ```
 
@@ -133,6 +135,8 @@ type DependencyConfigAndroidT = {
   folder: string;
   packageImportPath: string;
   packageInstance: string;
+  manifestPath: string;
+  packageName: string;
 };
 ```
 

--- a/packages/platform-android/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/platform-android/src/config/__tests__/getProjectConfig.test.ts
@@ -99,4 +99,14 @@ describe('android::getProjectConfig', () => {
 
     expect(getProjectConfig(folder, userConfig)).toBeNull();
   });
+
+  it('should correctly resolve mainFilePath', () => {
+    const userConfig = {};
+    const folder = '/nested';
+
+    const config = getProjectConfig(folder, userConfig);
+    expect(config.mainFilePath).toEqual(
+      '/nested/android/app/src/main/java/com/some/example/MainApplication.java',
+    );
+  });
 });

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -60,23 +60,23 @@ export function projectConfig(
   const mainFilePath = path.join(
     sourceDir,
     userConfig.mainFilePath ||
-      `src/main/java/${packageFolder}/MainApplication.java`,
+      path.join(appName, `src/main/java/${packageFolder}/MainApplication.java`),
   );
 
   const stringsPath = path.join(
     sourceDir,
-    userConfig.stringsPath || 'src/main/res/values/strings.xml',
+    userConfig.stringsPath ||
+      path.join(appName, '/src/main/res/values/strings.xml'),
   );
 
   const settingsGradlePath = path.join(
-    root,
-    'android',
+    sourceDir,
     userConfig.settingsGradlePath || 'settings.gradle',
   );
 
   const assetsPath = path.join(
     sourceDir,
-    userConfig.assetsPath || 'src/main/assets',
+    userConfig.assetsPath || path.join(appName, '/src/main/assets'),
   );
 
   const buildGradlePath = path.join(
@@ -95,7 +95,7 @@ export function projectConfig(
     assetsPath,
     mainFilePath,
     packageName,
-    packageFolder: '',
+    packageFolder,
     appName,
   };
 }


### PR DESCRIPTION
Summary:
---------

After #1029 the Android config was not correctly resolving the default values for `stringsPath`, `assetsPath` and `mainFilePath`. It was also not returning a value for `packageFolder`. This PR also updates the Android config typedef in the docs.


Test Plan:
----------

Added jest test. Manually linked into existing project and verified that `npx react-native config` was returning the correct values.