### PR TITLE
Allow out of tree platforms to work without custom metro configs

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -40,6 +40,7 @@ At the end, a map of available platforms is passed to the bundler (Metro) to mak
 
 ```ts
 type PlatformConfig<ProjectParams, ProjectConfig, DependencyConfig> = {
+  npmPackageName?: string;
   projectConfig: (string, ProjectParams) => ?ProjectConfig,
   dependencyConfig: (string, ProjectParams) => ?DependencyConfig,
   linkConfig: () => {
@@ -56,6 +57,13 @@ type PlatformConfig<ProjectParams, ProjectConfig, DependencyConfig> = {
   },
 };
 ```
+
+### npmPackageName
+
+Returns the name of the npm package that should be used as the source for react-native JS code for platforms that provide platform specific overrides to core JS files.  This causes the default metro config to redirect imports of react-native to another package based when bundling for that platform.  The package specified should provide a complete react-native implementation for that platform.
+
+If this property is not specified, it is assumed that the code in core `react-native` works for the platform.
+
 
 ### projectConfig
 

--- a/packages/cli-types/src/index.ts
+++ b/packages/cli-types/src/index.ts
@@ -63,6 +63,7 @@ interface PlatformConfig<
   DependencyConfig,
   DependencyParams
 > {
+  npmPackageName?: string;
   projectConfig: (
     projectRoot: string,
     projectParams: ProjectParams | void,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "metro-config": "^0.58.0",
     "metro-core": "^0.58.0",
     "metro-react-native-babel-transformer": "^0.58.0",
+    "metro-resolver": "^0.58.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-stream-zip": "^1.9.1",

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -83,6 +83,7 @@ export const dependencyConfig = t
     platforms: map(
       t.string(),
       t.object({
+        npmPackageName: t.string().optional(),
         dependencyConfig: t.func(),
         projectConfig: t.func(),
         linkConfig: t.func(),
@@ -178,6 +179,7 @@ export const projectConfig = t
     platforms: map(
       t.string(),
       t.object({
+        npmPackageName: t.string().optional(),
         dependencyConfig: t.func(),
         projectConfig: t.func(),
         linkConfig: t.func(),

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -55,28 +55,39 @@ export interface MetroConfig {
  * Default configuration
  */
 export const getDefaultConfig = (ctx: Config): MetroConfig => {
+  const outOfTreePlatforms = Object.keys(ctx.platforms).filter(
+    platform => ctx.platforms[platform].npmPackageName,
+  );
+
   return {
     resolver: {
       resolveRequest:
-        Object.keys(ctx.platforms).filter(
-          platform => ctx.platforms[platform].npmPackageName,
-        ).length === 0
+        outOfTreePlatforms.length === 0
           ? undefined
           : reactNativePlatformResolver(
-              Object.keys(ctx.platforms)
-                .filter(platform => ctx.platforms[platform].npmPackageName)
-                .reduce<{[platform: string]: string}>((result, platform) => {
+              outOfTreePlatforms.reduce<{[platform: string]: string}>(
+                (result, platform) => {
                   result[platform] = ctx.platforms[platform].npmPackageName!;
                   return result;
-                }, {}),
+                },
+                {},
+              ),
             ),
       resolverMainFields: ['react-native', 'browser', 'main'],
       platforms: [...Object.keys(ctx.platforms), 'native'],
     },
     serializer: {
+      // We can include multiple copies of InitializeCore here because metro will
+      // only add ones that are already part of the bundle
       getModulesRunBeforeMainModule: () => [
         require.resolve(
           path.join(ctx.reactNativePath, 'Libraries/Core/InitializeCore'),
+        ),
+        ...outOfTreePlatforms.map(platform =>
+          require.resolve(
+            `${ctx.platforms[platform]
+              .npmPackageName!}/Libraries/Core/InitializeCore`,
+          ),
         ),
       ],
       getPolyfills: () =>

--- a/packages/cli/src/tools/metroPlatformResolver.ts
+++ b/packages/cli/src/tools/metroPlatformResolver.ts
@@ -1,0 +1,49 @@
+/**
+ * This is an implementation of a metro resolveRequest option which will remap react-native imports
+ * to different npm packages based on the platform requested.  This allows a single metro instance/config
+ * to produce bundles for multiple out of tree platforms at a time.
+ *
+ * @param platformImplementations
+ * A map of platform to npm package that implements that platform
+ *
+ * Ex:
+ * {
+ *    windows: 'react-native-windows'
+ *    macos: 'react-native-macos'
+ * }
+ */
+// @ts-ignore - no typed definition for the package
+import {resolve} from 'metro-resolver';
+
+export function reactNativePlatformResolver(platformImplementations: {
+  [platform: string]: string;
+}) {
+  return (
+    context: any,
+    _realModuleName: string,
+    platform: string,
+    moduleName: string,
+  ) => {
+    let backupResolveRequest = context.resolveRequest;
+    delete context.resolveRequest;
+
+    try {
+      let modifiedModuleName = moduleName;
+      if (platformImplementations[platform]) {
+        if (moduleName === 'react-native') {
+          modifiedModuleName = platformImplementations[platform];
+        } else if (moduleName.startsWith('react-native/')) {
+          modifiedModuleName = `${
+            platformImplementations[platform]
+          }/${modifiedModuleName.slice('react-native/'.length)}`;
+        }
+      }
+      let result = resolve(context, modifiedModuleName, platform);
+      context.resolveRequest = backupResolveRequest;
+      return result;
+    } catch (e) {
+      context.resolveRequest = backupResolveRequest;
+      throw e;
+    }
+  };
+}

--- a/packages/cli/src/tools/metroPlatformResolver.ts
+++ b/packages/cli/src/tools/metroPlatformResolver.ts
@@ -39,11 +39,11 @@ export function reactNativePlatformResolver(platformImplementations: {
         }
       }
       let result = resolve(context, modifiedModuleName, platform);
-      context.resolveRequest = backupResolveRequest;
       return result;
     } catch (e) {
-      context.resolveRequest = backupResolveRequest;
       throw e;
+    } finally {
+      context.resolveRequest = backupResolveRequest;
     }
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7752,7 +7752,7 @@ metro-react-native-babel-transformer@^0.58.0:
     metro-react-native-babel-preset "0.58.0"
     metro-source-map "0.58.0"
 
-metro-resolver@0.58.0:
+metro-resolver@0.58.0, metro-resolver@^0.58.0:
   version "0.58.0"
   resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.58.0.tgz#4d03edc52e2e25d45f16688adf3b3f268ea60df9"
   integrity sha512-XFbAKvCHN2iWqKeiRARzEXn69eTDdJVJC7lu16S4dPQJ+Dy82dZBr5Es12iN+NmbJuFgrAuIHbpWrdnA9tOf6Q==


### PR DESCRIPTION
Summary:
---------

Currently it is hard to write out of tree platforms that do the right thing, and have a single metro config.  Basically as fallout from the removal of haste, now out of tree platforms contain a full implementation of react-native.  In order to build an out tree platform you have to redirect any `react-native` import into an import into to a different package.

`react-native-macos` and `react-native-windows` do this today by specifying custom extraNodeModules settings on the metro resolver to redirect `react-native` to their respective packages.  But that requires a different metro config to build macos vs building windows.

We have come up with a new solution that uses a custom **resolveRequest** function to rewrite the resolutions at bundle time, at which point we know which platform is being built, and can redirect to different packages for different platforms.

This change takes that code and generalizes it into the CLI.  So now any out of tree platform can just specify the npm package that metro should use as a redirect for `react-native` for that platform. -- And otherwise the default metro config should work.

One note, in addition to changing the **resolveRequest** property, I've changed the **assetRegistryPath** proeprty.  Previously it would be a full path, which would mean that it would not be correctly redirected by the new **reactNativePlatformResolver**.  This path is added as a require statement in the transformer, so it should be fine for most uses as `react-native/Libraries/Image/AssetRegistry`

Test Plan:
----------

Posting this early for feedback.  We recently applied this change to `react-native-windows` and are still in the process of validating that locally.  Then we'll verify that pushing this to the CLI will make everything cleaner.  -- So this has not been validated yet.
