### PR TITLE
chore: update docs link in the Android installation error message

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -84,8 +84,7 @@ async function runOnAllDevices(
 
 function createInstallError(error: Error & {stderr: string}) {
   const stderr = (error.stderr || '').toString();
-  const docs =
-    'https://reactnative.dev/docs/getting-started.html#android-development-environment';
+  const docs = 'https://reactnative.dev/docs/environment-setup';
   let message = `Make sure you have the Android development environment set up: ${chalk.underline.dim(
     docs,
   )}`;


### PR DESCRIPTION
Summary:
---------

This small PR updates outdated link to the React Native documentation in the Android app installation error message. Unfortunately in the current version of docs it's not possible to select `React Native CLI` and `Android` tabs using anchors (`#`) in the URL.


Test Plan:
----------

N/A
