### PR TITLE
Add the ability to change the packager commands

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -51,6 +51,7 @@ export interface Flags {
   port: number;
   terminal: string;
   jetifier: boolean;
+  launchPackagerDirectory: string;
 }
 
 type AndroidProject = NonNullable<Config['project']['android']>;
@@ -94,6 +95,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
         startServerInNewWindow(
           args.port,
           args.terminal,
+          args.launchPackagerDirectory,
           config.reactNativePath,
         );
       } catch (error) {
@@ -237,6 +239,7 @@ function installAndLaunchOnDevice(
 function startServerInNewWindow(
   port: number,
   terminal: string,
+  launchPackagerDirectory: string,
   reactNativePath: string,
 ) {
   /**
@@ -254,8 +257,9 @@ function startServerInNewWindow(
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
    */
+
   const launchPackagerScript = path.join(
-    reactNativePath,
+    launchPackagerDirectory !== '' ? launchPackagerDirectory : reactNativePath,
     `scripts/${scriptFile}`,
   );
 
@@ -322,6 +326,11 @@ export default {
       description:
         '[DEPRECATED - root is discovered automatically] Override the root directory for the android build (which contains the android directory)',
       default: '',
+    },
+    {
+      name: '--launchPackagerDirectory <string>',
+      description:
+        'The directory that contains the command and the environment file to launch the packager',
     },
     {
       name: '--variant <string>',


### PR DESCRIPTION
Summary:
---------
At Shopify, we are using the React Native CLI in a monorepo setup. Since the CLI launches the packager taking the directory where React Native lives as the working directory, it causes the packager command to read the Metro configuration from the wrong directory. 

This PR fixes it by giving the users the flexibility to customize the directory where the launch packager command and environment files are defined. On iOS, we changed the packager build phase to use our own launcher.

Please, let me know if you'd have taken a different approach. We only need to be able to specify where the Metro configuration lives.


Test Plan:
----------
We tested it with our own monorepo and it works. We included that directory with the command and our own instructions on how to launch the packager.

cc @ElviraBurchik
