### PR TITLE
fix: disable caching of assets for the development server

### DIFF
--- a/packages/cli-server-api/package.json
+++ b/packages/cli-server-api/package.json
@@ -12,6 +12,7 @@
     "compression": "^1.7.1",
     "connect": "^3.6.5",
     "errorhandler": "^1.5.0",
+    "nocache": "^2.1.0",
     "pretty-format": "^26.6.2",
     "serve-static": "^1.13.1",
     "ws": "^1.1.0"

--- a/packages/cli-server-api/src/index.ts
+++ b/packages/cli-server-api/src/index.ts
@@ -4,6 +4,7 @@ import {Server as HttpsServer} from 'https';
 import compression from 'compression';
 import connect from 'connect';
 import errorhandler from 'errorhandler';
+import nocache from 'nocache';
 import serveStatic from 'serve-static';
 import {debuggerUIMiddleware} from '@react-native-community/cli-debugger-ui';
 
@@ -47,6 +48,7 @@ export function createDevServerMiddleware(options: MiddlewareOptions) {
     .use(securityHeadersMiddleware)
     // @ts-ignore compression and connect types mismatch
     .use(compression())
+    .use(nocache())
     .use('/debugger-ui', debuggerUIMiddleware())
     .use(
       '/launch-js-devtools',

--- a/packages/debugger-ui/package.json
+++ b/packages/debugger-ui/package.json
@@ -5,7 +5,7 @@
   "main": "./build/middleware",
   "scripts": {
     "build": "yarn build:ui && yarn build:middleware",
-    "build:ui": "parcel build src/ui/index.html --out-dir build/ui --public-url '/debugger-ui'",
+    "build:ui": "parcel build --no-content-hash src/ui/index.html --out-dir build/ui --public-url '/debugger-ui'",
     "build:middleware": "tsc"
   },
   "files": [

--- a/packages/debugger-ui/src/middleware/index.ts
+++ b/packages/debugger-ui/src/middleware/index.ts
@@ -2,5 +2,7 @@ import serveStatic from 'serve-static';
 import path from 'path';
 
 export function debuggerUIMiddleware() {
-  return serveStatic(path.join(__dirname, '..', 'ui'));
+  return serveStatic(path.join(__dirname, '..', 'ui'), {
+    cacheControl: false,
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,6 +8445,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nocache@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
+  integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
+
 node-addon-api@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"


### PR DESCRIPTION
Summary:
---------

It looks like the built assets get cached sometimes causing issues such as https://github.com/facebook/react-native/issues/28844
This might happen if the HTML file got cached, but there's a new version available with different links.

It's better to disable the caching altogether since the development server is run locally and caching files causes more problems than it helps.
Normally it's possible by developers to disable caching when devtools is open, but it's not reasonable to expect everyone to do it.

The commit changes 2 things:

- Set relevant headers to prevent caching of assets using the 'nocache' middleware
- When building files with parcel, make sure that the name of the built files don't change

Fixes #1081 

Test Plan:
----------

I have tested this in a fresh React Native project following the instructions in CONTRIBUTING.md and observed that the debugger works as expected.

cc @brentvatne 