### PR TITLE
The keyword error gives a misleading message when the keyword is not "React"

### DIFF
--- a/packages/cli/src/commands/init/errors/ReservedNameError.ts
+++ b/packages/cli/src/commands/init/errors/ReservedNameError.ts
@@ -1,5 +1,5 @@
 export default class ReservedNameError extends Error {
-  constructor(name: string) {
+  constructor(name: string = 'React') {
     super(
       `Not a valid name for a project. Please do not use the reserved word "${name}".`,
     );

--- a/packages/cli/src/commands/init/errors/ReservedNameError.ts
+++ b/packages/cli/src/commands/init/errors/ReservedNameError.ts
@@ -1,5 +1,5 @@
 export default class ReservedNameError extends Error {
-  constructor(name: string = 'React') {
+  constructor(name: string) {
     super(
       `Not a valid name for a project. Please do not use the reserved word "${name}".`,
     );

--- a/packages/cli/src/commands/init/errors/ReservedNameError.ts
+++ b/packages/cli/src/commands/init/errors/ReservedNameError.ts
@@ -1,7 +1,7 @@
 export default class ReservedNameError extends Error {
-  constructor() {
+  constructor(name: string) {
     super(
-      'Not a valid name for a project. Please do not use the reserved word "React".',
+      `Not a valid name for a project. Please do not use the reserved word "${name}".`,
     );
   }
 }

--- a/packages/cli/src/commands/init/validate.ts
+++ b/packages/cli/src/commands/init/validate.ts
@@ -67,7 +67,7 @@ export function validateProjectName(name: string) {
 
   const lowerCaseName = name.toLowerCase();
   if (reservedNames.includes(lowerCaseName)) {
-    throw new ReservedNameError();
+    throw new ReservedNameError(lowerCaseName);
   }
 
   if (name.match(/helloworld/gi)) {


### PR DESCRIPTION
Summary:
---------

to be a valid project name the name must not be a keyword, currently the error being thrown will claim the user tried using "React" as the project name even if they used another keyword.


Test Plan:
----------
There is already a test that check the error is created correctly, we can add a test with another keyword but I don't think that is needed.

There are two commits in this PR, the second one can be dropped if we don't consider the error class part of the public API since we only use the class in one place and in that place I added the new parameter.
