### PR TITLE
feat: improve progress indicator for iOS builds without xcpretty

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -328,7 +328,7 @@ function buildProject(
           logger.debug(stringData);
         } else {
           loader.start(
-            `Building your app${'.'.repeat(buildOutput.length % 10)}`,
+            `Building the app${'.'.repeat(buildOutput.length % 10)}`,
           );
         }
       }


### PR DESCRIPTION
Summary:
---------
Hey,
So I had a look at #963 and switched out the dots for an Ora spinner and a message about building the app. 

The spinner on its own didn't make much sense as for the initial build, which can take up more time, it could give the wrong impression that the build hang. To remedy that I opted for a build message with a few dots, which clearly indicates that it's running the process.

note: This is only visible if the user doesn't have `xcpretty` installed, otherwise the output is formatted through it.

![build indicator](https://user-images.githubusercontent.com/32240132/90874181-a40f6900-e39f-11ea-9fd3-46b67338c77d.gif)

Fixes  #963

Let me know that you think, thanks!

Test Plan:
----------
- tested with and without `xcpretty` installed.
- ran for the initial build and subsequent ones.
- ran all the tests and eslint

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
