### PR TITLE
chore: remove await in getLatestFile function call from downloadProfile file.

### DIFF
--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -52,7 +52,7 @@ export async function downloadProfile(
     const packageName = getPackageName(androidProject);
 
     // If file name is not specified, pull the latest file from device
-    const file = filename || (getLatestFile(packageName));
+    const file = filename || getLatestFile(packageName);
     if (!file) {
       throw new CLIError(
         'There is no file in the cache/ directory. Did you record a profile from the developer menu?',

--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -52,7 +52,7 @@ export async function downloadProfile(
     const packageName = getPackageName(androidProject);
 
     // If file name is not specified, pull the latest file from device
-    const file = filename || (await getLatestFile(packageName));
+    const file = filename || (getLatestFile(packageName));
     if (!file) {
       throw new CLIError(
         'There is no file in the cache/ directory. Did you record a profile from the developer menu?',


### PR DESCRIPTION
Summary:
---------
this PR remove await in `getLatestFile `  call function from `packages/src/cli-hermes/profileHermes/downloadProfile.ts` it has no effect this function. 
