### PR TITLE
Allow runserver on a different port than 8081

### DIFF
--- a/packages/cli/src/commands/start/runServer.ts
+++ b/packages/cli/src/commands/start/runServer.ts
@@ -91,6 +91,7 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
 
   const serverInstance = await Metro.runServer(metroConfig, {
     host: args.host,
+    port: metroConfig.server.port,
     secure: args.https,
     secureCert: args.cert,
     secureKey: args.key,


### PR DESCRIPTION
Fix #1259 
