### PR TITLE
fix: split output by EOL

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import execa from 'execa';
 import Adb from './adb';
 
@@ -8,7 +9,7 @@ const emulatorCommand = process.env.ANDROID_HOME
 const getEmulators = () => {
   try {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
-    return emulatorsOutput.split('\n').filter(name => name !== '');
+    return emulatorsOutput.split(os.EOL).filter(name => name !== '');
   } catch {
     return [];
   }


### PR DESCRIPTION
Summary:
---------

Windows uses different `EOL` when `UNIX` systems. We can fix this by using node API: https://nodejs.org/api/os.html#os_os_eol.

Fixes: https://github.com/react-native-community/cli/issues/1084
