### PR TITLE
chore: target not 8.3, not 8.0

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = {
     [
       require.resolve('@babel/preset-env'),
       {
-        targets: {node: 8},
+        targets: {node: '8.3'},
         useBuiltIns: 'entry',
         corejs: '2.x',
       },


### PR DESCRIPTION
Summary:
---------

Realized we were targeting Node 8.0, while react-native targets 8.3, because it introduces object spread. This results in the `cli` package being 8.5kB uncompressed smaller.

Test Plan:
----------

Green CI
