### PR TITLE
Make run-android work properly on Linux

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -325,15 +325,16 @@ function startServerInNewWindow(
   }
   if (process.platform === 'linux') {
     // Awaiting this causes the CLI to hang indefinitely, so this must execute without .sync.
-    const process = execa(terminal, ['-e', 'sh', launchPackagerScript], {
+    return execa(terminal, ['-e', 'sh', launchPackagerScript], {
       ...procConfig,
       detached: true,
-    });
-
-    return process.catch(_ => {
+    }).catch(_ => {
       // If the terminal could not be opened, fall back to running it inside the process.
       const processSh = execa('sh', [launchPackagerScript], procConfig);
+
+      // Unreference the process to avoid quitting when run-android is done.
       processSh.unref();
+
       return processSh;
     });
   }

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -329,7 +329,7 @@ async function startServerInNewWindow(
         ...procConfig,
         detached: true,
       });
-    } catch (_) {
+    } catch {
       logger.error(
         `Could not open terminal ${terminal}. Falling back to running the packager inside the process.`,
       );


### PR DESCRIPTION
Summary:
---------

Some terminals did not start when `react-native run-android` was called, because they expect the arguments to not be quoted. This is defined in e.g. xterm, but xterm does not care. Some other terminals however, like alacritty and rxvt-unicode, do care, and will crash with an error.

execa was called synchronously, which didn't allow the command to continue building and running the Android app. This was already fixed by the Windows command by removing .sync, so I did the same for Linux. macOS does not need this, because `open` quits immediately after opening the terminal.

Since `.sync` is not used on the execa call, the error also does not get caught in the try-catch. This was fixed by using a Promise-style `.catch` on the returned value.


<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

- Build react-native-cli: `yarn build`
- Link into a react-native project: `yarn link "@react-native-community/cli-platform-ios" "@react-native-community/cli-platform-android" "@react-native-community/cli" "@react-native-community/cli-server-api" "@react-native-community/cli-types" "@react-native-community/cli-tools" "@react-native-community/cli-debugger-ui"`
- Run `yarn android --terminal foo` to test without terminal
- Run `yarn android --terminal xterm` for a terminal that does support -e with a string
- Run `yarn android --terminal alacritty` for one that does not.
