### PR TITLE
feat: allow uppercase in android package names

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -25,7 +25,7 @@ import warnAboutManuallyLinkedLibs from '../../link/warnAboutManuallyLinkedLibs'
 
 // Validates that the package name is correct
 function validatePackageName(packageName: string) {
-  return /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/.test(packageName);
+  return /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$/.test(packageName);
 }
 
 function displayWarnings(config: Config, args: Flags) {


### PR DESCRIPTION
Summary:
---------

I'm proposing to allow uppercase letters in android package names. Oracle states that lowercase letters are used by convention here: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html.  But the spec does not seem to prohibit the use of uppercase letters. My company doesn't follow the convention and uses an uppercase letter like `com.company.myPackage`. If possible I'd like to update the validation so that my company won't see the warning about an invalid package name on every build.

