### PR TITLE
fix: 🐛 executableFolderPath to run app name in iOS 14.0 (#1236) for 3.x branch

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -366,18 +366,22 @@ function bootSimulator(selectedSimulator: Device) {
   }
 }
 
-function getTargetBuildDir(buildSettings: string) {
+function getTargetPaths(buildSettings: string) {
   const settings = JSON.parse(buildSettings);
 
   // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
   for (const i in settings) {
     const wrapperExtension = settings[i].buildSettings.WRAPPER_EXTENSION;
+
     if (wrapperExtension === 'app') {
-      return settings[i].buildSettings.TARGET_BUILD_DIR;
+      return {
+        targetBuildDir: settings[i].buildSettings.TARGET_BUILD_DIR,
+        executableFolderPath: settings[i].buildSettings.EXECUTABLE_FOLDER_PATH,
+      };
     }
   }
 
-  return null;
+  return {};
 }
 
 function getBuildPath(
@@ -413,12 +417,17 @@ function getBuildPath(
     ],
     {encoding: 'utf8'},
   );
-  const targetBuildDir = getTargetBuildDir(buildSettings);
+  const {targetBuildDir, executableFolderPath} = getTargetPaths(buildSettings);
+
   if (!targetBuildDir) {
     throw new CLIError('Failed to get the target build directory.');
   }
 
-  return `${targetBuildDir}/${appName}.app`;
+  if (!executableFolderPath) {
+    throw new CLIError('Failed to get the app name.');
+  }
+
+  return `${targetBuildDir}/${executableFolderPath}`;
 }
 
 function getProductName(buildOutput: string) {


### PR DESCRIPTION
Summary:
---------

This request is to cherry-pick the fix for #1208 from commit c736b21c8f3965028b5c59bd8cde07b0b32d08cc onto the 3.x branch for RN 0.61 compatibility with iOS 14 SDK. The commit applied cleanly with no modification.

See pull #1236 for original, summary included here:

Fix: #1208

This behavior
![image](https://user-images.githubusercontent.com/87394/98402149-ab97f300-201b-11eb-9fba-a0b81cf8c4a4.png)

with this envs:

```
PRODUCT_BUNDLE_IDENTIFIER = paz.church;
PRODUCT_NAME = Paz.Church;
```

Test Plan:
----------

test plan from original PR:

```
react-native run-ios --simulator="iPhone 11 Pro Max"
error React Native CLI uses autolinking for native dependencies, but the following modules are linked manually:
  - react-native-code-push (to unlink run: "react-native unlink react-native-code-push")
This is likely happening when upgrading React Native from below 0.60 to 0.60 or above. Going forward, you can unlink this dependency via "react-native unlink <dependency>" and it will be included in your app automatically. If a library isn't compatible with autolinking, disregard this message and notify the library maintainers.
Read more about autolinking: https://github.com/react-native-community/cli/blob/master/docs/autolinking.md
info Found Xcode workspace "pazchurch.xcworkspace"
info Building (using "xcodebuild -workspace pazchurch.xcworkspace -configuration Debug -scheme pazchurch -destination id=8A35A779-3306-4EEA-A4C5-EEAF9303C236")
..........................................
wrapperExtension app
info Installing "/Users/emmet/Library/Developer/Xcode/DerivedData/pazchurch-dfffuyvjrmhokibjznhcqhpichmy/Build/Products/Debug-iphonesimulator/Paz.Church.app"
info Launching "paz.church"
success Successfully launched the app on the simulator
```
