### PR TITLE
feat: detach doctor command

### DIFF
--- a/__e2e__/__snapshots__/default.test.ts.snap
+++ b/__e2e__/__snapshots__/default.test.ts.snap
@@ -9,5 +9,6 @@ Options:
   -h, --help                    output usage information
 
 Commands:
-  init [options] <projectName>  Initialize a new React Native project named <projectName> in a directory of the same name."
+  init [options] <projectName>  Initialize a new React Native project named <projectName> in a directory of the same name.
+  doctor [options]              [EXPERIMENTAL] Diagnose and fix common Node.js, iOS, Android & React Native issues."
 `;

--- a/packages/cli/src/commands/doctor/index.ts
+++ b/packages/cli/src/commands/doctor/index.ts
@@ -2,6 +2,7 @@ import doctor from './doctor';
 
 export default {
   func: doctor,
+  detached: true,
   name: 'doctor',
   description:
     '[EXPERIMENTAL] Diagnose and fix common Node.js, iOS, Android & React Native issues.',

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -23,6 +23,7 @@ export const projectCommands = [
   upgrade,
   info,
   config,
+  doctor,
 ] as Command[];
 
 export const detachedCommands = [init, doctor] as DetachedCommand[];

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,6 +1,4 @@
 import {Command, DetachedCommand} from '@react-native-community/cli-types';
-
-// @ts-ignore - JS file
 import start from './start/start';
 import bundle from './bundle/bundle';
 import ramBundle from './bundle/ramBundle';
@@ -12,7 +10,6 @@ import upgrade from './upgrade/upgrade';
 import info from './info/info';
 import config from './config/config';
 import init from './init';
-// @ts-ignore - JS file
 import doctor from './doctor';
 
 export const projectCommands = [
@@ -26,7 +23,6 @@ export const projectCommands = [
   upgrade,
   info,
   config,
-  doctor,
 ] as Command[];
 
-export const detachedCommands = [init] as DetachedCommand[];
+export const detachedCommands = [init, doctor] as DetachedCommand[];


### PR DESCRIPTION
Summary:
---------

Detaching the `doctor` command so it's possible to run without being in react-native project like this:

```sh
npx @react-native-community/cli doctor
npx react-native doctor
```

cc @brentvatne since you brought that up recently

Test Plan:
----------

Tests updated
