### PR TITLE
Fix minor typo in run-ios

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -546,7 +546,7 @@ export default {
     {
       name: '--simulator [string]',
       description:
-        'Explicitly set simulator to use. Optionally include iOS version between' +
+        'Explicitly set simulator to use. Optionally include iOS version between ' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
       default: 'iPhone 11',
     },


### PR DESCRIPTION
Currently, we have
```
...
Options:
  --simulator [string]      Explicitly set simulator to use. Optionally include iOS version betweenparenthesis at the end to match an exact version: "iPhone 6 (10.0)" (default: "iPhone 11")
  --configuration [string]  Explicitly set the scheme configuration to use (default: "Debug")
  --scheme [string]         Explicitly set Xcode scheme to use
  --project-path [string]   Path relative to project root where the Xcode project (.xcodeproj) lives. (default: "ios")
  --device [string]         Explicitly set device to use by name.  The value is not required if you have a single device connected.
  --udid [string]           Explicitly set device to use by udid
  --no-packager             Do not launch packager while building
  --verbose                 Do not use xcpretty even if installed
  --port [number]            (default: 8081)
  --terminal [string]       Launches the Metro Bundler in a new window using the specified terminal path. (default: "iTerm.app")
  -h, --help                output usage information
...
```

The `--simulator` help text concatenates lines, but there wasn't a space at the end of the first line