### PR TITLE
chore: make `cleanup` async

### DIFF
--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -4,7 +4,7 @@ import {wrap} from 'jest-snapshot-serializer-raw';
 import {
   runCLI,
   getTempDirectory,
-  cleanup,
+  cleanupSync,
   writeFiles,
   spawnScript,
   replaceProjectRootInOutput,
@@ -44,7 +44,7 @@ beforeAll(() => {
   }
 
   // Clean up folder and re-create a new project
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {});
 
   // Initialise React Native project
@@ -63,7 +63,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
 });
 
 test('shows up current config without unnecessary output', () => {

--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -35,7 +35,7 @@ function createCorruptedSetupEnvScript() {
   };
 }
 
-beforeAll(() => {
+beforeAll(async () => {
   // Register all packages to be linked
   for (const pkg of ['platform-ios', 'platform-android']) {
     spawnScript('yarn', ['link'], {
@@ -44,7 +44,7 @@ beforeAll(() => {
   }
 
   // Clean up folder and re-create a new project
-  cleanup(DIR);
+  await cleanup(DIR);
   writeFiles(DIR, {});
 
   // Initialise React Native project
@@ -62,8 +62,8 @@ beforeAll(() => {
   });
 });
 
-afterAll(() => {
-  cleanup(DIR);
+afterAll(async () => {
+  await cleanup(DIR);
 });
 
 test('shows up current config without unnecessary output', () => {

--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -35,7 +35,7 @@ function createCorruptedSetupEnvScript() {
   };
 }
 
-beforeAll(async () => {
+beforeAll(() => {
   // Register all packages to be linked
   for (const pkg of ['platform-ios', 'platform-android']) {
     spawnScript('yarn', ['link'], {
@@ -44,7 +44,7 @@ beforeAll(async () => {
   }
 
   // Clean up folder and re-create a new project
-  await cleanup(DIR);
+  cleanup(DIR, false);
   writeFiles(DIR, {});
 
   // Initialise React Native project
@@ -62,8 +62,8 @@ beforeAll(async () => {
   });
 });
 
-afterAll(async () => {
-  await cleanup(DIR);
+afterAll(() => {
+  cleanup(DIR, false);
 });
 
 test('shows up current config without unnecessary output', () => {

--- a/__e2e__/default.test.ts
+++ b/__e2e__/default.test.ts
@@ -7,7 +7,7 @@ import {
 
 const DIR = getTempDirectory('test_default_behavior');
 
-beforeEach(async () => {
+beforeEach(() => {
   cleanupSync(DIR);
   writeFiles(DIR, {});
 });

--- a/__e2e__/default.test.ts
+++ b/__e2e__/default.test.ts
@@ -3,11 +3,11 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 const DIR = getTempDirectory('test_default_behavior');
 
 beforeEach(async () => {
-  await cleanup(DIR);
+  cleanup(DIR, false);
   writeFiles(DIR, {});
 });
 afterEach(async () => {
-  await cleanup(DIR);
+  cleanup(DIR, false);
 });
 
 test('shows up help information without passing in any args', () => {

--- a/__e2e__/default.test.ts
+++ b/__e2e__/default.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   cleanupSync(DIR);
   writeFiles(DIR, {});
 });
-afterEach(async () => {
+afterEach(() => {
   cleanupSync(DIR);
 });
 

--- a/__e2e__/default.test.ts
+++ b/__e2e__/default.test.ts
@@ -1,13 +1,18 @@
-import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {
+  runCLI,
+  getTempDirectory,
+  cleanupSync,
+  writeFiles,
+} from '../jest/helpers';
 
 const DIR = getTempDirectory('test_default_behavior');
 
 beforeEach(async () => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {});
 });
 afterEach(async () => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
 });
 
 test('shows up help information without passing in any args', () => {

--- a/__e2e__/default.test.ts
+++ b/__e2e__/default.test.ts
@@ -2,12 +2,12 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('test_default_behavior');
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   writeFiles(DIR, {});
 });
-afterEach(() => {
-  cleanup(DIR);
+afterEach(async () => {
+  await cleanup(DIR);
 });
 
 test('shows up help information without passing in any args', () => {

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -26,12 +26,12 @@ const customTemplateCopiedFiles = [
   'yarn.lock',
 ];
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   writeFiles(DIR, {});
 });
-afterEach(() => {
-  cleanup(DIR);
+afterEach(async () => {
+  await cleanup(DIR);
 });
 
 test('init --template fails without package name', () => {

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -26,12 +26,12 @@ const customTemplateCopiedFiles = [
   'yarn.lock',
 ];
 
-beforeEach(async () => {
-  await cleanup(DIR);
+beforeEach(() => {
+  cleanup(DIR, false);
   writeFiles(DIR, {});
 });
-afterEach(async () => {
-  await cleanup(DIR);
+afterEach(() => {
+  cleanup(DIR, false);
 });
 
 test('init --template fails without package name', () => {

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -1,6 +1,11 @@
 import fs from 'fs';
 import path from 'path';
-import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {
+  runCLI,
+  getTempDirectory,
+  cleanupSync,
+  writeFiles,
+} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-init');
 
@@ -27,11 +32,11 @@ const customTemplateCopiedFiles = [
 ];
 
 beforeEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {});
 });
 afterEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
 });
 
 test('init --template fails without package name', () => {

--- a/__e2e__/install.test.ts
+++ b/__e2e__/install.test.ts
@@ -4,14 +4,14 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 const DIR = getTempDirectory('command-install-test');
 const pkg = 'react-native-config';
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'package.json': '{}',
   });
 });
-afterEach(() => cleanup(DIR));
+afterEach(async () => await cleanup(DIR));
 
 test.each(['yarn', 'npm'])('install module with %s', pm => {
   if (pm === 'yarn') {

--- a/__e2e__/install.test.ts
+++ b/__e2e__/install.test.ts
@@ -4,14 +4,14 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 const DIR = getTempDirectory('command-install-test');
 const pkg = 'react-native-config';
 
-beforeEach(async () => {
-  await cleanup(DIR);
+beforeEach(() => {
+  cleanup(DIR, false);
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'package.json': '{}',
   });
 });
-afterEach(async () => await cleanup(DIR));
+afterEach(() => cleanup(DIR, false));
 
 test.each(['yarn', 'npm'])('install module with %s', pm => {
   if (pm === 'yarn') {

--- a/__e2e__/install.test.ts
+++ b/__e2e__/install.test.ts
@@ -1,17 +1,22 @@
 import path from 'path';
-import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {
+  runCLI,
+  getTempDirectory,
+  cleanupSync,
+  writeFiles,
+} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-install-test');
 const pkg = 'react-native-config';
 
 beforeEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'package.json': '{}',
   });
 });
-afterEach(() => cleanup(DIR, false));
+afterEach(() => cleanupSync(DIR));
 
 test.each(['yarn', 'npm'])('install module with %s', pm => {
   if (pm === 'yarn') {

--- a/__e2e__/legacyInit.test.ts
+++ b/__e2e__/legacyInit.test.ts
@@ -2,16 +2,16 @@ import fs from 'fs';
 import path from 'path';
 // @ts-ignore
 import execa from 'execa';
-import {getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {getTempDirectory, cleanupSync, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-legacy-init');
 
 beforeEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {});
 });
 afterEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
 });
 
 // We skip this test, because it's flaky and we don't really update

--- a/__e2e__/legacyInit.test.ts
+++ b/__e2e__/legacyInit.test.ts
@@ -6,12 +6,12 @@ import {getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-legacy-init');
 
-beforeEach(async () => {
-  await cleanup(DIR);
+beforeEach(() => {
+  cleanup(DIR, false);
   writeFiles(DIR, {});
 });
-afterEach(async () => {
-  await cleanup(DIR);
+afterEach(() => {
+  cleanup(DIR, false);
 });
 
 // We skip this test, because it's flaky and we don't really update

--- a/__e2e__/legacyInit.test.ts
+++ b/__e2e__/legacyInit.test.ts
@@ -6,12 +6,12 @@ import {getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-legacy-init');
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   writeFiles(DIR, {});
 });
-afterEach(() => {
-  cleanup(DIR);
+afterEach(async () => {
+  await cleanup(DIR);
 });
 
 // We skip this test, because it's flaky and we don't really update

--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -10,7 +10,7 @@ import {
 
 const cwd = getTempDirectory('test_different_roots');
 
-beforeAll(async () => {
+beforeAll(() => {
   // Register all packages to be linked
   for (const pkg of ['platform-ios', 'platform-android']) {
     spawnScript('yarn', ['link'], {
@@ -19,7 +19,7 @@ beforeAll(async () => {
   }
 
   // Clean up folder and re-create a new project
-  await cleanup(cwd);
+  cleanup(cwd, false);
   writeFiles(cwd, {});
 
   // Initialise React Native project
@@ -36,8 +36,8 @@ beforeAll(async () => {
   });
 });
 
-afterAll(async () => {
-  await cleanup(cwd);
+afterAll(() => {
+  cleanup(cwd, false);
 });
 
 test('works when Gradle is run outside of the project hierarchy', () => {

--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -10,7 +10,7 @@ import {
 
 const cwd = getTempDirectory('test_different_roots');
 
-beforeAll(() => {
+beforeAll(async () => {
   // Register all packages to be linked
   for (const pkg of ['platform-ios', 'platform-android']) {
     spawnScript('yarn', ['link'], {
@@ -19,7 +19,7 @@ beforeAll(() => {
   }
 
   // Clean up folder and re-create a new project
-  cleanup(cwd);
+  await cleanup(cwd);
   writeFiles(cwd, {});
 
   // Initialise React Native project
@@ -36,8 +36,8 @@ beforeAll(() => {
   });
 });
 
-afterAll(() => {
-  cleanup(cwd);
+afterAll(async () => {
+  await cleanup(cwd);
 });
 
 test('works when Gradle is run outside of the project hierarchy', () => {

--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -4,7 +4,7 @@ import {
   spawnScript,
   runCLI,
   getTempDirectory,
-  cleanup,
+  cleanupSync,
   writeFiles,
 } from '../jest/helpers';
 
@@ -19,7 +19,7 @@ beforeAll(() => {
   }
 
   // Clean up folder and re-create a new project
-  cleanup(cwd, false);
+  cleanupSync(cwd);
   writeFiles(cwd, {});
 
   // Initialise React Native project
@@ -37,7 +37,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  cleanup(cwd, false);
+  cleanupSync(cwd);
 });
 
 test('works when Gradle is run outside of the project hierarchy', () => {

--- a/__e2e__/uninstall.test.ts
+++ b/__e2e__/uninstall.test.ts
@@ -3,8 +3,8 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 const DIR = getTempDirectory('command-uninstall-test');
 const pkg = 'react-native-config';
 
-beforeEach(async () => {
-  await cleanup(DIR);
+beforeEach(() => {
+  cleanup(DIR, false);
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'node_modules/react-native-config/package.json': '{}',
@@ -15,7 +15,7 @@ beforeEach(async () => {
     }`,
   });
 });
-afterEach(async () => await cleanup(DIR));
+afterEach(() => cleanup(DIR, false));
 
 test('uninstall fails when package is not defined', () => {
   writeFiles(DIR, {

--- a/__e2e__/uninstall.test.ts
+++ b/__e2e__/uninstall.test.ts
@@ -1,10 +1,15 @@
-import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {
+  runCLI,
+  getTempDirectory,
+  cleanupSync,
+  writeFiles,
+} from '../jest/helpers';
 
 const DIR = getTempDirectory('command-uninstall-test');
 const pkg = 'react-native-config';
 
 beforeEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'node_modules/react-native-config/package.json': '{}',
@@ -15,7 +20,7 @@ beforeEach(() => {
     }`,
   });
 });
-afterEach(() => cleanup(DIR, false));
+afterEach(() => cleanupSync(DIR));
 
 test('uninstall fails when package is not defined', () => {
   writeFiles(DIR, {

--- a/__e2e__/uninstall.test.ts
+++ b/__e2e__/uninstall.test.ts
@@ -3,8 +3,8 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 const DIR = getTempDirectory('command-uninstall-test');
 const pkg = 'react-native-config';
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',
     'node_modules/react-native-config/package.json': '{}',
@@ -15,7 +15,7 @@ beforeEach(() => {
     }`,
   });
 });
-afterEach(() => cleanup(DIR));
+afterEach(async () => await cleanup(DIR));
 
 test('uninstall fails when package is not defined', () => {
   writeFiles(DIR, {

--- a/__e2e__/unknown.test.ts
+++ b/__e2e__/unknown.test.ts
@@ -2,12 +2,12 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('test_unknown');
 
-beforeEach(async () => {
-  await cleanup(DIR);
+beforeEach(() => {
+  cleanup(DIR, false);
   writeFiles(DIR, {});
 });
-afterEach(async () => {
-  await cleanup(DIR);
+afterEach(() => {
+  cleanup(DIR, false);
 });
 
 test('warn for passing in unknown commands', () => {

--- a/__e2e__/unknown.test.ts
+++ b/__e2e__/unknown.test.ts
@@ -2,12 +2,12 @@ import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
 
 const DIR = getTempDirectory('test_unknown');
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   writeFiles(DIR, {});
 });
-afterEach(() => {
-  cleanup(DIR);
+afterEach(async () => {
+  await cleanup(DIR);
 });
 
 test('warn for passing in unknown commands', () => {

--- a/__e2e__/unknown.test.ts
+++ b/__e2e__/unknown.test.ts
@@ -1,13 +1,18 @@
-import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {
+  runCLI,
+  getTempDirectory,
+  cleanupSync,
+  writeFiles,
+} from '../jest/helpers';
 
 const DIR = getTempDirectory('test_unknown');
 
 beforeEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
   writeFiles(DIR, {});
 });
 afterEach(() => {
-  cleanup(DIR, false);
+  cleanupSync(DIR);
 });
 
 test('warn for passing in unknown commands', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
       ...common,
       displayName: 'e2e',
       setupFiles: ['<rootDir>/jest/setupE2eTests.js'],
-      testMatch: ['<rootDir>/**/__e2e__/*{.,-}test.[jt]s'],
+      testMatch: ['<rootDir>/__e2e__/*{.,-}test.[jt]s'],
     },
     {
       ...common,

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -80,12 +80,12 @@ export const makeTemplate = (
     return values[number - 1];
   });
 
-export const cleanup = (directory: string, async = true) => {
-  if (!async) {
-    return rimraf.sync(directory);
-  } else {
-    return rimrafAsync(directory);
-  }
+export const cleanup = (directory: string) => {
+  return rimrafAsync(directory);
+};
+
+export const cleanupSync = (directory: string) => {
+  rimraf.sync(directory);
 };
 
 /**

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -80,7 +80,13 @@ export const makeTemplate = (
     return values[number - 1];
   });
 
-export const cleanup = (directory: string) => rimrafAsync(directory);
+export const cleanup = (directory: string, async = true) => {
+  if (!async) {
+    return rimraf.sync(directory);
+  } else {
+    return rimrafAsync(directory);
+  }
+};
 
 /**
  * Creates a nested directory with files and their contents

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import {promisify} from 'util';
 import {createDirectory} from 'jest-util';
 // @ts-ignore jsfile
 import rimraf from 'rimraf';
@@ -9,6 +10,8 @@ import chalk from 'chalk';
 import slash from 'slash';
 // @ts-ignore jsfile
 import {Writable} from 'readable-stream';
+
+const rimrafAsync = promisify(rimraf);
 
 const CLI_PATH = path.resolve(__dirname, '../packages/cli/build/bin.js');
 
@@ -77,7 +80,7 @@ export const makeTemplate = (
     return values[number - 1];
   });
 
-export const cleanup = (directory: string) => rimraf.sync(directory);
+export const cleanup = (directory: string) => rimrafAsync(directory);
 
 /**
  * Creates a nested directory with files and their contents
@@ -189,7 +192,7 @@ function handleTestFailure(
 ) {
   if (!options.expectedFailure && result.code !== 0) {
     console.log(`Running ${cmd} command failed for unexpected reason. Here's more info:
-${chalk.bold('cmd:')}     ${cmd}    
+${chalk.bold('cmd:')}     ${cmd}
 ${chalk.bold('options:')} ${JSON.stringify(options)}
 ${chalk.bold('args:')}    ${(args || []).join(' ')}
 ${chalk.bold('stderr:')}  ${result.stderr}

--- a/jest/setupE2eTests.js
+++ b/jest/setupE2eTests.js
@@ -1,1 +1,1 @@
-jest.setTimeout(120000);
+jest.setTimeout(60000);

--- a/jest/setupE2eTests.js
+++ b/jest/setupE2eTests.js
@@ -1,1 +1,1 @@
-jest.setTimeout(60000);
+jest.setTimeout(120000);

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -38,7 +38,9 @@ describe('androidSDK', () => {
     });
   });
 
-  afterAll(() => cleanup(join(mockWorkingDir, 'android/build.gradle')));
+  afterAll(
+    async () => await cleanup(join(mockWorkingDir, 'android/build.gradle')),
+  );
 
   let environmentInfo: EnvironmentInfo;
 
@@ -99,7 +101,7 @@ describe('androidSDK', () => {
       stdout: 'build-tools;28.0.3',
     });
 
-    cleanup(join(mockWorkingDir, 'android/build.gradle'));
+    await cleanup(join(mockWorkingDir, 'android/build.gradle'));
 
     const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(true);

--- a/packages/cli/src/tools/__tests__/copyFiles.test.ts
+++ b/packages/cli/src/tools/__tests__/copyFiles.test.ts
@@ -6,13 +6,13 @@ import replacePathSepForRegex from '../replacePathSepForRegex';
 
 const DIR = getTempDirectory('copyFiles-test');
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   fs.mkdirSync(DIR);
 });
 
-afterEach(() => {
-  cleanup(DIR);
+afterEach(async () => {
+  await cleanup(DIR);
 });
 
 test('copies text and binary files from source to destination', async () => {

--- a/packages/cli/src/tools/config/__tests__/findDependencies-test.ts
+++ b/packages/cli/src/tools/config/__tests__/findDependencies-test.ts
@@ -7,12 +7,12 @@ import {
 
 jest.mock('../resolveNodeModuleDir');
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   jest.resetModules();
 });
 
-afterEach(() => cleanup(DIR));
+afterEach(async () => await cleanup(DIR));
 
 const DIR = getTempDirectory('find_dependencies_test');
 

--- a/packages/cli/src/tools/config/__tests__/findProjectRoot-test.ts
+++ b/packages/cli/src/tools/config/__tests__/findProjectRoot-test.ts
@@ -6,12 +6,12 @@ import {
   getTempDirectory,
 } from '../../../../../../jest/helpers';
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   jest.resetModules();
 });
 
-afterEach(() => cleanup(DIR));
+afterEach(async () => await cleanup(DIR));
 
 const DIR = getTempDirectory('find_project_root_test');
 

--- a/packages/cli/src/tools/config/__tests__/index-test.ts
+++ b/packages/cli/src/tools/config/__tests__/index-test.ts
@@ -51,13 +51,13 @@ const removeString = (config, str) =>
     ),
   );
 
-beforeEach(() => {
-  cleanup(DIR);
+beforeEach(async () => {
+  await cleanup(DIR);
   jest.resetModules();
   jest.clearAllMocks();
 });
 
-afterEach(() => cleanup(DIR));
+afterEach(async () => await cleanup(DIR));
 
 test('should have a valid structure by default', () => {
   writeFiles(DIR, {


### PR DESCRIPTION
Summary:
---------

I'm trying to improve the reliability of Windows CI so I can get #1109 green.
I've found out that `cleanup()` uses `rimraf.sync` underneath. Windows FS is not very... reliable, and sometimes you can end up with `ENOTEMPTY` errors like [this one](https://dev.azure.com/react-native-community/cli/_build/results?buildId=1248&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=5caf77c8-9b10-50ef-b5c7-ca89c63e1c86&l=417). In fact, [`rimraf`'s documentation](https://www.npmjs.com/package/rimraf#api) calls that out:

> Windows: `EBUSY` and `ENOTEMPTY` - rimraf will back off a maximum of `opts.maxBusyTries` times before giving up, adding 100ms of wait between each attempt. The default `maxBusyTries` is 3.

The problem is the above does not apply when using the sync method:

> If an `EBUSY`, `ENOTEMPTY`, or `EPERM` error code is encountered on Windows systems, then rimraf will retry with a linear backoff wait of 100ms longer on each try. The default maxBusyTries is 3.
> **Only relevant for async usage.**

I've changed it to use the async version and updated the tests. Hopefully that should make Windows more reliable.

Test Plan:
----------

CI