### PR TITLE
fix: Podfile.lock paths are no longer absolute

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-  "editor.rulers": [80],
+  "editor.rulers": [
+    80
+  ],
   "files.exclude": {
     "**/.git": true,
     "**/node_modules": true,

--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -65,6 +65,7 @@ export type IOSScriptPhase = ({script: string} | {path: string}) & {
  * requirements of `native_modules.rb` change.
  */
 export interface IOSNativeModulesConfig {
+  reactNativePath: string;
   project: {
     ios?: {
       sourceDir: string;

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -135,6 +135,8 @@ if $0 == __FILE__
     Pod::Config.instance.silent = true
   end
 
+  return_values = []
+
   podfile = Pod::Podfile.new do
     if runInput["podsActivatedByUser"]
       runInput["podsActivatedByUser"].each do |name|
@@ -143,15 +145,15 @@ if $0 == __FILE__
     end
     target 'iOS Target' do
       platform :ios
-      use_native_modules!(runInput["dependencyConfig"])
+      return_values[0] = use_native_modules!(runInput["dependencyConfig"])
     end
     target 'macOS Target' do
       platform :osx
-      use_native_modules!(runInput["dependencyConfig"])
+      return_values[1] = use_native_modules!(runInput["dependencyConfig"])
     end
   end
 
   unless runInput["captureStdout"]
-    puts podfile.to_hash.to_json
+    puts podfile.to_hash.merge({ "return_values": return_values }).to_json
   end
 end

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -120,7 +120,9 @@ def use_native_modules!(config = nil)
     Pod::UI.puts "Auto-linking React Native #{"module".pluralize(found_pods.size)} for target `#{current_target_definition.name}`: #{pods}"
   end
   
-  config
+  absolute_react_native_path = Pathname.new(config["reactNativePath"])
+
+  { :reactNativePath => absolute_react_native_path.relative_path_from(project_root).to_s }
 end
 
 # You can run the tests for this file by running:

--- a/packages/platform-ios/src/config/__tests__/native_modules.test.ts
+++ b/packages/platform-ios/src/config/__tests__/native_modules.test.ts
@@ -86,7 +86,7 @@ function describeIfSupportedEnv() {
   }
   console.warn(
     '[!] The `native_modules.rb` tests are disabled – ensure you have `ruby` ' +
-      'and the `cocoapods` gem installed in order to run them.',
+    'and the `cocoapods` gem installed in order to run them.',
   );
   return describe.skip;
 }
@@ -97,6 +97,7 @@ describeIfSupportedEnv()('native_modules.rb', () => {
   beforeEach(() => {
     runConfig = {
       dependencyConfig: {
+        reactNativePath: '/root/app/node_modules/react_native',
         project: {ios: {sourceDir: FIXTURES_ROOT}},
         dependencies: {
           'android-dep': {
@@ -247,12 +248,12 @@ describeIfSupportedEnv()('native_modules.rb', () => {
       runConfig.dependencyConfig.dependencies[
         'ios-dep'
       ].platforms.ios.scriptPhases = [
-        {
-          script: '123',
-          name: 'My Name',
-          execution_position: 'before_compile',
-        },
-      ];
+          {
+            script: '123',
+            name: 'My Name',
+            execution_position: 'before_compile',
+          },
+        ];
       return run(runConfig).then((rootTargetDefinition: TargetDefinition) => {
         expect(rootTargetDefinition.children[0].script_phases)
           .toMatchInlineSnapshot(`
@@ -271,12 +272,12 @@ describeIfSupportedEnv()('native_modules.rb', () => {
       runConfig.dependencyConfig.dependencies[
         'ios-dep'
       ].platforms.ios.scriptPhases = [
-        {
-          path: './some_shell_script.sh',
-          name: 'My Name',
-          execution_position: 'before_compile',
-        },
-      ];
+          {
+            path: './some_shell_script.sh',
+            name: 'My Name',
+            execution_position: 'before_compile',
+          },
+        ];
       return run(runConfig).then((rootTargetDefinition: TargetDefinition) => {
         expect(rootTargetDefinition.children[0].script_phases)
           .toMatchInlineSnapshot(`

--- a/packages/platform-ios/src/config/__tests__/native_modules.test.ts
+++ b/packages/platform-ios/src/config/__tests__/native_modules.test.ts
@@ -5,7 +5,7 @@ import hasbin from 'hasbin';
 
 const SCRIPT_PATH = path.resolve(__dirname, '../../../native_modules.rb');
 const FIXTURES_ROOT = path.resolve(__dirname, '../__fixtures__/native_modules');
-const REACT_NATIVE_ROOT = '/root/app/node_modules/react_native';
+const REACT_NATIVE_ROOT = '/root/app/node_modules/react-native';
 
 interface Dependency {
   path: string;
@@ -114,7 +114,7 @@ describeIfSupportedEnv()('native_modules.rb', () => {
   beforeEach(() => {
     runConfig = {
       dependencyConfig: {
-        reactNativePath: '/root/app/node_modules/react_native',
+        reactNativePath: REACT_NATIVE_ROOT,
         project: {ios: {sourceDir: FIXTURES_ROOT}},
         dependencies: {
           'android-dep': {


### PR DESCRIPTION
Summary:
---------

Small regression introduced by a previous change to the file. `reactNativePath` is absolute (as returned by the CLI configuration) in order to be used in various places.

The path used by `Podfile` has to be relative to its location, hence the change. I am leaving the object as a return value to avoid changing RN files and make it easy to customize in the future.

Context: The output of running `use_native_modules` is used here: https://github.com/facebook/react-native/tree/master/template/ios/Podfile#L9
