### PR TITLE
chore(breaking): use Node 12 as compile target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ defaults: &defaults
   working_directory: ~/react-native-cli
 
 executors:
-  node10:
+  node12:
     <<: *defaults
     docker:
-      - image: circleci/node:dubnium
+      - image: circleci/node:erbium
   nodelts:
     <<: *defaults
     docker:
@@ -68,11 +68,11 @@ commands:
 
 jobs:
   setup:
-    executor: node10
+    executor: node12
     steps:
       - install-dependencies
   lint:
-    executor: node10
+    executor: node12
     steps:
       - run-lint
   cocoa-pods:
@@ -81,7 +81,7 @@ jobs:
       - install-cocoapods
       - run-cocoa-pods-tests
   unit-tests:
-    executor: node10
+    executor: node12
     steps:
       - run-unit-tests
   e2e-tests:

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = {
     [
       require.resolve('@babel/preset-env'),
       {
-        targets: {node: '10'},
+        targets: {node: '12'},
         useBuiltIns: 'entry',
         corejs: '2.x',
       },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -18,7 +18,7 @@
   ],
   "engineStrict": true,
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary:
---------

Updated node version of CI to use v12, as supported node version for React Native will be v12 from react-native v0.64

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
CI to pass on Node v12
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
