### PR TITLE
Allow react-native nightly builds

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
     "wcwidth": "^1.0.1"
   },
   "peerDependencies": {
-    "react-native": ">=0.64.0-rc.0"
+    "react-native": ">=0.64.0-rc.0 || 0.0.0-*"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",


### PR DESCRIPTION
Summary:
---------

Fix https://github.com/react-native-community/cli/issues/1318

```
npm WARN ERESOLVE overriding peer dependency
npm WARN Found: react-native@undefined
npm WARN node_modules/react-native/node_modules/react-native
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react-native@">=0.64.0-rc.0" from @react-native-community/cli@5.0.1-alpha.0
npm WARN node_modules/react-native/node_modules/@react-native-community/cli
npm WARN   @react-native-community/cli@"^5.0.1-alpha.0" from react-native@0.0.0-00e623ddb
npm WARN   node_modules/react-native
npm ERR! code ETARGET
npm ERR! notarget No matching version found for react-native@>=0.64.0-rc.0.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```

Test Plan:
----------

Didn't verify this fixes the above error on npm 7 yet. Two things to consider:
  - Whether the syntax `|| 0.0.0-*` is correct
  - Why the error mentions `Found: react-native@undefined` instead of `Found: react-native@0.0.0-00e623ddb`