### PR TITLE
feat: added --skip-install option to init command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -207,6 +207,10 @@ module.exports = {
 };
 ```
 
+#### `--skip-install`
+
+Skip dependencies installation
+
 #### `--npm`
 
 Force use of npm during initialization

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -28,5 +28,9 @@ export default {
       name: '--title [string]',
       description: 'Uses a custom app title name for application',
     },
+    {
+      name: '--skip-install',
+      description: 'Skips dependencies installation step',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -29,6 +29,7 @@ type Options = {
   directory?: string;
   displayName?: string;
   title?: string;
+  skipInstall?: boolean;
 };
 
 interface TemplateOptions {
@@ -37,6 +38,7 @@ interface TemplateOptions {
   npm?: boolean;
   directory: string;
   projectTitle?: string;
+  skipInstall?: boolean;
 }
 
 function doesDirectoryExist(dir: string) {
@@ -80,6 +82,7 @@ async function createFromTemplate({
   npm,
   directory,
   projectTitle,
+  skipInstall,
 }: TemplateOptions) {
   logger.debug('Initializing new project');
   logger.log(banner);
@@ -124,12 +127,16 @@ async function createFromTemplate({
       loader.succeed();
     }
 
-    await installDependencies({
-      projectName,
-      npm,
-      loader,
-      root: projectDirectory,
-    });
+    if (!skipInstall) {
+      await installDependencies({
+        projectName,
+        npm,
+        loader,
+        root: projectDirectory,
+      });
+    } else {
+      loader.succeed('Dependencies installation skipped');
+    }
   } catch (e) {
     loader.fail();
     throw new Error(e);
@@ -178,6 +185,7 @@ async function createProject(
     npm: options.npm,
     directory,
     projectTitle: options.title,
+    skipInstall: options.skipInstall,
   });
 }
 


### PR DESCRIPTION
Summary:
---------

Added skip install options mentioned in #1142, this option adds the ability to simply skip the installation of dependencies after the template has been set up


Test Plan:
----------

This option doesn't fundamentally change  any mechanics, I ran every test mentioned in [CONTRIBUTING.md](CONTRIBUTING.md), also tested by creating a project and manually installing the dependencies and checking that everything was in place and worked correctly
