### PR TITLE
fix: doctor command prints output twice

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -24,7 +24,6 @@ export const projectCommands = [
   upgrade,
   info,
   config,
-  doctor,
   profileHermes,
 ] as Command[];
 


### PR DESCRIPTION
It turns out that, by a mistake, `doctor` command is registered twice, both as project and detached command. It has been converted to `detached` few months ago. 

It could be hidden `commander` feature that when multiple functions are registered under the same name, they run in order. Attaching some screenshots for reference:

Removing it from `projectCommands` fixes the problem.

We will address similar issue https://github.com/react-native-community/cli/issues/1261 soon where detached commands (such as `doctor` included) can receive and take advantage of `config` when present in the project.

<img width="866" alt="Screenshot 2020-12-07 at 13 15 44" src="https://user-images.githubusercontent.com/2464966/101351968-b56a7b80-3891-11eb-9dfa-c5950c274f14.png">

