### PR TITLE
chore: bump joi types to 17

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,7 @@
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.3",
-    "@types/hapi__joi": "^15.0.4",
+    "@types/hapi__joi": "^17.1.6",
     "@types/lodash": "^4.14.149",
     "@types/minimist": "^1.2.0",
     "@types/mkdirp": "^0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2316,17 +2316,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/hapi__joi@*":
-  version "16.0.12"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-16.0.12.tgz#fb9113f17cf5764d6b3586ae9817d1606cc7c90c"
-  integrity sha512-xJYifuz59jXdWY5JMS15uvA3ycS3nQYOGqoIIE0+fwQ0qI3/4CxBc6RHsOTp6wk9M0NWEdpcTl02lOQOKMifbQ==
-
-"@types/hapi__joi@^15.0.4":
-  version "15.0.4"
-  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-15.0.4.tgz#49e2e1e6da15ade0fdd6db4daf94aecb07bb391b"
-  integrity sha512-VSS6zc7AIOdHVXmqKaGNPYl8eGrMvWi0R5pt3evJL3UdxO8XS28/XAkBXNyLQoymHxhMd4bF3o1U9mZkWDeN8w==
-  dependencies:
-    "@types/hapi__joi" "*"
+"@types/hapi__joi@^17.1.6":
+  version "17.1.6"
+  resolved "https://registry.yarnpkg.com/@types/hapi__joi/-/hapi__joi-17.1.6.tgz#b84663676aa9753c17183718338dd40ddcbd3754"
+  integrity sha512-y3A1MzNC0FmzD5+ys59RziE1WqKrL13nxtJgrSzjoO7boue5B7zZD2nZLPwrSuUviFjpKFQtgHYSvhDGfIE4jA==
 
 "@types/ip@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
Summary:
---------

Refs: #1244

This PR bumps Joi types package to match used Joi version. New types are still available under org scoped `hapi__joi`, the `joi` types package stops at 14 release.

Test Plan:
----------

Successful `yarn install` run!
