### PR TITLE
Just use the users default browser

### DIFF
--- a/packages/tools/src/launchDebugger.ts
+++ b/packages/tools/src/launchDebugger.ts
@@ -7,74 +7,10 @@
  * @format
  */
 
-import open from 'open';
-import {execSync} from 'child_process';
-import logger from './logger';
 import launchDefaultBrowser from './launchDefaultBrowser';
-import chalk from 'chalk';
-
-function commandExistsUnixSync(commandName: string) {
-  try {
-    const stdout = execSync(
-      `command -v ${commandName} 2>/dev/null` +
-        ` && { echo >&1 '${commandName} found'; exit 0; }`,
-    );
-    return !!stdout;
-  } catch (error) {
-    return false;
-  }
-}
-
-function getChromeAppName(): string {
-  switch (process.platform) {
-    case 'darwin':
-      return 'google chrome';
-    case 'win32': {
-      const possibleDebuggingApps = ['chrome.exe', 'msedge.exe'];
-      const output = execSync(
-        'tasklist /NH /FO CSV /FI "SESSIONNAME ne Services"',
-      ).toString();
-      const runningProcesses = output
-        .split('\n')
-        .map((line: string) => line.replace(/^"|".*\r$/gm, ''));
-
-      for (const app of possibleDebuggingApps) {
-        if (runningProcesses.includes(app)) {
-          return app;
-        }
-      }
-      return 'chrome';
-    }
-    case 'linux':
-      if (commandExistsUnixSync('google-chrome')) {
-        return 'google-chrome';
-      }
-      if (commandExistsUnixSync('chromium-browser')) {
-        return 'chromium-browser';
-      }
-      return 'chromium';
-
-    default:
-      return 'google-chrome';
-  }
-}
-
-function launchChrome(url: string) {
-  return open(url, {app: [getChromeAppName()], wait: true});
-}
 
 async function launchDebugger(url: string) {
-  try {
-    await launchChrome(url);
-  } catch (error) {
-    logger.debug(error);
-    logger.info(
-      `For a better debugging experience please install Google Chrome from: ${chalk.underline.dim(
-        'https://www.google.com/chrome/',
-      )}`,
-    );
-    launchDefaultBrowser(url);
-  }
+  return launchDefaultBrowser(url);
 }
 
 export default launchDebugger;


### PR DESCRIPTION
Summary:
---------

Currently the CLI has a bunch of messy code to try to force the usage of chrome, then if that fails we use the default browser.  This removes that code and just always uses the users default browser.


Test Plan:
----------

Tested locally on my box.  (Windows machine - msedge default).  The code being run isn't new code, as its run when a user doesn't have chrome installed so it should work ok.