### PR TITLE
chore: add e2e test for when init fails if the directory already exists

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -39,6 +39,15 @@ afterEach(() => {
   cleanupSync(DIR);
 });
 
+test('init fails if the directory already exists', () => {
+  fs.mkdirSync(path.join(DIR, 'TestInit'));
+
+  const {stderr} = runCLI(DIR, ['init', 'TestInit'], {expectedFailure: true});
+  expect(stderr).toBe(
+    'error Cannot initialize new project because directory "TestInit" already exists.',
+  );
+});
+
 test('init --template fails without package name', () => {
   const {stderr} = runCLI(
     DIR,


### PR DESCRIPTION
Summary:
---------

The init functionality fails if the specified directory already exists; added a test case for this scenario.


Test Plan:
----------

This PR aims at updating the test suite.