### PR TITLE
Support experimental transform profile for bundle command

### DIFF
--- a/packages/cli/src/commands/bundle/buildBundle.ts
+++ b/packages/cli/src/commands/bundle/buildBundle.ts
@@ -24,6 +24,7 @@ interface RequestOptions {
   dev: boolean;
   minify: boolean;
   platform: string | undefined;
+  unstable_transformProfile: string | undefined;
 }
 
 export interface AssetData {
@@ -83,6 +84,7 @@ async function buildBundle(
     dev: args.dev,
     minify: args.minify !== undefined ? args.minify : !args.dev,
     platform: args.platform,
+    unstable_transformProfile: args.unstableTransformProfile,
   };
   const server = new Server(config);
 

--- a/packages/cli/src/commands/bundle/bundleCommandLineArgs.ts
+++ b/packages/cli/src/commands/bundle/bundleCommandLineArgs.ts
@@ -25,6 +25,7 @@ export interface CommandLineArgs {
   sourcemapSourcesRoot?: string;
   sourcemapUseAbsolutePath: boolean;
   verbose: boolean;
+  unstableTransformProfile?: string;
 }
 
 export default [
@@ -94,6 +95,11 @@ export default [
     name: '--assets-dest [string]',
     description:
       'Directory name where to store assets referenced in the bundle',
+  },
+  {
+    name: '--unstable-transform-profile [string]',
+    description:
+      'Experimental, transform JS for a specific JS engine. Currently supported: hermes, hermes-canary, default',
   },
   {
     name: '--reset-cache',


### PR DESCRIPTION
Summary:
---------

This adds a new command line option `--unstable-transform-profile` and simply passes the value to metro.

Test Plan:
----------

Tested in an app by adding `extraPackagerArgs: ["--unstable-transform-profile", "hermes-canary"],` in the build.gradle react config.
