### PR TITLE
fix: proper range on RN peer dep

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "wcwidth": "^1.0.1"
   },
   "peerDependencies": {
-    "react-native": "^0.62.0-rc.0"
+    "react-native": ">=0.62.0-rc.0 <0.64.0"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",


### PR DESCRIPTION
Summary:
---------

v4 supports both 0.62 and 0.63.


Test Plan:
----------

No peer dep warning
