### PR TITLE
fix: Use correct terminal on linux systems

### DIFF
--- a/packages/tools/src/getDefaultUserTerminal.ts
+++ b/packages/tools/src/getDefaultUserTerminal.ts
@@ -1,4 +1,17 @@
-const getDefaultUserTerminal = (): string | undefined =>
-  process.env.REACT_TERMINAL || process.env.TERM_PROGRAM;
+import os from 'os';
+
+const getDefaultUserTerminal = (): string | undefined => {
+  const {REACT_TERMINAL, TERM_PROGRAM, TERM} = process.env;
+
+  if (REACT_TERMINAL) {
+    return REACT_TERMINAL;
+  }
+
+  if (os.platform() === 'darwin') {
+    return TERM_PROGRAM;
+  }
+
+  return TERM;
+};
 
 export default getDefaultUserTerminal;


### PR DESCRIPTION
Summary:
---------

User correct `env` variable for opening new terminal on `linux`.

EDIT: This assumes that `linux` users have their `TERM` env variable exported correctly (I think this is the only reliable way to tell what terminals are used on linux systems). On my ArchLinux it was exported with value `xterm-256color` (it should be just `xterm`).

Test Plan:
----------

Tested on ArchLinux

