### PR TITLE
[backport from 0.62] fix: pick correct TARGET_BUILD_DIR for run-ios (#1032)

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -367,10 +367,17 @@ function bootSimulator(selectedSimulator: Device) {
 }
 
 function getTargetBuildDir(buildSettings: string) {
-  const targetBuildMatch = /TARGET_BUILD_DIR = (.+)$/m.exec(buildSettings);
-  return targetBuildMatch && targetBuildMatch[1]
-    ? targetBuildMatch[1].trim()
-    : null;
+  const settings = JSON.parse(buildSettings);
+
+  // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
+  for (const i in settings) {
+    const wrapperExtension = settings[i].buildSettings.WRAPPER_EXTENSION;
+    if (wrapperExtension === 'app') {
+      return settings[i].buildSettings.TARGET_BUILD_DIR;
+    }
+  }
+
+  return null;
 }
 
 function getBuildPath(
@@ -402,6 +409,7 @@ function getBuildPath(
       '-configuration',
       configuration,
       '-showBuildSettings',
+      '-json',
     ],
     {encoding: 'utf8'},
   );


### PR DESCRIPTION
Summary:
---------

Cherry-pick from https://github.com/react-native-community/cli/pull/1032

A fix to `react-native run-ios` was merged into 0.62 but 0.61's `run-ios` command still has the bug, so this PR just backports the fix.

Test Plan:
----------

Ran `react-native run-ios` in our codebase using 0.61 with this patch, and it now works. It was previously broken because `run-ios` was confused by the `TARGET_BUILD_DIR` present in the `React` pod target's build settings (as opposed to our app's build settings)
