### PR TITLE
feat: default to enableOptionalDependencies: true in metro config

### DIFF
--- a/packages/cli/src/tools/__tests__/loadMetroConfig-test.ts
+++ b/packages/cli/src/tools/__tests__/loadMetroConfig-test.ts
@@ -1,0 +1,16 @@
+import {getDefaultConfig} from '../loadMetroConfig';
+
+jest.mock('fs');
+jest.mock('path');
+
+describe('getDefaultConfig', () => {
+  it('should preserve transformer.allowOptionalDependencies=true when overriding other transformer options', async () => {
+    const config = getDefaultConfig({
+      root: '/',
+      reactNativePath: '',
+      platforms: {},
+    });
+
+    expect(config.transformer.allowOptionalDependencies).toBe(true);
+  });
+});

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -20,6 +20,12 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
   ].join('|'),
 );
 
+type ConfigLoadingContext = Pick<Config, 'root' | 'reactNativePath'> & {
+  platforms: {
+    [name: string]: {npmPackageName?: string};
+  };
+};
+
 export interface MetroConfig {
   resolver: {
     resolveRequest?: (
@@ -56,7 +62,7 @@ export interface MetroConfig {
 /**
  * Default configuration
  */
-export const getDefaultConfig = (ctx: Config): MetroConfig => {
+export const getDefaultConfig = (ctx: ConfigLoadingContext): MetroConfig => {
   const outOfTreePlatforms = Object.keys(ctx.platforms).filter(
     (platform) => ctx.platforms[platform].npmPackageName,
   );
@@ -137,7 +143,7 @@ export interface ConfigOptionsT {
  * This allows the CLI to always overwrite the file settings.
  */
 export default function load(
-  ctx: Config,
+  ctx: ConfigLoadingContext,
   options?: ConfigOptionsT,
 ): Promise<MetroConfig> {
   const defaultConfig = getDefaultConfig(ctx);

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -20,11 +20,10 @@ const INTERNAL_CALLSITES_REGEX = new RegExp(
   ].join('|'),
 );
 
-type ConfigLoadingContext = Pick<Config, 'root' | 'reactNativePath'> & {
-  platforms: {
-    [name: string]: {npmPackageName?: string};
-  };
-};
+type ConfigLoadingContext = Pick<
+  Config,
+  'root' | 'reactNativePath' | 'platforms'
+>;
 
 export interface MetroConfig {
   resolver: {

--- a/packages/cli/src/tools/loadMetroConfig.ts
+++ b/packages/cli/src/tools/loadMetroConfig.ts
@@ -43,6 +43,7 @@ export interface MetroConfig {
     customizeFrame: (frame: {file: string | null}) => {collapse: boolean};
   };
   transformer: {
+    allowOptionalDependencies?: boolean;
     babelTransformerPath: string;
     assetRegistryPath: string;
     assetPlugins?: Array<string>;
@@ -106,6 +107,7 @@ export const getDefaultConfig = (ctx: Config): MetroConfig => {
       },
     },
     transformer: {
+      allowOptionalDependencies: true,
       babelTransformerPath: require.resolve(
         'metro-react-native-babel-transformer',
       ),


### PR DESCRIPTION
Summary:
---------

Motivation outlined in https://github.com/react-native-community/cli/issues/1348

Test Plan:
----------

I wasn't sure what to do for testing this because there isn't any precedent for testing `loadMetroConfig` or `getDefaultConfig` that I could find. I added a test for `getDefaultConfig` to ensure this option doesn't accidentally get disabled, although I understand that this is not the most useful test.

Note: the `Context` type is massive and difficult to construct, so I tried to narrow it to just what we use here by replacing `ctx: Context` with `ctx: ConfigLoadingContext` as defined here:

```ts
type ConfigLoadingContext = Pick<Config, 'root' | 'reactNativePath'> & {
  platforms: {
    [name: string]: {npmPackageName?: string};
  };
};
```

I tried to add a test for `loadMetroConfig` to ensure that if we override other `transformer` properties we still preserve the default `allowOptionalDependencies` value, but metro's config loading code via `cosmiconfig` didn't work out of the box with the the cli's existing `fs` mocking code so I shelved that idea for now.

Note:
----------

As discussed in https://github.com/react-native-community/cli/issues/1348 I'd love to see this backported to 4.x along with https://github.com/react-native-community/cli/pull/1351