### PR TITLE
imp: Manifest cleanup

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -128,12 +128,7 @@ function buildAndRun(args: Flags, androidProject: AndroidProject) {
   // "app" is usually the default value for Android apps with only 1 app
   const {appName, manifestPath} = androidProject;
   const {appFolder} = args;
-  const fallbackManifestPath = `${appFolder ||
-    appName}/src/main/AndroidManifest.xml`;
-  const androidManifest = fs.readFileSync(
-    manifestPath || fallbackManifestPath,
-    'utf8',
-  );
+  const androidManifest = fs.readFileSync(manifestPath, 'utf8');
 
   let packageNameMatchArray = androidManifest.match(/package="(.+?)"/);
   if (!packageNameMatchArray || packageNameMatchArray.length === 0) {


### PR DESCRIPTION
Summary:
---------

`manifestPath` should be always available in `run`. If it doesn't exist we throw an Error on `config` creation level - https://github.com/react-native-community/cli/blob/4c8af54e29059af74b7edd813425f4ab0815eeb5/packages/platform-android/src/config/index.ts#L46.

cc. @grabbou @thymikee 
