### PR TITLE
Minor fix for health check schema

### DIFF
--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -39,7 +39,7 @@ const healthCheck = t.object({
   healthchecks: t.array().items(
     t.object({
       label: t.string().required(),
-      isRequired: t.string(),
+      isRequired: t.bool(),
       description: t.string(),
       getDiagnostics: t.func(),
       win32AutomaticFix: t.func(),


### PR DESCRIPTION
Summary:
---------

Minor error in the health check schema prevents plugins from being able to specify that a health check is not required.

I found this while adding a bunch of health checks to `react-native-windows`: https://github.com/microsoft/react-native-windows/pull/7090.


Test Plan:
----------

Verified that with this change I can use the isRequired property from within `react-native-windows` and it'll show a failed check using the yellow circle instead of a red x.