### PR TITLE
chore: improve desc of `--version` option in `init` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -154,7 +154,7 @@ Initialize a new React Native project named <projectName> in a directory of the 
 
 #### `--version [string]`
 
-Uses a valid semver version of React Native as a template.
+Shortcut for `--template react-native@version`.
 
 #### `--directory [string]`
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -9,7 +9,7 @@ export default {
   options: [
     {
       name: '--version [string]',
-      description: 'Uses a valid semver version of React Native as a template',
+      description: 'Shortcut for `--template react-native@version`',
     },
     {
       name: '--template [string]',


### PR DESCRIPTION
Summary:
---------

I got a bit confused while reviewing https://github.com/react-native-community/cli/pull/1110, so decided to propose some description updates.

