### PR TITLE
feat: augment `info` with out of tree platform packages info

### DIFF
--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -20,6 +20,7 @@ async function getEnvironmentInfo(
   let packages = ['react', 'react-native', '@react-native-community/cli'];
 
   const outOfTreePlatforms: {[key: string]: string} = {
+    darwin: 'react-native-macos',
     win32: 'react-native-windows',
   };
 

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -24,7 +24,7 @@ async function getEnvironmentInfo(
     win32: 'react-native-windows',
   };
 
-  const outOfTreePlatformPackage: any = outOfTreePlatforms[platform()];
+  const outOfTreePlatformPackage = outOfTreePlatforms[platform()];
   if (outOfTreePlatformPackage) {
     packages.push(outOfTreePlatformPackage);
   }

--- a/packages/cli/src/tools/envinfo.ts
+++ b/packages/cli/src/tools/envinfo.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import envinfo from 'envinfo';
 import {EnvironmentInfo} from '../commands/doctor/types';
+import {platform} from 'os';
 
 /**
  * Returns information about the running system.
@@ -16,6 +17,17 @@ async function getEnvironmentInfo(
 ): Promise<string | EnvironmentInfo> {
   const options = {json, showNotFound: true};
 
+  let packages = ['react', 'react-native', '@react-native-community/cli'];
+
+  const outOfTreePlatforms: {[key: string]: string} = {
+    win32: 'react-native-windows',
+  };
+
+  const outOfTreePlatformPackage: any = outOfTreePlatforms[platform()];
+  if (outOfTreePlatformPackage) {
+    packages.push(outOfTreePlatformPackage);
+  }
+
   const info = (await envinfo.run(
     {
       System: ['OS', 'CPU', 'Memory', 'Shell'],
@@ -24,7 +36,7 @@ async function getEnvironmentInfo(
       Managers: ['CocoaPods'],
       Languages: ['Java', 'Python'],
       SDKs: ['iOS SDK', 'Android SDK', 'Windows SDK'],
-      npmPackages: ['react', 'react-native', '@react-native-community/cli'],
+      npmPackages: packages,
       npmGlobalPackages: ['*react-native*'],
     },
     options,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3455,14 +3455,6 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"


### PR DESCRIPTION
Summary:
---------

This PR will enable out of tree platforms to report their npm packages in `react-native info`


Test Plan:
----------

Verified that running the built JS on a react-native-windows app correctly reports the react-native-windows package too.
![image](https://user-images.githubusercontent.com/22989529/92340069-db536a80-f06d-11ea-99c0-b798393dcd1b.png)

Verified that changing the mapping to not include win32 (so that platform never matches it) correctly does not report it.