### PR TITLE
chore: adjust run instruction based on the user platform

### DIFF
--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -9,39 +9,63 @@
 
 import path from 'path';
 import fs from 'fs';
+import process from 'process';
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 
 function printRunInstructions(projectDir: string, projectName: string) {
-  const iosProjectDir = path.resolve(projectDir, 'ios');
-  const iosPodsFile = path.resolve(iosProjectDir, `${projectName}.xcworkspace`);
-  const isUsingPods = fs.existsSync(iosPodsFile);
+  let iosInstructions;
+  let desktopInstructions;
 
-  const relativeXcodeProjectPath = path.relative(
-    '..',
-    isUsingPods
-      ? iosPodsFile
-      : path.resolve(iosProjectDir, `${projectName}.xcodeproj`),
-  );
+  if (process.platform === 'darwin') {
+    const iosProjectDir = path.resolve(projectDir, 'ios');
+    const iosPodsFile = path.resolve(
+      iosProjectDir,
+      `${projectName}.xcworkspace`,
+    );
+    const isUsingPods = fs.existsSync(iosPodsFile);
 
-  logger.log(`
-  ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-    • cd "${projectDir}" && npx react-native run-ios
+    const relativeXcodeProjectPath = path.relative(
+      '..',
+      isUsingPods
+        ? iosPodsFile
+        : path.resolve(iosProjectDir, `${projectName}.xcodeproj`),
+    );
+
+    iosInstructions = `
+    ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
+      • cd "${projectDir}" && npx react-native run-ios
     ${chalk.dim('- or -')}
-    • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
-    • Hit the Run button
+      • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
+      • Hit the Run button
+    `;
 
+    desktopInstructions = `
+    ${chalk.magenta(`Run instructions for ${chalk.bold('macOS')}`)}:
+    • See ${chalk.underline(
+      'https://microsoft.github.io/react-native-windows/docs/rnm-getting-started',
+    )} for the latest up-to-date instructions.
+    `;
+  }
+
+  if (process.platform === 'win32') {
+    desktopInstructions = `
+    ${chalk.magenta(`Run instructions for ${chalk.bold('Windows')}`)}:
+    • See ${chalk.underline(
+      'https://microsoft.github.io/react-native-windows/docs/getting-started',
+    )} for the latest up-to-date instructions.
+    `;
+  }
+
+  const androidInstructions = `
   ${chalk.green(`Run instructions for ${chalk.bold('Android')}`)}:
     • Have an Android emulator running (quickest way to get started), or a device connected.
     • cd "${projectDir}" && npx react-native run-android
+  `;
 
-  ${chalk.magenta(
-    `Run instructions for ${chalk.bold('Windows')} and ${chalk.bold('macOS')}`,
-  )}:
-    • See ${chalk.underline(
-      'https://aka.ms/ReactNative',
-    )} for the latest up-to-date instructions.
-`);
+  logger.log(`
+  ${androidInstructions}${iosInstructions}${desktopInstructions}
+  `);
 }
 
 export default printRunInstructions;

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -50,7 +50,7 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
   if (process.platform === 'win32') {
     desktopInstructions = `
-  ${chalk.magenta(`Run instructions for ${chalk.bold('Windows')}`)}:
+  ${chalk.cyan(`Run instructions for ${chalk.bold('Windows')}`)}:
     • See ${chalk.underline(
       'https://aka.ms/ReactNativeGuideWindows',
     )} for the latest up-to-date instructions.

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -35,7 +35,7 @@ function printRunInstructions(projectDir: string, projectName: string) {
     iosInstructions = `
   ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
     • cd "${projectDir}" && npx react-native run-ios
-  ${chalk.dim('- or -')}
+    ${chalk.dim('- or -')}
     • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
     • Hit the Run button
     `;

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -14,8 +14,8 @@ import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 
 function printRunInstructions(projectDir: string, projectName: string) {
-  let iosInstructions;
-  let desktopInstructions;
+  let iosInstructions = '';
+  let desktopInstructions = '';
 
   if (process.platform === 'darwin') {
     const iosProjectDir = path.resolve(projectDir, 'ios');

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -33,15 +33,15 @@ function printRunInstructions(projectDir: string, projectName: string) {
     );
 
     iosInstructions = `
-    ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-      • cd "${projectDir}" && npx react-native run-ios
-    ${chalk.dim('- or -')}
-      • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
-      • Hit the Run button
+  ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
+    • cd "${projectDir}" && npx react-native run-ios
+  ${chalk.dim('- or -')}
+    • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
+    • Hit the Run button
     `;
 
     desktopInstructions = `
-    ${chalk.magenta(`Run instructions for ${chalk.bold('macOS')}`)}:
+  ${chalk.magenta(`Run instructions for ${chalk.bold('macOS')}`)}:
     • See ${chalk.underline(
       'https://microsoft.github.io/react-native-windows/docs/rnm-getting-started',
     )} for the latest up-to-date instructions.
@@ -50,7 +50,7 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
   if (process.platform === 'win32') {
     desktopInstructions = `
-    ${chalk.magenta(`Run instructions for ${chalk.bold('Windows')}`)}:
+  ${chalk.magenta(`Run instructions for ${chalk.bold('Windows')}`)}:
     • See ${chalk.underline(
       'https://microsoft.github.io/react-native-windows/docs/getting-started',
     )} for the latest up-to-date instructions.

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -43,7 +43,7 @@ function printRunInstructions(projectDir: string, projectName: string) {
     desktopInstructions = `
   ${chalk.magenta(`Run instructions for ${chalk.bold('macOS')}`)}:
     • See ${chalk.underline(
-      'https://microsoft.github.io/react-native-windows/docs/rnm-getting-started',
+      'https://aka.ms/ReactNativeGuideMacOS',
     )} for the latest up-to-date instructions.
     `;
   }
@@ -52,7 +52,7 @@ function printRunInstructions(projectDir: string, projectName: string) {
     desktopInstructions = `
   ${chalk.magenta(`Run instructions for ${chalk.bold('Windows')}`)}:
     • See ${chalk.underline(
-      'https://microsoft.github.io/react-native-windows/docs/getting-started',
+      'https://aka.ms/ReactNativeGuideWindows',
     )} for the latest up-to-date instructions.
     `;
   }


### PR DESCRIPTION
Summary:
---------

This PR adjust the run instructions printed at the end of `init` command run which now should show only valid targets for the user platform. I have also updated the links for the desktop forks from MS to lead exactly to platform specific guides.

* `iOS` and `macOS` instructions will be only visible on `darwin`
* `Windows` instructions will be only visible on `win32`

Test Plan:
----------

I was trying to test the `init` locally using [Contributing guide](https://github.com/react-native-community/cli/blob/master/CONTRIBUTING.md#testing-init-command), but I have experienced problems and issues after publishing `react-native` master locally. 

One of many problems which leads to `init` termination:
```
error Couldn't find package "@typescript-eslint/experimental-utils@2.34.0" required by "@typescript-eslint/eslint-plugin@^2.25.0" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
Error: Couldn't find package "eslint-plugin-flowtype@2.50.3" required by "@react-native-community/eslint-config@^1.1.0" on the "npm" registry.
    at MessageError.ExtendableBuiltin (/usr/local/Cellar/yarn/1.22.5/libexec/lib/cli.js:721:66)
    at new MessageError (/usr/local/Cellar/yarn/1.22.5/libexec/lib/cli.js:750:123)
    at PackageRequest.<anonymous> (/usr/local/Cellar/yarn/1.22.5/libexec/lib/cli.js:36539:17)
    at Generator.throw (<anonymous>)
    at step (/usr/local/Cellar/yarn/1.22.5/libexec/lib/cli.js:310:30)
    at /usr/local/Cellar/yarn/1.22.5/libexec/lib/cli.js:323:13
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

Please let me know is there any other way to test the `init` command without publishing `react-native` locally.