### PR TITLE
Fix package name for main activity when appId set

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -21,7 +21,9 @@ function tryLaunchAppOnDevice(
     .filter(Boolean)
     .join('.');
 
-  const activityToLaunch = args.mainActivity.includes(".") ? args.mainActivity : [packageName, args.mainActivity].filter(Boolean).join('.');
+  const activityToLaunch = args.mainActivity.includes('.')
+    ? args.mainActivity
+    : [packageName, args.mainActivity].filter(Boolean).join('.');
 
   try {
     const adbArgs = [

--- a/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -21,13 +21,15 @@ function tryLaunchAppOnDevice(
     .filter(Boolean)
     .join('.');
 
+  const activityToLaunch = args.mainActivity.includes(".") ? args.mainActivity : [packageName, args.mainActivity].filter(Boolean).join('.');
+
   try {
     const adbArgs = [
       'shell',
       'am',
       'start',
       '-n',
-      `${packageNameWithSuffix}/${packageName}.${args.mainActivity}`,
+      `${packageNameWithSuffix}/${activityToLaunch}`,
     ];
     if (device) {
       adbArgs.unshift('-s', device);


### PR DESCRIPTION
Summary:
---------

Working on a white label feature for an app, I ran into an issue where I needed to set the appId differently to the package name and an explicit main activity in a different package.

For example my build.gradle application ID could be `com.test` and the manifest package be `com.test` however my main activity, from a dependency, has been set explicitly set in the manifest as `com.dependency.AnActivity`.

When running:

`react-native run-android --appId com.test --main-activity com.dependency.AnActivity`

the result would be:

`Error: Activity class {com.test/com.packagename.com.dependency.AnActivity} does not exist.`

I have made a small change to allow an explicit main activity with package name set.


Test Plan:
----------

Run similar to `react-native run-android --appId com.test --main-activity com.dependency.AnActivity` and expect the explicit activity to start.

Run `react-native run-android --appId com.test --main-activity AnActivity` and expect the detected package name to be the prefix of the specified activity.



