### PR TITLE
Add windows logic to guess the users preferred editor for launchEditor

### DIFF
--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -155,13 +155,13 @@ function guessEditor() {
 
 function printInstructions(title: string) {
   const WINDOWS_FIXIT_INSTRUCTIONS = [
-    'To set it up, you can run something like "SETX REACT_EDITOR code"',
-    'which will set the environment variable in future shells,',
-    'then "SET REACTEDITOR=code" to set it in the current shell',
+    '  To set it up, you can run something like "SETX REACT_EDITOR code"',
+    '  which will set the environment variable in future shells,',
+    '  then "SET REACTEDITOR=code" to set it in the current shell',
   ];
 
   const FIXIT_INSTRUCTIONS = [
-    'To set it up, you can add something like ',
+    '  To set it up, you can add something like ',
     '  export REACT_EDITOR=atom to your ~/.bashrc or ~/.zshrc depending on ',
     '  which shell you use.',
   ];

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -135,8 +135,7 @@ function guessEditor() {
     if (process.platform === 'darwin') {
       const output = execSync('ps x').toString();
       const processNames = Object.keys(COMMON_EDITORS);
-      for (let i = 0; i < processNames.length; i++) {
-        const processName = processNames[i];
+      for (const processName of processNames) {
         if (output.indexOf(processName) !== -1) {
           return [COMMON_EDITORS[processName]];
         }
@@ -146,10 +145,12 @@ function guessEditor() {
         'tasklist /NH /FO CSV /FI "SESSIONNAME ne Services"',
       ).toString();
 
+      const runningProcesses = output
+        .split('\n')
+        .map(line => line.replace(/^"|".*\r$/gm, ''));
       const processNames = Object.keys(COMMON_WINDOWS_EDITORS);
-      for (let i = 0; i < processNames.length; i++) {
-        const processName = processNames[i];
-        if (output.indexOf(processName) !== -1) {
+      for (const processName of processNames) {
+        if (runningProcesses.includes(processName)) {
           return [COMMON_WINDOWS_EDITORS[processName]];
         }
       }

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -236,7 +236,7 @@ function editorWindowsLaunchPath(editor: string) {
     const editorImageNames = Object.keys(COMMON_WINDOWS_EDITORS);
     for (let i = 0; i < editorNames.length; i++) {
       const editorName = editorNames[i];
-      if (editor === editorName) {
+      if (editor.toLowerCase() === editorName.toLowerCase()) {
         // An editor was guessed by guessEditor, but isn't part of the users path
         // Attempt to get the executable location from the running process
         const output = execSync(

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -202,12 +202,9 @@ function findRootForFile(
 
 // On windows, find the editor executable path even if its not in the users path
 function editorWindowsLaunchPath(editor: string) {
-  try {
-    execSync(`dir "${editor}"`, {stdio: 'ignore'});
+  if (fs.existsSync(editor)) {
     // Editor is a full path to an exe, we can just launch it
     return editor;
-  } catch (error) {
-    // ignore
   }
 
   try {

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -239,7 +239,9 @@ function editorWindowsLaunchPath(editor: string) {
         const pid = parseInt(results[1].replace(/^"|"$/gm, ''), 10);
         return execSync(
           `powershell (Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").ExecutablePath`,
-        ).toString();
+        )
+          .toString()
+          .trim();
       }
     }
   } catch (error) {

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -110,7 +110,7 @@ function getArgumentsForLineNumber(
 function getArgumentsForFileName(
   editor: string,
   fileName: string,
-  workspace: string,
+  workspace: any,
 ) {
   switch (path.basename(editor)) {
     case 'code':

--- a/packages/tools/src/launchEditor.ts
+++ b/packages/tools/src/launchEditor.ts
@@ -107,6 +107,22 @@ function getArgumentsForLineNumber(
   }
 }
 
+function getArgumentsForFileName(
+  editor: string,
+  fileName: string,
+  workspace: string,
+) {
+  switch (path.basename(editor)) {
+    case 'code':
+      return addWorkspaceToArgumentsIfExists([fileName], workspace);
+    case 'devenv':
+      return ['/EDIT', fileName];
+    // Every other editor just takes the filename as an argument
+    default:
+      return [fileName];
+  }
+}
+
 function guessEditor() {
   // Explicit config always wins
   if (process.env.REACT_EDITOR) {
@@ -245,7 +261,8 @@ function editorWindowsLaunchPath(editor: string) {
     // ignore
   }
 
-  // Just use what the user specified.. it'll probably fail, but we'll show some help text when we fail to launch it
+  // Just use what the user specified, it will probably fail,
+  // but we will show some help text when it fails.
   return editor;
 }
 
@@ -277,7 +294,7 @@ function launchEditor(
       getArgumentsForLineNumber(editor, fileName, lineNumber, workspace),
     );
   } else {
-    args.push(fileName);
+    args = args.concat(getArgumentsForFileName(editor, fileName, workspace));
   }
 
   // cmd.exe on Windows is vulnerable to RCE attacks given a file name of the


### PR DESCRIPTION
Summary:
---------

There is logic for guessing an appropriate text editor on macOS.  This adds similar logic for windows.  Without this, developers have to manually set the `REACT_EDITOR` environment variable in order to navigate to code from redbox/logbox.

This change roughly aligns with the logic on macOS.  If `REACT_EDITOR` is set we default to using that.  But if the developer is running in order VSCode, SublimeText, Visual Studio, or lastly notepad, then we assume that we should use that editor.

Also fixed an issue where if the linenumber wasn't specified, the workspace would not be passed to vscode, which could cause the file to open in the incorrect vscode window.

Test Plan:
----------

Tested locally on windows with these apps running  / not running or `REACT_EDITOR` set, and clicking on a stack from within a logbox.
