### PR TITLE
fix: 🐛 executableFolderPath to run app name in iOS 14.0

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -373,18 +373,22 @@ function bootSimulator(selectedSimulator: Device) {
   }
 }
 
-function getTargetBuildDir(buildSettings: string) {
+function getTargetPaths(buildSettings: string) {
   const settings = JSON.parse(buildSettings);
 
   // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
   for (const i in settings) {
     const wrapperExtension = settings[i].buildSettings.WRAPPER_EXTENSION;
+
     if (wrapperExtension === 'app') {
-      return settings[i].buildSettings.TARGET_BUILD_DIR;
+      return {
+        targetBuildDir: settings[i].buildSettings.TARGET_BUILD_DIR,
+        executableFolderPath: settings[i].buildSettings.EXECUTABLE_FOLDER_PATH,
+      };
     }
   }
 
-  return null;
+  return {};
 }
 
 function getBuildPath(
@@ -420,12 +424,17 @@ function getBuildPath(
     ],
     {encoding: 'utf8'},
   );
-  const targetBuildDir = getTargetBuildDir(buildSettings);
+  const {targetBuildDir, executableFolderPath} = getTargetPaths(buildSettings);
+
   if (!targetBuildDir) {
     throw new CLIError('Failed to get the target build directory.');
   }
 
-  return `${targetBuildDir}/${appName}.app`;
+  if (!executableFolderPath) {
+    throw new CLIError('Failed to get the app name.');
+  }
+
+  return `${targetBuildDir}/${executableFolderPath}`;
 }
 
 function getProductName(buildOutput: string) {


### PR DESCRIPTION
Summary:
---------
Fix: https://github.com/react-native-community/cli/issues/1208

This behavior
![image](https://user-images.githubusercontent.com/12778450/89113401-0c28fa00-d447-11ea-9bc9-3cf58378e683.png)

with this envs:
```
PRODUCT_BUNDLE_IDENTIFIER = paz.church;
PRODUCT_NAME = Paz.Church;
```

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

```
 react-native run-ios --simulator="iPhone 11 Pro Max"
error React Native CLI uses autolinking for native dependencies, but the following modules are linked manually:
  - react-native-code-push (to unlink run: "react-native unlink react-native-code-push")
This is likely happening when upgrading React Native from below 0.60 to 0.60 or above. Going forward, you can unlink this dependency via "react-native unlink <dependency>" and it will be included in your app automatically. If a library isn't compatible with autolinking, disregard this message and notify the library maintainers.
Read more about autolinking: https://github.com/react-native-community/cli/blob/master/docs/autolinking.md
info Found Xcode workspace "pazchurch.xcworkspace"
info Building (using "xcodebuild -workspace pazchurch.xcworkspace -configuration Debug -scheme pazchurch -destination id=8A35A779-3306-4EEA-A4C5-EEAF9303C236")
..........................................
wrapperExtension app
info Installing "/Users/emmet/Library/Developer/Xcode/DerivedData/pazchurch-dfffuyvjrmhokibjznhcqhpichmy/Build/Products/Debug-iphonesimulator/Paz.Church.app"
info Launching "paz.church"
success Successfully launched the app on the simulator
```
