### PR TITLE
Fix: allow Hermes Debugger to connect from Flipper

### DIFF
--- a/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.ts
@@ -13,7 +13,7 @@ export default function getSecurityHeadersMiddleware(
 ) {
   // Block any cross origin request.
   if (
-    typeof req.headers.origin === "string" &&
+    typeof req.headers.origin === 'string' &&
     !req.headers.origin.match(/^https?:\/\/localhost:/)
   ) {
     next(

--- a/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.ts
@@ -11,12 +11,9 @@ export default function getSecurityHeadersMiddleware(
   res: http.ServerResponse,
   next: (err?: any) => void,
 ) {
-  // @ts-ignore Property 'client' does not exist on type 'IncomingMessage', verify
-  const address = req.client.server.address();
-
   // Block any cross origin request.
   if (
-    req.headers.origin &&
+    typeof req.headers.origin === "string" &&
     !req.headers.origin.match(/^https?:\/\/localhost:/)
   ) {
     next(

--- a/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getSecurityHeadersMiddleware.ts
@@ -17,7 +17,7 @@ export default function getSecurityHeadersMiddleware(
   // Block any cross origin request.
   if (
     req.headers.origin &&
-    req.headers.origin !== `http://localhost:${address.port}`
+    !req.headers.origin.match(/^https?:\/\/localhost:/)
   ) {
     next(
       new Error(


### PR DESCRIPTION
Summary:
---------

This change reflects D20526486 by @rickhanlonii  at Facebook: when Running Hermes Debugger from inside Flipper, the origin is localhost, but not the metro port. This fixes https://github.com/facebook/flipper/issues/660#issuecomment-606239984

Test Plan:
----------

* Init fresh project with React Native
* Enable Hermes
* Open Flipper, start the Hermes Debugger. This will generate the error in the metro logs: "Error: Unauthorized request from http://localhost:3000. This may happen because of a conflicting browser extension. Please try to disable it and try again."
* After this change (tested by directly editing in node_modules) and restart metro, the debugger does connect:

![Screen Shot 2020-03-31 at 11 16 51](https://user-images.githubusercontent.com/1820292/78015328-2cce2f80-7341-11ea-92cc-4e2eda4ac97a.png)

