### PR TITLE
feat: shorter binary alias (#1247)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
     "access": "public"
   },
   "bin": {
+    "rn": "build/bin.js",
     "react-native": "build/bin.js"
   },
   "files": [


### PR DESCRIPTION
Summary:
---------

Closes #1247

Adds a shorter binary alias as proposed in the above issue.

Test Plan:
----------
- Verify that `npx rn init` works correctly
- Verify that `npx react-native init` still works
- Verify that `rn start`, `rn run-ios`, `rn run-android` and all other cli commands work
- Verify that `react-native start`, `react-native run-ios`, `react-native run-android` and all other existing cli commands still work