### PR TITLE
Add missing project refs

### DIFF
--- a/packages/cli-server-api/tsconfig.json
+++ b/packages/cli-server-api/tsconfig.json
@@ -3,5 +3,9 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build"
-  }
+  },
+  "references": [
+    {"path": "../tools"},
+    {"path": "../debugger-ui"}
+  ]
 }


### PR DESCRIPTION
Summary:
---------

I was having issues with the ts build after a fresh clone because it couldn't find the debugger-ui package. I noticed the cli-server-api package didn't have any project refs defined. Adding those and doing a clean build makes it work again.

Test Plan:
----------

Run clean + build