### PR TITLE
fix: read request body for Metro symbolication

### DIFF
--- a/packages/cli-server-api/src/index.ts
+++ b/packages/cli-server-api/src/index.ts
@@ -55,6 +55,7 @@ export function createDevServerMiddleware(options: MiddlewareOptions) {
     .use('/open-stack-frame', openStackFrameInEditorMiddleware(options))
     .use('/open-url', openURLMiddleware)
     .use('/status', statusPageMiddleware)
+    .use('/symbolicate', rawBodyMiddleware)
     .use('/systrace', systraceProfileMiddleware)
     .use('/reload', (_req: http.IncomingMessage, res: http.ServerResponse) => {
       broadcast('reload');


### PR DESCRIPTION
Summary:
---------

Metro `/symbolicate` endpoint requires the request body to be available
in `req.rawBody`, which the `rawBodyMiddleware` adds.

Fixes the following error from `cli-server-api`:

    SyntaxError: Unexpected token u in JSON at position 0
        at JSON.parse (<anonymous>)
        at /Users/ville/Projects/react-native-cli/node_modules/metro/src/Server.js:1026:28


Test Plan:
----------

Tested this together with https://github.com/react-native-community/cli/pull/1140, as the `master` branch doesn't have `cli-server-api` enabled yet.

Without the fix, running an app with a `console.warn` or `throw new Error` in the code resulted in the following error printed to the console: `SyntaxError: Unexpected token u in JSON at position 0`. Also the stack traces were not symbolicated, showing Metro bundle URLs instead of filenames:
![Simulator Screen Shot - iPhone 11 - 2020-04-30 at 15 33 09](https://user-images.githubusercontent.com/497214/80711511-20342700-8af9-11ea-9f8d-8b24d8fcb488.png)

After adding this patch, the error did not occur and the stack traces displayed correct filenames:
![Simulator Screen Shot - iPhone 11 - 2020-04-30 at 15 30 44](https://user-images.githubusercontent.com/497214/80711565-393cd800-8af9-11ea-8530-26b02e49261a.png)


