### PR TITLE
chore: bump Node types to match supported Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/glob": "^7.1.1",
     "@types/jest": "^25.1.4",
     "@types/mkdirp": "^0.5.2",
-    "@types/node": "^8.0.0",
+    "@types/node": "^10.0.0",
     "@types/node-fetch": "^2.3.7",
     "babel-jest": "^25.2.4",
     "babel-plugin-module-resolver": "^3.2.0",
@@ -58,6 +58,6 @@
   },
   "resolutions": {
     "mkdirp": "^0.5.3",
-    "@types/node": "^8.0.0"
+    "@types/node": "^10.0.0"
   }
 }

--- a/packages/cli/src/commands/start/watchMode.ts
+++ b/packages/cli/src/commands/start/watchMode.ts
@@ -39,7 +39,7 @@ function enableWatchMode(messageSocket: any) {
           process.exit();
           break;
         case 'z':
-          process.emit('SIGTSTP');
+          process.emit('SIGTSTP', 'SIGTSTP');
           break;
       }
     } else if (name === 'r') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2413,10 +2413,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@>= 8", "@types/node@^8.0.0":
-  version "8.10.59"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.59.tgz#9e34261f30183f9777017a13d185dfac6b899e04"
-  integrity sha512-8RkBivJrDCyPpBXhVZcjh7cQxVBSmRk9QM7hOketZzp6Tg79c0N8kkpAIito9bnJ3HCVCHVYz+KHTEbfQNfeVQ==
+"@types/node@*", "@types/node@>= 8", "@types/node@^10.0.0":
+  version "10.17.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.35.tgz#58058f29b870e6ae57b20e4f6e928f02b7129f56"
+  integrity sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==
 
 "@types/plist@^3.0.2":
   version "3.0.2"


### PR DESCRIPTION
Summary:
---------

Refs: #1072

This small PR bumps the Node types package (`@types/node`) to the `10.0.0` version to match the current [minimal supported version](https://github.com/react-native-community/cli/blob/master/packages/cli/package.json#L21) of Node required for the CLI.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Successful `yarn install` run!