### PR TITLE
feat: allow adding modules only for the specific build type

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -111,7 +111,7 @@ See [`script_phase` options](https://www.rubydoc.info/gems/cocoapods-core/Pod/Po
 
 #### platforms.ios.configurations
 
-An array of build configurations which will include the dependency. If the array is empty, your dependency will be installed in all configurations. If you're working on a helper library, you should set debug as a value, to avoid shipping it as a part of the release process. For more details, see [`build configurations`](https://guides.cocoapods.org/syntax/podfile.html#pod).
+An array of build configurations which will include the dependency. If the array is empty, your dependency will be installed in all configurations. If you're working on a helper library that should only be included in development, such as a replacement for the React Native development menu, you should set this to `['debug']` to avoid shipping the library in a release build. For more details, see [`build configurations`](https://guides.cocoapods.org/syntax/podfile.html#pod).
 
 #### platforms.android.sourceDir
 
@@ -133,7 +133,7 @@ For settings applicable on other platforms, please consult their respective docu
 
 #### platforms.android.buildTypes
 
-An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. If you're working on a helper library, you should set debug as a value, to avoid shipping it as a part of the release process. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
+An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. If you're working on a helper library that should only be included in development, such as a replacement for the React Native development menu, you should set this to `['debug']` to avoid shipping the library in a release build. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
 
 ### assets
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -58,6 +58,7 @@ type DependencyParamsIOST = {
   project?: string;
   podspecPath?: string;
   sharedLibraries?: string[];
+  buildTypes?: string[];
 };
 
 type DependencyParamsAndroidT = {
@@ -65,6 +66,7 @@ type DependencyParamsAndroidT = {
   manifestPath?: string;
   packageImportPath?: string;
   packageInstance?: string;
+  buildTypes?: string[];
 };
 ```
 
@@ -107,6 +109,10 @@ module.exports = {
 
 See [`script_phase` options](https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method) for a full list of available object keys.
 
+#### platforms.ios.buildTypes
+
+An array of build configurations which will include the dependency. If the array is empty, your dependency will be installed in all configurations. For more details, see [`build configurations`](https://guides.cocoapods.org/syntax/podfile.html#pod).
+
 #### platforms.android.sourceDir
 
 A relative path to a folder with Android project (Gradle root project), e.g. `./path/to/custom-android`. By default, CLI searches for `./android` as source dir.
@@ -124,6 +130,10 @@ Custom package import. For example: `import com.acme.AwesomePackage;`.
 Custom syntax to instantiate a package. By default, it's a `new AwesomePackage()`. It can be useful when your package requires additional arguments while initializing.
 
 For settings applicable on other platforms, please consult their respective documentation.
+
+#### platforms.android.buildTypes
+
+An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
 
 ### assets
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -58,7 +58,7 @@ type DependencyParamsIOST = {
   project?: string;
   podspecPath?: string;
   sharedLibraries?: string[];
-  buildTypes?: string[];
+  configurations?: string[];
 };
 
 type DependencyParamsAndroidT = {
@@ -109,9 +109,9 @@ module.exports = {
 
 See [`script_phase` options](https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method) for a full list of available object keys.
 
-#### platforms.ios.buildTypes
+#### platforms.ios.configurations
 
-An array of build configurations which will include the dependency. If the array is empty, your dependency will be installed in all configurations. For more details, see [`build configurations`](https://guides.cocoapods.org/syntax/podfile.html#pod).
+An array of build configurations which will include the dependency. If the array is empty, your dependency will be installed in all configurations. If you're working on a helper library, you should set debug as a value, to avoid shipping it as a part of the release process. For more details, see [`build configurations`](https://guides.cocoapods.org/syntax/podfile.html#pod).
 
 #### platforms.android.sourceDir
 
@@ -133,7 +133,7 @@ For settings applicable on other platforms, please consult their respective docu
 
 #### platforms.android.buildTypes
 
-An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
+An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. If you're working on a helper library, you should set debug as a value, to avoid shipping it as a part of the release process. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
 
 ### assets
 

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -22,6 +22,7 @@ export interface AndroidDependencyConfig {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
+  buildTypes: string[];
 }
 
 export type AndroidDependencyParams = Partial<AndroidDependencyConfig>;

--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -20,7 +20,9 @@ export interface IOSProjectParams {
   scriptPhases?: Array<any>;
 }
 
-export interface IOSDependencyParams extends IOSProjectParams {}
+export interface IOSDependencyParams extends IOSProjectParams {
+  buildTypes?: string[];
+}
 
 // The following types are used in untyped-parts of the codebase, so I am leaving them
 // until we actually need them.
@@ -37,7 +39,9 @@ export interface IOSProjectConfig {
   plist: Array<any>;
 }
 
-export interface IOSDependencyConfig extends IOSProjectConfig {}
+export interface IOSDependencyConfig extends IOSProjectConfig {
+  buildTypes: string[];
+}
 
 /**
  * @see https://www.rubydoc.info/gems/cocoapods-core/Pod/Podfile/DSL#script_phase-instance_method

--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -21,7 +21,7 @@ export interface IOSProjectParams {
 }
 
 export interface IOSDependencyParams extends IOSProjectParams {
-  buildTypes?: string[];
+  configurations?: string[];
 }
 
 // The following types are used in untyped-parts of the codebase, so I am leaving them
@@ -40,7 +40,7 @@ export interface IOSProjectConfig {
 }
 
 export interface IOSDependencyConfig extends IOSProjectConfig {
-  buildTypes: string[];
+  configurations: string[];
 }
 
 /**

--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.ts.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should apply build types from dependency config 1`] = `
+Object {
+  "assets": Array [],
+  "hooks": Object {},
+  "name": "react-native-test",
+  "params": Array [],
+  "platforms": Object {
+    "android": null,
+    "ios": Object {
+      "buildTypes": Array [
+        "debug",
+      ],
+      "folder": "<<REPLACED>>/node_modules/react-native-test",
+      "libraryFolder": "Libraries",
+      "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj",
+      "plist": Array [],
+      "podfile": null,
+      "podspecPath": null,
+      "projectName": "HelloWorld.xcodeproj",
+      "projectPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj",
+      "scriptPhases": Array [],
+      "sharedLibraries": Array [],
+      "sourceDir": "<<REPLACED>>/node_modules/react-native-test/ios",
+    },
+  },
+  "root": "<<REPLACED>>/node_modules/react-native-test",
+}
+`;
+
 exports[`should have a valid structure by default 1`] = `
 Object {
   "assets": Array [],
@@ -37,6 +66,7 @@ Object {
   "platforms": Object {
     "android": null,
     "ios": Object {
+      "buildTypes": Array [],
       "folder": "<<REPLACED>>/node_modules/react-native-test",
       "libraryFolder": "Libraries",
       "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj",
@@ -63,6 +93,7 @@ Object {
   "platforms": Object {
     "android": null,
     "ios": Object {
+      "buildTypes": Array [],
       "folder": "<<REPLACED>>/node_modules/react-native-test",
       "libraryFolder": "Libraries",
       "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/customLocation/customProject.xcodeproj/project.pbxproj",
@@ -101,6 +132,7 @@ Object {
     "platforms": Object {
       "android": null,
       "ios": Object {
+        "buildTypes": Array [],
         "folder": "<<REPLACED>>/node_modules/react-native-test",
         "libraryFolder": "Libraries",
         "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj",
@@ -122,3 +154,32 @@ Object {
 exports[`should skip packages that have invalid configuration: dependencies config 1`] = `Object {}`;
 
 exports[`should skip packages that have invalid configuration: logged warning 1`] = `"Package [1mreact-native[22m has been ignored because it contains invalid configuration. Reason: [2m\\"dependency.invalidProperty\\" is not allowed[22m"`;
+
+exports[`supports dependencies from user configuration with custom build type 1`] = `
+Object {
+  "assets": Array [],
+  "hooks": Object {},
+  "name": "react-native-test",
+  "params": Array [],
+  "platforms": Object {
+    "android": null,
+    "ios": Object {
+      "buildTypes": Array [
+        "custom_build_type",
+      ],
+      "folder": "<<REPLACED>>/node_modules/react-native-test",
+      "libraryFolder": "Libraries",
+      "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj",
+      "plist": Array [],
+      "podfile": null,
+      "podspecPath": null,
+      "projectName": "HelloWorld.xcodeproj",
+      "projectPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj",
+      "scriptPhases": Array [],
+      "sharedLibraries": Array [],
+      "sourceDir": "<<REPLACED>>/node_modules/react-native-test/ios",
+    },
+  },
+  "root": "<<REPLACED>>/node_modules/react-native-test",
+}
+`;

--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.ts.snap
@@ -9,7 +9,7 @@ Object {
   "platforms": Object {
     "android": null,
     "ios": Object {
-      "buildTypes": Array [
+      "configurations": Array [
         "debug",
       ],
       "folder": "<<REPLACED>>/node_modules/react-native-test",
@@ -66,7 +66,7 @@ Object {
   "platforms": Object {
     "android": null,
     "ios": Object {
-      "buildTypes": Array [],
+      "configurations": Array [],
       "folder": "<<REPLACED>>/node_modules/react-native-test",
       "libraryFolder": "Libraries",
       "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj",
@@ -93,7 +93,7 @@ Object {
   "platforms": Object {
     "android": null,
     "ios": Object {
-      "buildTypes": Array [],
+      "configurations": Array [],
       "folder": "<<REPLACED>>/node_modules/react-native-test",
       "libraryFolder": "Libraries",
       "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/customLocation/customProject.xcodeproj/project.pbxproj",
@@ -132,7 +132,7 @@ Object {
     "platforms": Object {
       "android": null,
       "ios": Object {
-        "buildTypes": Array [],
+        "configurations": Array [],
         "folder": "<<REPLACED>>/node_modules/react-native-test",
         "libraryFolder": "Libraries",
         "pbxprojPath": "<<REPLACED>>/node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj",
@@ -164,7 +164,7 @@ Object {
   "platforms": Object {
     "android": null,
     "ios": Object {
-      "buildTypes": Array [
+      "configurations": Array [
         "custom_build_type",
       ],
       "folder": "<<REPLACED>>/node_modules/react-native-test",

--- a/packages/cli/src/tools/config/__tests__/index-test.ts
+++ b/packages/cli/src/tools/config/__tests__/index-test.ts
@@ -268,6 +268,7 @@ module.exports = {
       "platforms": Object {
         "android": null,
         "ios": Object {
+          "buildTypes": Array [],
           "folder": "<<REPLACED>>/native-libs/local-lib",
           "libraryFolder": "Libraries",
           "pbxprojPath": "<<REPLACED>>/native-libs/local-lib/ios/LocalRNLibrary.xcodeproj/project.pbxproj",
@@ -284,4 +285,63 @@ module.exports = {
       "root": "<<REPLACED>>/native-libs/local-lib",
     }
   `);
+});
+
+test('should apply build types from dependency config', () => {
+  writeFiles(DIR, {
+    ...REACT_NATIVE_MOCK,
+    'node_modules/react-native-test/package.json': '{}',
+    'node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj':
+      '',
+    'node_modules/react-native-test/react-native.config.js': `module.exports = {
+      dependency: {
+        platforms: {
+          ios: {
+            buildTypes: ["debug"]
+          }
+        }
+      }
+    }`,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1",
+        "react-native-test": "0.0.1"
+      }
+    }`,
+  });
+  const {dependencies} = loadConfig(DIR);
+  expect(
+    removeString(dependencies['react-native-test'], DIR),
+  ).toMatchSnapshot();
+});
+
+test('supports dependencies from user configuration with custom build type', () => {
+  writeFiles(DIR, {
+    ...REACT_NATIVE_MOCK,
+    'react-native.config.js': `module.exports = {
+  dependencies: {
+    'react-native-test': {
+      platforms: {
+        ios: {
+          buildTypes: ["custom_build_type"]
+        }
+      }
+    },
+  }
+}`,
+    'node_modules/react-native-test/package.json': '{}',
+    'node_modules/react-native-test/ios/HelloWorld.xcodeproj/project.pbxproj':
+      '',
+    'node_modules/react-native-test/react-native.config.js': `module.exports = {}`,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1",
+        "react-native-test": "0.0.1"
+      }
+    }`,
+  });
+  const {dependencies} = loadConfig(DIR);
+  expect(
+    removeString(dependencies['react-native-test'], DIR),
+  ).toMatchSnapshot();
 });

--- a/packages/cli/src/tools/config/__tests__/index-test.ts
+++ b/packages/cli/src/tools/config/__tests__/index-test.ts
@@ -268,7 +268,7 @@ module.exports = {
       "platforms": Object {
         "android": null,
         "ios": Object {
-          "buildTypes": Array [],
+          "configurations": Array [],
           "folder": "<<REPLACED>>/native-libs/local-lib",
           "libraryFolder": "Libraries",
           "pbxprojPath": "<<REPLACED>>/native-libs/local-lib/ios/LocalRNLibrary.xcodeproj/project.pbxproj",
@@ -297,7 +297,7 @@ test('should apply build types from dependency config', () => {
       dependency: {
         platforms: {
           ios: {
-            buildTypes: ["debug"]
+            configurations: ["debug"]
           }
         }
       }
@@ -323,7 +323,7 @@ test('supports dependencies from user configuration with custom build type', () 
     'react-native-test': {
       platforms: {
         ios: {
-          buildTypes: ["custom_build_type"]
+          configurations: ["custom_build_type"]
         }
       }
     },

--- a/packages/cli/src/tools/config/__tests__/index-test.ts
+++ b/packages/cli/src/tools/config/__tests__/index-test.ts
@@ -288,6 +288,7 @@ module.exports = {
 });
 
 test('should apply build types from dependency config', () => {
+  DIR = getTempDirectory('config_test_apply_dependency_config');
   writeFiles(DIR, {
     ...REACT_NATIVE_MOCK,
     'node_modules/react-native-test/package.json': '{}',
@@ -316,6 +317,7 @@ test('should apply build types from dependency config', () => {
 });
 
 test('supports dependencies from user configuration with custom build type', () => {
+  DIR = getTempDirectory('config_test_apply_custom_build_config');
   writeFiles(DIR, {
     ...REACT_NATIVE_MOCK,
     'react-native.config.js': `module.exports = {
@@ -340,6 +342,7 @@ test('supports dependencies from user configuration with custom build type', () 
       }
     }`,
   });
+
   const {dependencies} = loadConfig(DIR);
   expect(
     removeString(dependencies['react-native-test'], DIR),

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -131,6 +131,7 @@ export const projectConfig = t
                 projectName: t.string(),
                 libraryFolder: t.string(),
                 sharedLibraries: t.array().items(t.string()),
+                buildTypes: t.array().items(t.string()).default([]),
               })
               .allow(null),
             android: t
@@ -139,6 +140,7 @@ export const projectConfig = t
                 folder: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
+                buildTypes: t.array().items(t.string()).default([]),
               })
               .allow(null),
           }),

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -66,6 +66,7 @@ export const dependencyConfig = t
                 sharedLibraries: t.array().items(t.string()),
                 libraryFolder: t.string(),
                 scriptPhases: t.array().items(t.object()),
+                buildTypes: t.array().items(t.string()).default([]),
               })
               .default({}),
             android: t
@@ -74,6 +75,7 @@ export const dependencyConfig = t
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
+                buildTypes: t.array().items(t.string()).default([]),
               })
               .default({}),
           })

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -66,7 +66,7 @@ export const dependencyConfig = t
                 sharedLibraries: t.array().items(t.string()),
                 libraryFolder: t.string(),
                 scriptPhases: t.array().items(t.object()),
-                buildTypes: t.array().items(t.string()).default([]),
+                configurations: t.array().items(t.string()).default([]),
               })
               .default({}),
             android: t
@@ -131,7 +131,7 @@ export const projectConfig = t
                 projectName: t.string(),
                 libraryFolder: t.string(),
                 sharedLibraries: t.array().items(t.string()),
-                buildTypes: t.array().items(t.string()).default([]),
+                configurations: t.array().items(t.string()).default([]),
               })
               .allow(null),
             android: t

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -73,6 +73,7 @@ class ReactNativeModules {
   private String packageName
   private File root
   private ArrayList<HashMap<String, String>> reactNativeModules
+  private HashMap<String, ArrayList> reactNativeModulesBuildVariants
 
   private static String LOG_PREFIX = ":ReactNative:"
 
@@ -80,8 +81,9 @@ class ReactNativeModules {
     this.logger = logger
     this.root = root
 
-    def (nativeModules, packageName) = this.getReactNativeConfig()
+    def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
     this.reactNativeModules = nativeModules
+    this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
     this.packageName = packageName
   }
 
@@ -104,8 +106,16 @@ class ReactNativeModules {
     reactNativeModules.forEach { reactNativeModule ->
       def nameCleansed = reactNativeModule["nameCleansed"]
       appProject.dependencies {
-        // TODO(salakar): are other dependency scope methods such as `api` required?
-        implementation project(path: ":${nameCleansed}")
+        if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
+          reactNativeModulesBuildVariants
+            .get(nameCleansed)
+            .forEach { buildVariant ->
+              "${buildVariant}Implementation" project(path: ":${nameCleansed}")
+            }
+        } else {
+          // TODO(salakar): are other dependency scope methods such as `api` required?
+          implementation project(path: ":${nameCleansed}")
+        }
       }
     }
   }
@@ -208,7 +218,8 @@ class ReactNativeModules {
     if (this.reactNativeModules != null) return this.reactNativeModules
 
     ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
-
+    HashMap<String, ArrayList> reactNativeModulesBuildVariants = new HashMap<String, ArrayList>()
+    
     /**
      * Resolve the CLI location from Gradle file
      *
@@ -243,22 +254,26 @@ class ReactNativeModules {
 
       if (androidConfig != null && androidConfig["sourceDir"] != null) {
         this.logger.info("${LOG_PREFIX}Automatically adding native module '${name}'")
-
+        
         HashMap reactNativeModuleConfig = new HashMap<String, String>()
+        def nameCleansed = name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_')
         reactNativeModuleConfig.put("name", name)
-        reactNativeModuleConfig.put("nameCleansed", name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_'))
+        reactNativeModuleConfig.put("nameCleansed", nameCleansed)
         reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
         reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
+        if (!androidConfig["buildTypes"].isEmpty()) {
+          reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
+        }
         this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
-
+        
         reactNativeModules.add(reactNativeModuleConfig)
       } else {
         this.logger.info("${LOG_PREFIX}Skipping native module '${name}'")
       }
     }
 
-    return [reactNativeModules, json["project"]["android"]["packageName"]];
+    return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]["packageName"]];
   }
 }
 

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -154,5 +154,13 @@ export function dependencyConfig(
   const packageInstance =
     userConfig.packageInstance || `new ${packageClassName}()`;
 
-  return {sourceDir, folder: root, packageImportPath, packageInstance};
+  const buildTypes = userConfig.buildTypes || [];
+
+  return {
+    sourceDir,
+    folder: root,
+    packageImportPath,
+    packageInstance,
+    buildTypes,
+  };
 }

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -46,7 +46,7 @@ def use_native_modules!(config = nil)
     next unless package_config = package["platforms"]["ios"]
 
     podspec_path = package_config["podspecPath"]
-    buildTypes = package_config["buildTypes"]
+    configurations = package_config["configurations"]
 
     # Add a warning to the queue and continue to the next dependency if the podspec_path is nil/empty
     if podspec_path.nil? || podspec_path.empty?
@@ -87,13 +87,7 @@ def use_native_modules!(config = nil)
     podspec_dir_path = Pathname.new(File.dirname(podspec_path))
 
     relative_path = podspec_dir_path.relative_path_from project_root
-
-    if buildTypes.nil? || buildTypes.empty?
-      pod spec.name, :path => relative_path.to_path
-    elsif
-      pod spec.name, :path => relative_path.to_path, :configurations => buildTypes
-    end
-
+    pod spec.name, :path => relative_path.to_path, :configurations => configurations
     if package_config["scriptPhases"] && !this_target.abstract?
       # Can be either an object, or an array of objects
       Array(package_config["scriptPhases"]).each do |phase|

--- a/packages/platform-ios/native_modules.rb
+++ b/packages/platform-ios/native_modules.rb
@@ -46,6 +46,7 @@ def use_native_modules!(config = nil)
     next unless package_config = package["platforms"]["ios"]
 
     podspec_path = package_config["podspecPath"]
+    buildTypes = package_config["buildTypes"]
 
     # Add a warning to the queue and continue to the next dependency if the podspec_path is nil/empty
     if podspec_path.nil? || podspec_path.empty?
@@ -87,7 +88,11 @@ def use_native_modules!(config = nil)
 
     relative_path = podspec_dir_path.relative_path_from project_root
 
-    pod spec.name, :path => relative_path.to_path
+    if buildTypes.nil? || buildTypes.empty?
+      pod spec.name, :path => relative_path.to_path
+    elsif
+      pod spec.name, :path => relative_path.to_path, :configurations => buildTypes
+    end
 
     if package_config["scriptPhases"] && !this_target.abstract?
       # Can be either an object, or an array of objects

--- a/packages/platform-ios/src/config/index.ts
+++ b/packages/platform-ios/src/config/index.ts
@@ -74,12 +74,12 @@ export function dependencyConfig(
   folder: string,
   userConfig: IOSDependencyParams,
 ) {
-  const buildTypes = userConfig.buildTypes || [];
+  const configurations = userConfig.configurations || [];
 
   const baseConfig = projectConfig(folder, userConfig);
   if (!baseConfig) {
     return null;
   }
 
-  return {...baseConfig, buildTypes};
+  return {...baseConfig, configurations};
 }

--- a/packages/platform-ios/src/config/index.ts
+++ b/packages/platform-ios/src/config/index.ts
@@ -11,7 +11,10 @@ import {memoize} from 'lodash';
 import findProject from './findProject';
 import findPodfilePath from './findPodfilePath';
 import findPodspec from './findPodspec';
-import {IOSProjectParams} from '@react-native-community/cli-types';
+import {
+  IOSProjectParams,
+  IOSDependencyParams,
+} from '@react-native-community/cli-types';
 
 const memoizedFindProject = memoize(findProject);
 
@@ -67,4 +70,16 @@ export function projectConfig(folder: string, userConfig: IOSProjectParams) {
   };
 }
 
-export const dependencyConfig = projectConfig;
+export function dependencyConfig(
+  folder: string,
+  userConfig: IOSDependencyParams,
+) {
+  const buildTypes = userConfig.buildTypes || [];
+
+  const baseConfig = projectConfig(folder, userConfig);
+  if (!baseConfig) {
+    return null;
+  }
+
+  return {...baseConfig, buildTypes};
+}


### PR DESCRIPTION
Summary:
---------

Currently, you can't use the auto-linking with modules that should be added only to a specific build type (for example, only to the debug builds). With those changes, people can easier install helper packages. I believe this is a really nice addition to the `react-native-cli`.

Why have I added two fields (under `ios` and `android`)?
I believe in that way we give users the most control over their packages. Moreover, users people can use everything that native platforms give them - build variants/flavors on Android, pod configuration on iOS.

Test Plan:
----------

- create a package with custom `react-native.config.js`
```
module.exports = {
    dependency: {
        platforms: {
            android: {
                buildTypes: ['debug']
            },
            ios: {
                buildTypes: ['debug']
            }
        }
    }
}
```
- link this package into your RN project 
- check if dependency is added only to the `debug` build - not to the release one