### PR TITLE
Add an ability to add custom scope methods and configurations in android dependencies autolinking

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -100,12 +100,15 @@ class ReactNativeModules {
   /**
    * Adds the react native modules as dependencies to the users `app` project
    */
-  void addReactNativeModuleDependencies(Project appProject) {
+  void addReactNativeModuleDependencies(Project appProject, String scopeMethod, String configuration) {
     reactNativeModules.forEach { reactNativeModule ->
       def nameCleansed = reactNativeModule["nameCleansed"]
       appProject.dependencies {
-        // TODO(salakar): are other dependency scope methods such as `api` required?
-        implementation project(path: ":${nameCleansed}")
+        if (configuration != null) {
+          "${scopeMethod}" project(path: ":${nameCleansed}", configuration: "${configuration}")
+        } else {
+          "${scopeMethod}" project(path: ":${nameCleansed}")
+        }
       }
     }
   }
@@ -283,12 +286,12 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String
   autoModules.addReactNativeModuleProjects(defaultSettings)
 }
 
-ext.applyNativeModulesAppBuildGradle = { Project project, String root = null ->
+ext.applyNativeModulesAppBuildGradle = { Project project, String root = null, String scopeMethod = "implementation", String configuration = null ->
   if (root != null) {
     logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now");
     logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesAppBuildGradle`.");
   }
-  autoModules.addReactNativeModuleDependencies(project)
+  autoModules.addReactNativeModuleDependencies(project, scopeMethod, configuration)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
   def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Currently there's no way to use any scope method for autolinked dependencies except for hardcoded `implementation`. This PR adds an ability to choose custom scope method and configuration for `ReactNativeModules.addReactNativeModuleDependencies` gradle method.

Test Plan:
----------
Following calls should work. (for corresponding project configuration).

**REQUIRED**
`app/build.gradle`
```groovy
apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle");
applyNativeModulesAppBuildGradle(project, "../../..")
```
Expected: Not to throw any errors.

**OPTIONAL:**
```groovy
apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle");
applyNativeModulesAppBuildGradle(project, "../../..", "api")
```

Expected: Not to throw any errors if `implementation` method is replaceable with `api` for given project. 

```groovy
apply from: file("../../../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle");
applyNativeModulesAppBuildGradle(project, "../../..", "embed", "default")
```

Expected: Not to throw any errors using custom scope method from https://github.com/kezong/fat-aar-android.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
