### PR TITLE
Provide bundler host & port to the custom debugger

### DIFF
--- a/packages/cli-server-api/src/devToolsMiddleware.ts
+++ b/packages/cli-server-api/src/devToolsMiddleware.ts
@@ -8,13 +8,8 @@ import http from 'http';
 import {launchDebugger, logger} from '@react-native-community/cli-tools';
 import {exec} from 'child_process';
 
-function launchDefaultDebugger(
-  host: string | undefined,
-  port: number,
-  args = '',
-) {
-  const hostname = host || 'localhost';
-  const debuggerURL = `http://${hostname}:${port}/debugger-ui${args}`;
+function launchDefaultDebugger(host: string, port: number, args = '') {
+  const debuggerURL = `http://${host}:${port}/debugger-ui${args}`;
   logger.info('Launching Dev Tools...');
   launchDebugger(debuggerURL);
 }
@@ -34,13 +29,14 @@ function launchDevTools(
   {host, port, watchFolders}: LaunchDevToolsOptions,
   isDebuggerConnected: () => boolean,
 ) {
+  const hostname = host ?? 'localhost';
   // Explicit config always wins
   const customDebugger = process.env.REACT_DEBUGGER;
   if (customDebugger) {
-    startCustomDebugger({watchFolders, customDebugger, host, port});
+    startCustomDebugger({watchFolders, customDebugger, host: hostname, port});
   } else if (!isDebuggerConnected()) {
     // Debugger is not yet open; we need to open a session
-    launchDefaultDebugger(host, port);
+    launchDefaultDebugger(hostname, port);
   }
 }
 
@@ -52,10 +48,9 @@ function startCustomDebugger({
 }: {
   watchFolders: ReadonlyArray<string>;
   customDebugger: string;
-  host: string | undefined;
+  host: string;
   port: number;
 }) {
-  const hostname = host || 'localhost';
   const folders = watchFolders.map(escapePath).join(' ');
   const command = `${customDebugger} ${folders}`;
   logger.info('Starting custom debugger by executing:', command);
@@ -64,7 +59,7 @@ function startCustomDebugger({
     {
       env: {
         ...process.env,
-        REACT_BUNDLER_HOST: hostname,
+        REACT_BUNDLER_HOST: host,
         REACT_BUNDLER_PORT: `${port}`,
       },
     },


### PR DESCRIPTION
Summary:
---------

The `REACT_DEBUGGER` env variable allows a custom debugger to be used instead of the default Chrome debugger. So because I prefer React Native Debugger over Chrome I set `REACT_DEBUGGER` to `rndebugger-open --open --port 8081` in my shells profile.

This isn't ideal, because the port number is just a guess: e.g. expo uses a different port. It would be great if the middleware could pass this information to the debugger.

Because of this this PR introduces two new environment variables which it passes to the custom debugger to prevent them from having to guess.

- `REACT_BUNDLER_HOST` which is the the host where the bundler to debug runs (e.g. localhost)
- `REACT_BUNDLER_PORT` is the port (e.g. 8081)

This will allow the user to change their `REACT_DEBUGGER` script to pass the correct port to their debugger. Ideally the authors of the debugger could adopt over time and evaluate this variable directly.

Test Plan:
----------

I need to make sure that
- all the existing environment variable are being passed to the custom debugger like before
- my new environment variables are passed to the custom debugger as expected

I set my REACT_DEBUGGER env var to `rndebugger-test` and wrote a script rndebugger-test that dumps all env variables to a file so I can verify everything is there:
```
#!/bin/sh

env > /tmp/rndebugger-env-dump
```

Then I verified manually that
- the expected env vars are set correctly
- all the other env vars are still passed as expected