### PR TITLE
Update getAdbPath.ts

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/getAdbPath.ts
+++ b/packages/platform-android/src/commands/runAndroid/getAdbPath.ts
@@ -8,7 +8,7 @@
 
 function getAdbPath() {
   return process.env.ANDROID_HOME
-    ? `${process.env.ANDROID_HOME}/platform-tools/adb`
+    ? `${process.env.ANDROID_HOME}/platform-tools/adb.exe`
     : 'adb';
 }
 


### PR DESCRIPTION
I updated getAdbPath.ts because it seems platform-tools/adb is not found because filesystem might interpret it as a directory running Windows Subsystem for Linux version 2. I updated it by adding **.exe** extension.

See: #1344

Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
