### PR TITLE
Add doctor command at commands list

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -146,7 +146,7 @@ Usage:
 react-native doctor
 ```
 
-Get diagnosis about development environment required (Common, Android and IOS packages).
+[EXPERIMENTAL] Diagnose and fix common Node.js, iOS, Android & React Native issues.
 
 ### `init`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,6 +4,7 @@ React Native CLI comes with following commands:
 
 - [`bundle`](#bundle)
 - [`config`](#config)
+- [`doctor`](#doctor)
 - [`init`](#init)
 - [`info`](#info)
 - [`install`](#install)
@@ -136,6 +137,16 @@ react-native config
 ```
 
 Output project and dependencies configuration in JSON format to stdout. Used by [autolinking](./autolinking.md).
+
+### `doctor`
+
+Usage:
+
+```sh
+react-native doctor
+```
+
+Get diagnosis about development environment required (Common, Android and IOS packages).
 
 ### `init`
 


### PR DESCRIPTION
Summary:
---------

I found the doctor command at an issue in react-native repository (https://github.com/facebook/react-native/issues/28712). So I looking for here, at the cli documentation and I not found, I don't no the reason.

I believe this addition may help a lot of people