### PR TITLE
feat: Add new --dev-version option to Init

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -26,28 +26,6 @@ const customTemplateCopiedFiles = [
   'yarn.lock',
 ];
 
-// Files expected in the --dev-version tests
-const devVersionFiles = [
-  '.buckconfig',
-  '.eslintrc.js',
-  '.flowconfig',
-  '.gitattributes',
-  '.gitignore',
-  '.prettierrc.js',
-  '.watchmanconfig',
-  'App.js',
-  '__tests__',
-  'android',
-  'app.json',
-  'babel.config.js',
-  'index.js',
-  'ios',
-  'metro.config.js',
-  'node_modules',
-  'package.json',
-  'yarn.lock',
-];
-
 beforeEach(() => {
   cleanup(DIR);
   writeFiles(DIR, {});
@@ -144,32 +122,6 @@ test('init skips installation of dependencies with --skip-install', () => {
       file => !['node_modules', 'yarn.lock'].includes(file),
     ),
   );
-});
-
-test('init --dev-version with Git commit', () => {
-  const rnVersion = 'https://github.com/facebook/react-native#4118d79';
-  const {stdout} = runCLI(DIR, [
-    'init',
-    '--dev-version',
-    rnVersion,
-    'TestInit',
-  ]);
-
-  expect(stdout).toContain('Run instructions');
-
-  const packageJson = JSON.parse(
-    fs.readFileSync(path.join(DIR, 'TestInit', 'package.json'), 'utf8'),
-  );
-
-  // make sure that the version of `react-native` was properly updated
-  expect(packageJson.dependencies['react-native']).toEqual(rnVersion);
-
-  // make sure we don't leave garbage
-  expect(fs.readdirSync(DIR)).toEqual(['TestInit']);
-
-  let dirFiles = fs.readdirSync(path.join(DIR, 'TestInit'));
-
-  expect(dirFiles).toEqual(devVersionFiles);
 });
 
 test('init --dev-version with Git commit and --template filepath', () => {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -211,6 +211,10 @@ module.exports = {
 
 Skip dependencies installation
 
+#### `--dev-version [string]`
+
+Replace the version of "react-native" dependency of the template with specified string. Useful for testing react-native or forks from the source.
+
 #### `--npm`
 
 Force use of npm during initialization

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -107,8 +107,11 @@ export function changePlaceholderInTemplate({
     });
 }
 
-export function changeReactNativeVersionInTemplate(newVersion: string) {
-  const packageJsonPath = path.join(process.cwd(), './package.json');
+export function changeReactNativeVersionInTemplate(
+  newVersion: string,
+  projectDirectory: string,
+) {
+  const packageJsonPath = path.join(projectDirectory, './package.json');
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 
   if (!packageJson.dependencies) {

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -106,3 +106,26 @@ export function changePlaceholderInTemplate({
       processDotfiles(filePath);
     });
 }
+
+export function changeReactNativeVersionInTemplate(newVersion: string) {
+  const packageJsonPath = path.join(process.cwd(), './package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+
+  if (!packageJson.dependencies) {
+    packageJson.dependencies = {};
+  }
+
+  const oldVersion = packageJson.dependencies['react-native'] || '{none}';
+
+  logger.debug(
+    `Changing React Native version in template from ${oldVersion} to ${newVersion}`,
+  );
+
+  packageJson.dependencies['react-native'] = newVersion;
+
+  fs.writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify(packageJson, null, 2)}\n`,
+    'utf8',
+  );
+}

--- a/packages/cli/src/commands/init/errors/VersionAndDevVersionSetError.ts
+++ b/packages/cli/src/commands/init/errors/VersionAndDevVersionSetError.ts
@@ -1,0 +1,5 @@
+export default class VersionAndDevVersionSetError extends Error {
+  constructor() {
+    super('Cannot set --version and --dev-version at the same time.');
+  }
+}

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -35,7 +35,7 @@ export default {
     {
       name: '--dev-version [string]',
       description:
-        'Use a development version or fork of React Native. If no --template is provided, this will be used at the template as well.',
+        'Replace the version of "react-native" dependency of the template with specified string. Useful for testing react-native or forks from the source.',
     },
   ],
 };

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -32,5 +32,10 @@ export default {
       name: '--skip-install',
       description: 'Skips dependencies installation step',
     },
+    {
+      name: '--dev-version [string]',
+      description:
+        'Use a development version or fork of React Native. If no --template is provided, this will be used at the template as well.',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -126,7 +126,7 @@ async function createFromTemplate({
     });
 
     if (devVersion) {
-      changeReactNativeVersionInTemplate(devVersion);
+      changeReactNativeVersionInTemplate(devVersion, projectDirectory);
     }
 
     loader.succeed();
@@ -189,9 +189,7 @@ async function createProject(
   options: Options,
 ) {
   const templateName =
-    options.template ||
-    (options.devVersion && `react-native@${options.devVersion}`) ||
-    `react-native@${version}`;
+    options.template || `react-native@${options.devVersion || version}`;
 
   return createFromTemplate({
     projectName,


### PR DESCRIPTION
Summary:
---------

This pull request adds a new `--dev-version` option to the `init` command, which allows users to init a React Native project based off of a development version of React Native, or a fork.

To use it with a development version of React Native, you would be able to do this:

```sh
$ npx react-native init MyProject --verbose --dev-version https://github.com/facebook/react-native#4118d79
```

To use it with a forked version of React Native, e.g. using Microsoft's fork of React Native, you can do this:

```sh
$ npx react-native init MyProject --verbose --dev-version https://github.com/microsoft/react-native#f9df0ae
```

This functionality was added to a new command line flag, rather than overloading `--version`, because the desire is to keep the `--version` flag focused on valid RN versions on NPM. (see: #951)

Test Plan:
----------

Two additional tests were added to `__e2e__/init.test.ts`:

 * `init` with `--dev-version` set to a GitHub URL + a `#` commit
 * `init` with `--dev-version` set to a GitHub URL + a `#` commit, and a `--template` set to a local folder
