### PR TITLE
fix: overwrite asyncRequireModulePath to make Metro work locally

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,6 +53,7 @@
     "metro-core": "^0.64.0",
     "metro-react-native-babel-transformer": "^0.64.0",
     "metro-resolver": "^0.64.0",
+    "metro-runtime": "^0.64.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "node-stream-zip": "^1.9.1",

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -46,6 +46,7 @@ export interface MetroConfig {
     babelTransformerPath: string;
     assetRegistryPath: string;
     assetPlugins?: Array<string>;
+    asyncRequireModulePath?: string;
   };
   watchFolders: ReadonlyArray<string>;
   reporter?: any;
@@ -109,6 +110,9 @@ export const getDefaultConfig = (ctx: Config): MetroConfig => {
         'metro-react-native-babel-transformer',
       ),
       assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
+      asyncRequireModulePath: require.resolve(
+        'metro-runtime/src/modules/asyncRequire',
+      ),
     },
     watchFolders: [],
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8042,7 +8042,7 @@ metro-resolver@0.64.0, metro-resolver@^0.64.0:
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.64.0:
+metro-runtime@0.64.0, metro-runtime@^0.64.0:
   version "0.64.0"
   resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.64.0.tgz#cdaa1121d91041bf6345f2a69eb7c2fb289eff7b"
   integrity sha512-m7XbWOaIOeFX7YcxUhmnOi6Pg8EaeL89xyZ+quZyZVF1aNoTr4w8FfbKxvijpjsytKHIZtd+43m2Wt5JrqyQmQ==


### PR DESCRIPTION
Summary:
---------

When testing RN CLI on a sample project we pass a `--watchFolders /path/to/cli` flag to Metro after performing `yarn link` to overcome no symlinks support. In one of the recent releases of Metro (0.63 or later) this workflow broke with `UnableToResolveError`. After small digging it turned out that `metro-runtime/src/modules/asyncRequire` is not resolved properly in such a workflow. 

We can overcome this in CLI by manually overwriting `asyncRequireModulePath` with an absolutely resolved path. Not sure if CLI users need that change, but without it we can't test Metro locally, so adding this just in case.

Test Plan:
----------

Run `react-native start` locally set up to run CLI from source and make sure it runs properly in cases like fast refreshing, reloading from terminal, remote debugging.
