### PR TITLE
chore: use iPhone SE instead of iPhone 5 in `run-ios` example

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -525,8 +525,8 @@ export default {
   func: runIOS,
   examples: [
     {
-      desc: 'Run on a different simulator, e.g. iPhone 5',
-      cmd: 'react-native run-ios --simulator "iPhone 5"',
+      desc: 'Run on a different simulator, e.g. iPhone SE',
+      cmd: 'react-native run-ios --simulator "iPhone SE"',
     },
     {
       desc: 'Pass a non-standard location of iOS directory',


### PR DESCRIPTION
this PR update iOS simulators descriptions, i think `iPhone 5` it is old so i changed for `iPhone SE`.