### PR TITLE
Accept `null` as a platform configuration value.

### DIFF
--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -67,6 +67,7 @@ export const dependencyConfig = t
                 libraryFolder: t.string(),
                 scriptPhases: t.array().items(t.object()),
               })
+              .allow(null)
               .default({}),
             android: t
               .object({
@@ -75,6 +76,7 @@ export const dependencyConfig = t
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
               })
+              .allow(null)
               .default({}),
           })
           .default(),


### PR DESCRIPTION
Summary:
---------

Hey folks.

I've got a tiny little patch here which updates the validation schema for platform specific config in `react-native.config.js` to accept `null` as a value. The official documentation [suggests doing this](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library) in order to disable autolinking, but I've [found out recently](https://github.com/adammcarth/react-native-segmented-picker/issues/28) that this has the unintended consequence of suggesting third party libraries are configured incorrectly whenever developers run `react-native start`.

```shell
$ react-native start --reset-cache

warn Package "<package name>" has been ignored because it contains invalid configuration. Reason: Option dependency.platforms.ios must be a object, instead got object
```

...but despite that error message, I've read the CLI code and it _does_ indeed account for the value being `null` (or at least falsy):

```javascript
// packages/cli/src/tools/config/index.ts:38-42
  dependency[platform] =
    // Linking platforms is not supported
    isPlatform || !platformConfig
      ? null
       : ...
```

So in light of all that, updating the validation schema seemed like the most appropriate fix. Thoughts?

Test Plan:
----------

I've tested this patch using my library which [completely disables autolinking](https://github.com/adammcarth/react-native-segmented-picker/blob/master/react-native.config.js) for the `android` and `ios` platforms.

1. Install the library into a React Native 0.60.0+ project: `yarn add react-native-segmented-picker`.
2. Run `react-native start` and see that you get the configuration warning message reported as per the above screenshot.
3. Install this CLI patch into the project.
4. Re-run `react-native start` and see that you no longer get a warning message.

A small side note: I also tried adding a unit test to capture this validation logic inside of `packages/cli/src/tools/config/__tests__/index-test.ts`, but there was something _very_ strange going on with that file. It only seemed to be running the last 4 tests in the file? It seems like there's a comment in there talking about some of the existing tests being occasionally flakey (one of them is even skipped) - is that potentially related?
