### PR TITLE
feat: return config from the Ruby function

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -103,6 +103,8 @@ def use_native_modules!(config = nil)
     pods = found_pods.map { |p| p.name }.sort.to_sentence
     Pod::UI.puts "Detected React Native module #{"pod".pluralize(found_pods.size)} for #{pods}"
   end
+  
+  config
 end
 
 # You can run the tests for this file by running:


### PR DESCRIPTION
Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/865. It's not autolinking React Native, but we have a helper function already called `use_react_native!`. This PR enables `use_native_modules!` to return a configuration it used to set things up, so that CocoaPods can actually read `config["reactNativePath"]` rather than a hardcoded one.

See https://github.com/react-native-community/cli/issues/865#issuecomment-601214973 and https://github.com/react-native-community/cli/issues/865#issuecomment-601272596