### PR TITLE
Make podspecPath relative to the root of the package

### DIFF
--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -39,6 +39,7 @@ def use_native_modules!(config = nil)
   packages.each do |package_name, package|
     next unless package_config = package["platforms"]["ios"]
 
+    package_root_path = package["root"]
     podspec_path = package_config["podspecPath"]
 
     # Add a warning to the queue and continue to the next dependency if the podspec_path is nil/empty
@@ -52,6 +53,7 @@ def use_native_modules!(config = nil)
     end
     next if podspec_path.nil? || podspec_path.empty?
 
+    podspec_path = File.expand_path(podspec_path, package_root_path)
     spec = Pod::Specification.from_file(podspec_path)
 
     # We want to do a look up inside the current CocoaPods target


### PR DESCRIPTION
Summary:
---------
The current implementation of auto-linking using CocoaPods assumes that the `podspecPath` attribute of the packages is a path relative to the directory that contains the `Podfile`. That means that the following configuration for a package would not work:

```js
module.exports = {
  dependency: {
    platforms: {
      ios: {
        podspecPath:  './MyPackage.podspec',
      },
    },
  },
};
```
In order for the package to work with the auto-linking feature, the path would need to be `../node_modules/@company/react-my-package/RNMyPackage.podspec`, but the package would be making assumptions about the structure of the project, which is not good. 

For that reason, I'm changing the implementation to assume the path is relative to the path of the package. 

I don't know how to make this change non-breaking so I'm open to suggestions.

Test Plan:
----------

I tested it with a dependency that has the path relative to the package directory, and it works.
