### PR TITLE
fix: don't use appIdSuffix to generate run task

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -52,7 +52,7 @@ async function runOnAllDevices(
 
   try {
     const tasks = args.tasks || [
-      'install' + toPascalCase(args.appIdSuffix) + toPascalCase(args.variant),
+      'install' + toPascalCase(args.variant),
     ];
     const gradleArgs = getTaskNames(
       args.appFolder || androidProject.appName,

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -51,9 +51,7 @@ async function runOnAllDevices(
   }
 
   try {
-    const tasks = args.tasks || [
-      'install' + toPascalCase(args.variant),
-    ];
+    const tasks = args.tasks || ['install' + toPascalCase(args.variant)];
     const gradleArgs = getTaskNames(
       args.appFolder || androidProject.appName,
       tasks,


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
Ref. discussion in #1085 

Upgrade to CLI v4.4 breaks normal usage of `--appIdSuffix`. Bug was introduced with https://github.com/react-native-community/cli/commit/19ac71f02c0ececa669afb26dce2cb02f0de23f6#diff-b668aefc66b33ed6e984d3467db0abc1R54 where `appIdSuffix` is concatenated to `variant` in order to generate the run task name.

The suffix should probably only be used to launch the correct package, and not for deciding what to build. If the user needs to specify some build type + flavor, the best thing is to put the full variant name in `--variant`.


Test Plan:
----------

1. Create a new React Native project
2. Add an `applicationIdSuffix` to the `debug` buildType in `android/app/build.gradle`:
```gradle
    buildTypes {
        debug {
            applicationIdSuffix ".debug"
            signingConfig signingConfigs.debug
        }
    }
```
3. Run `npx react-native run-android --appIdSuffix debug` to verify that just `appIdSuffix` works
4. Add a product flavor in `android/app/build.gradle`:
```gradle
    flavorDimensions "version"
    productFlavors {
        demo {
            dimension "version"
            applicationIdSuffix ".demo"
        }
    }
```
5. Run `npx react-native run-android --appIdSuffix demo.debug --variant demoDebug` to verify that variant and appIdSuffix works.