### PR TITLE
chore: update description for ios simulator

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -537,8 +537,8 @@ export default {
   func: runIOS,
   examples: [
     {
-      desc: 'Run on a different simulator, e.g. iPhone SE',
-      cmd: 'react-native run-ios --simulator "iPhone SE"',
+      desc: 'Run on a different simulator, e.g. iPhone SE (1st generation)',
+      cmd: 'react-native run-ios --simulator "iPhone SE (1st generation)"',
     },
     {
       desc: 'Pass a non-standard location of iOS directory',


### PR DESCRIPTION

this PR update iOS description for `iPhone SE`, We have to specify the generation for the `iPhone SE` simulator.