### PR TITLE
[Windows] Use new chrome based edge if the user is already running it

### DIFF
--- a/packages/tools/src/launchDebugger.ts
+++ b/packages/tools/src/launchDebugger.ts
@@ -29,8 +29,22 @@ function getChromeAppName(): string {
   switch (process.platform) {
     case 'darwin':
       return 'google chrome';
-    case 'win32':
+    case 'win32': {
+      const possibleDebuggingApps = ['chrome.exe', 'msedge.exe'];
+      const output = execSync(
+        'tasklist /NH /FO CSV /FI "SESSIONNAME ne Services"',
+      ).toString();
+      const runningProcesses = output
+        .split('\n')
+        .map((line: string) => line.replace(/^"|".*\r$/gm, ''));
+
+      for (const app of possibleDebuggingApps) {
+        if (runningProcesses.includes(app)) {
+          return app;
+        }
+      }
       return 'chrome';
+    }
     case 'linux':
       if (commandExistsUnixSync('google-chrome')) {
         return 'google-chrome';


### PR DESCRIPTION
On windows, use new chromium based edge if the user is already running it, and is not running chrome

Summary:
---------

I'm still leaving the default as chrome on windows machines.  But if the user is using msedge, and not using chrome, then that will be used instead.

The debugging experience is basically the same with msedge and chrome.  Since windows already has edge, there is no need for users to install chrome to get a good developer experience.  This change makes the CLI use msedge if its running rather than prompting the user to install chrome.

I didn't go farther and change the default to use msedge unless we detect its running, as not all windows machines have it installed.

Test Plan:
----------

Validated on windows with and without chrome/edge running.  If chrome is running it'll use chrome.  If just chromium edge is running it'll use edge.  If neither are running it'll attempt to run chrome, and if that fails still notify the user that they should install chrome and launch the users default browser.

