### PR TITLE
Fix options object bug on healthchecks

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/index.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/index.ts
@@ -22,7 +22,7 @@ type Options = {
   contributor: boolean | void;
 };
 
-export const getHealthchecks = ({contributor}: Options): Healthchecks => ({
+export const getHealthchecks = (options: Options): Healthchecks => ({
   common: {
     label: 'Common',
     healthchecks: [
@@ -40,7 +40,7 @@ export const getHealthchecks = ({contributor}: Options): Healthchecks => ({
       androidStudio,
       androidSDK,
       androidHomeEnvVariable,
-      ...(contributor ? [androidNDK] : []),
+      ...((options && options.contributor) ? [androidNDK] : []),
     ],
   },
   ...(process.platform === 'darwin'


### PR DESCRIPTION
Closes #1190

Summary:
---------

Fixes a bug where the options object may be null.


Test Plan:
----------

Was having the issue and ran locally and it fixed the problem for me.