### PR TITLE
refactor: make watchFolders read-only everywhere

### DIFF
--- a/packages/cli-server-api/src/devToolsMiddleware.ts
+++ b/packages/cli-server-api/src/devToolsMiddleware.ts
@@ -27,7 +27,7 @@ function escapePath(pathname: string) {
 type LaunchDevToolsOptions = {
   host?: string;
   port: number;
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
 };
 
 function launchDevTools(
@@ -48,7 +48,7 @@ function startCustomDebugger({
   watchFolders,
   customDebugger,
 }: {
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
   customDebugger: string;
 }) {
   const folders = watchFolders.map(escapePath).join(' ');

--- a/packages/cli-server-api/src/index.ts
+++ b/packages/cli-server-api/src/index.ts
@@ -35,7 +35,7 @@ export {messageSocketServer};
 
 type MiddlewareOptions = {
   host?: string;
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
   port: number;
 };
 

--- a/packages/cli-server-api/src/openStackFrameInEditorMiddleware.ts
+++ b/packages/cli-server-api/src/openStackFrameInEditorMiddleware.ts
@@ -10,7 +10,7 @@ import connect from 'connect';
 import rawBodyMiddleware from './rawBodyMiddleware';
 
 type Options = {
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
 };
 
 function getOpenStackFrameInEditorMiddleware({watchFolders}: Options) {

--- a/packages/cli/src/commands/server/middleware/MiddlewareManager.ts
+++ b/packages/cli/src/commands/server/middleware/MiddlewareManager.ts
@@ -22,7 +22,7 @@ import getDevToolsMiddleware from './getDevToolsMiddleware';
 
 type Options = {
   host?: string;
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
   port: number;
 };
 

--- a/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/getDevToolsMiddleware.ts
@@ -27,7 +27,7 @@ function escapePath(pathname: string) {
 type LaunchDevToolsOptions = {
   host?: string;
   port: number;
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
 };
 
 function launchDevTools(
@@ -48,7 +48,7 @@ function startCustomDebugger({
   watchFolders,
   customDebugger,
 }: {
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
   customDebugger: string;
 }) {
   const folders = watchFolders.map(escapePath).join(' ');

--- a/packages/cli/src/commands/server/middleware/openStackFrameInEditorMiddleware.ts
+++ b/packages/cli/src/commands/server/middleware/openStackFrameInEditorMiddleware.ts
@@ -10,7 +10,7 @@ import {launchEditor} from '@react-native-community/cli-tools';
 export default function getOpenStackFrameInEditorMiddleware({
   watchFolders,
 }: {
-  watchFolders: Array<string>;
+  watchFolders: ReadonlyArray<string>;
 }) {
   return (
     req: http.IncomingMessage & {rawBody: string},

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -40,7 +40,7 @@ export interface MetroConfig {
     assetRegistryPath: string;
     assetPlugins?: Array<string>;
   };
-  watchFolders: string[];
+  watchFolders: ReadonlyArray<string>;
   reporter?: any;
 }
 

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -153,7 +153,10 @@ function transformToAbsolutePathIfNeeded(pathName: string) {
   return pathName;
 }
 
-function findRootForFile(projectRoots: string[], fileName: string) {
+function findRootForFile(
+  projectRoots: ReadonlyArray<string>,
+  fileName: string,
+) {
   const absoluteFileName = transformToAbsolutePathIfNeeded(fileName);
   return projectRoots.find(root => {
     const absoluteRoot = transformToAbsolutePathIfNeeded(root);
@@ -165,7 +168,7 @@ let _childProcess: ChildProcess | null = null;
 function launchEditor(
   fileName: string,
   lineNumber: number,
-  projectRoots: string[],
+  projectRoots: ReadonlyArray<string>,
 ) {
   if (!fs.existsSync(fileName)) {
     return;


### PR DESCRIPTION
Summary:
---------

This PR changes the TS type of `watchFolders` and `projectRoots` arrays to read-only everywhere. These arrays come from the Metro configuration and they've already been treated as immutable and not modified anywhere. The read-only array type signals this: the function doesn't modify the array.

The rationale for this type change is that it helps avoid type errors when `watchFolders` is passed from Metro config to `createDevServerMiddleware`, for example:
```ts
const { middleware, attachToServer } = createDevServerMiddleware({
  port: metroConfig.server.port,
  watchFolders: metroConfig.watchFolders,
});
```
When `watchFolders` was `Array<string>` , this code resulted in a type error, because `watchFolders` is `ReadonlyArray<string>` in Metro config. (A work-around was to defensively clone `watchFolders` before passing it in.)

Test Plan:
----------

Only verified that TypeScript build succeeded, as this PR doesn't change any functionality, only types.