### PR TITLE
fix: throw a better error when configuration is invalid

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -221,6 +221,10 @@ async function setupAndRun() {
       attachCommand(command, config);
     }
   } catch (error) {
+    /**
+     * When there is no `package.json` found, the CLI will enter `detached` mode and a subset
+     * of commands will be available. That's why we don't throw on such kind of error.
+     */
     if (error.message.includes("We couldn't find a package.json")) {
       logger.enable();
       logger.debug(error.message);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -221,7 +221,6 @@ async function setupAndRun() {
       attachCommand(command, ctx);
     }
   } catch (e) {
-    logger.enable();
     throw new CLIError(
       'Failed to load configuration of your project. Only a subset of commands will be available.',
       e,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,7 +5,7 @@ import leven from 'leven';
 import path from 'path';
 
 import {Command, Config} from '@react-native-community/cli-types';
-import {logger} from '@react-native-community/cli-tools';
+import {logger, CLIError} from '@react-native-community/cli-tools';
 
 import {detachedCommands, projectCommands} from './commands';
 import init from './commands/init/initCompat';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -212,10 +212,8 @@ async function setupAndRun() {
     attachCommand(command);
   }
 
-  let config: Config;
-
   try {
-    config = loadConfig();
+    const config = loadConfig();
 
     logger.enable();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -212,19 +212,29 @@ async function setupAndRun() {
     attachCommand(command);
   }
 
+  let config: Config;
+
   try {
-    const ctx = loadConfig();
+    config = loadConfig();
 
     logger.enable();
 
-    for (const command of [...projectCommands, ...ctx.commands]) {
-      attachCommand(command, ctx);
+    for (const command of [...projectCommands, ...config.commands]) {
+      attachCommand(command, config);
     }
-  } catch (e) {
-    throw new CLIError(
-      'Failed to load configuration of your project. Only a subset of commands will be available.',
-      e,
-    );
+  } catch (error) {
+    if (error.message.includes("We couldn't find a package.json")) {
+      logger.enable();
+      logger.debug(error.message);
+      logger.debug(
+        'Failed to load configuration of your project. Only a subset of commands will be available.',
+      );
+    } else {
+      throw new CLIError(
+        'Failed to load configuration of your project.',
+        error,
+      );
+    }
   }
 
   commander.parse(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -222,10 +222,7 @@ async function setupAndRun() {
     }
   } catch (e) {
     logger.enable();
-    logger.debug(e.message);
-    logger.debug(
-      'Failed to load configuration of your project. Only a subset of commands will be available.',
-    );
+    throw new CLIError('Failed to load configuration of your project. Only a subset of commands will be available.', e);
   }
 
   commander.parse(process.argv);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -222,7 +222,10 @@ async function setupAndRun() {
     }
   } catch (e) {
     logger.enable();
-    throw new CLIError('Failed to load configuration of your project. Only a subset of commands will be available.', e);
+    throw new CLIError(
+      'Failed to load configuration of your project. Only a subset of commands will be available.',
+      e,
+    );
   }
 
   commander.parse(process.argv);

--- a/packages/cli/src/tools/config/errors.ts
+++ b/packages/cli/src/tools/config/errors.ts
@@ -31,5 +31,9 @@ export class JoiError extends CLIError {
         })
         .join(),
     );
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, JoiError);
+    }
   }
 }

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -9,8 +9,7 @@ export class CLIError extends Error {
       this.stack =
         typeof originalError === 'string'
           ? originalError
-          : originalError.stack ||
-            ''
+          : (originalError.stack || '')
               .split('\n')
               .slice(0, 2)
               .join('\n');


### PR DESCRIPTION
Summary:
---------

Fixes #1181 

Throw an error with the correct message when configuration fails to load because of an invalid shape. Before the error was lost and running commands resulted in "Unrecognized command" error. The details were only available with `--verbose` flag and resulted in quite a confusion and poor experience.

Before:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/5106466/83192402-c34a8180-a135-11ea-853e-d7582a302693.png">

After:
<img width="839" alt="Screen Shot 2020-05-28 at 22 48 05" src="https://user-images.githubusercontent.com/5106466/83192416-c80f3580-a135-11ea-8556-ba62519b2418.png">


Test Plan:
- 

Use the below invalid config:
```js
module.exports = {
  project: {
    android: {
      wrongConfiguration: 'test',
    },
  },
};
```
- run `react-native config` or any other command requiring config
- The correct error should be shown