### PR TITLE
fix getProductName regex (run-ios)

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -441,7 +441,7 @@ function getBuildPath(
 }
 
 function getProductName(buildOutput: string) {
-  const productNameMatch = /export FULL_PRODUCT_NAME="?(.+).app"?$/m.exec(
+  const productNameMatch = /export FULL_PRODUCT_NAME\\="?(.+).app"?$/m.exec(
     buildOutput,
   );
   return productNameMatch ? productNameMatch[1] : null;


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

`getProductName` used in the `run-ios` command from `cli-platform-ios` was failing to correctly parse build output and instead only returned the scheme name passed. It seems that the build output has a backslash before all equals signs, so this change reflects that.


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Run `react-native run-ios` with a scheme name different from the CFBundleIdentifier.