### PR TITLE
fix: rename file cause "no such file" error

### DIFF
--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -43,7 +43,9 @@ function renameFile(filePath: string, oldName: string, newName: string) {
 
   logger.debug(`Renaming ${filePath} -> file:${newFileName}`);
 
-  fs.renameSync(filePath, newFileName);
+  if (!fs.existsSync(newFileName)) {
+    fs.renameSync(filePath, newFileName);
+  }
 }
 
 function shouldRenameFile(filePath: string, nameToReplace: string) {


### PR DESCRIPTION
Summary:
---------

os: Mac OS

### I have found that there is an error occur in this situation：

First, I use `react-native` create a custom template name 'template'.
```bash
npx react-native init template --skip-install
```
Then I create a `template.config.js`.

In the end, my workspace like:

![image](https://user-images.githubusercontent.com/23275036/106451533-ad117400-64c1-11eb-8728-0825494b19c7.png)

**And then, I use flowing commend to create my  new reate-native project**

```bash
npx react-native init test --skip-install --template /my/path/to/template
```

It cause an error like this:

![image](https://user-images.githubusercontent.com/23275036/106452424-d1ba1b80-64c2-11eb-8e53-5a610d66c6f0.png)

This only happen when the template project name called `template`, if use  other name, it won'd happen.

Test Plan:
----------

I try the exactly the same to create project, an it run well.

