### PR TITLE
Fix Android project's configuration `manifestPath` is not used by @react-native-community/cli-platform-android #1159

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -126,11 +126,12 @@ function buildAndRun(args: Flags, androidProject: AndroidProject) {
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
   // "app" is usually the default value for Android apps with only 1 app
-  const {appName} = androidProject;
+  const {appName, manifestPath} = androidProject;
   const {appFolder} = args;
-  // @ts-ignore
+  const fallbackManifestPath = `${appFolder ||
+    appName}/src/main/AndroidManifest.xml`;
   const androidManifest = fs.readFileSync(
-    `${appFolder || appName}/src/main/AndroidManifest.xml`,
+    manifestPath || fallbackManifestPath,
     'utf8',
   );
 


### PR DESCRIPTION
Summary:
---------

We have manifestPath defined already in Android project, but it was not used in the runAndroid command, so this just fixes that. Old parameters are kept as a fallback, they could be deprecated in future.

Test Plan:
----------

This is needed to test Android in react-native-webview, there's otherwise working code which just needs this change here: https://github.com/jussikinnula/react-native-webview/tree/feat-react-native-0-62-support