### PR TITLE
feat: export AssetUtils from cli package

### DIFF
--- a/packages/cli/src/__tests__/index-test.ts
+++ b/packages/cli/src/__tests__/index-test.ts
@@ -1,0 +1,13 @@
+import * as CLI from '../index';
+
+describe('cli index', () => {
+  it('exports AssetUtils with the expected function names', () => {
+    expect(CLI.AssetUtils.filterPlatformAssetScales).toBeDefined();
+    expect(CLI.AssetUtils.getAndroidAssetSuffix).toBeDefined();
+    expect(CLI.AssetUtils.getAndroidResourceFolderName).toBeDefined();
+    expect(CLI.AssetUtils.getAndroidResourceIdentifier).toBeDefined();
+    expect(CLI.AssetUtils.getAssetDestPathAndroid).toBeDefined();
+    expect(CLI.AssetUtils.getAssetDestPathIOS).toBeDefined();
+    expect(CLI.AssetUtils.getBasePath).toBeDefined();
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,6 +12,18 @@ import init from './commands/init/initCompat';
 import assertRequiredOptions from './tools/assertRequiredOptions';
 import loadConfig from './tools/config';
 
+import assetPathUtils from './commands/bundle/assetPathUtils';
+import filterPlatformAssetScales from './commands/bundle/filterPlatformAssetScales';
+import getAssetDestPathAndroid from './commands/bundle/getAssetDestPathAndroid';
+import getAssetDestPathIOS from './commands/bundle/getAssetDestPathIOS';
+
+const AssetUtils = {
+  ...assetPathUtils,
+  filterPlatformAssetScales,
+  getAssetDestPathAndroid,
+  getAssetDestPathIOS,
+};
+
 const pkgJson = require('../package.json');
 
 commander
@@ -244,4 +256,4 @@ async function setupAndRun() {
 
 const bin = require.resolve('./bin');
 
-export {run, init, bin};
+export {run, init, bin, AssetUtils};


### PR DESCRIPTION
Summary:
---------

This PR exposes in the public API the utility methods used to map assets on disk to their locations in the embedded binary. This allows other libraries to take the list of assets from Metro and then predictably find each asset's location in the binary. 

Currently this is possible only by more fragile coupling methods, like importing these methods directly from their location in the package, or just copying + pasting the code. Looking back in the git history it looks like most of these utility methods have not changed meaningfully in the last few years, so I propose simply exposing these methods in the external-facing API so that packages that need the above functionality can depend directly on them. This PR does exactly that.

I left the names of the methods alone, but I know they were originally meant as internal methods where the names are not so important. Would be happy to rename any of them for the public API at your discretion. Please let me know what you think!

Test Plan:
----------

Added some basic unit tests to ensure that the exported set of functions stays the same (or when changed, is changed intentionally).

Additionally, I tested with a modified version of `expo-updates` that depends on these exported utils for the functionality described above. (`expo-updates` takes a list of assets from Metro and must, in native code, find each asset inside the binary.) The output of expo-updates' `createManifest` function was the same as before, with the copied+pasted versions of these utils.