### PR TITLE
Make project name lowercased in package.json

### DIFF
--- a/packages/cli/src/commands/init/__fixtures__/editTemplate/package.json
+++ b/packages/cli/src/commands/init/__fixtures__/editTemplate/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "PlaceholderName",
+  "version": "0.0.1"
+}

--- a/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.ts.snap
+++ b/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should edit package.json template 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -1,3 +1,3 @@
+  {
+-   \\"name\\": \\"PlaceholderName\\",
++   \\"name\\": \\"projectname\\",
+    \\"version\\": \\"0.0.1\\""
+`;
+
 exports[`should edit template 1`] = `
 "Snapshot Diff:
 - First value

--- a/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.ts.snap
+++ b/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`should edit package.json template 1`] = `
+exports[`changePlaceholderInTemplate should produce a lowercased version of "ProjectName" in package.json "name" field 1`] = `
 "Snapshot Diff:
 - First value
 + Second value

--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -125,25 +125,32 @@ test('should edit template with custom title', () => {
   ).toMatchSnapshot();
 });
 
-test('should edit package.json template', () => {
-  jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
-  changePlaceholderInTemplate({
-    projectName: PROJECT_NAME,
-    placeholderName: PLACEHOLDER_NAME,
+describe('changePlaceholderInTemplate', () => {
+  beforeEach(() => {
+    jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
   });
 
-  const oldPackageJsonFile = fs.readFileSync(
-    path.resolve(FIXTURE_DIR, 'package.json'),
-    'utf8',
-  );
-  const newPackageJsonFile = fs.readFileSync(
-    path.resolve(testPath, 'package.json'),
-    'utf8',
-  );
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
 
-  console.log(oldPackageJsonFile);
+  test(`should produce a lowercased version of "${PROJECT_NAME}" in package.json "name" field`, () => {
+    changePlaceholderInTemplate({
+      projectName: PROJECT_NAME,
+      placeholderName: PLACEHOLDER_NAME,
+    });
 
-  expect(
-    snapshotDiff(oldPackageJsonFile, newPackageJsonFile, {contextLines: 1}),
-  ).toMatchSnapshot();
+    const oldPackageJsonFile = fs.readFileSync(
+      path.resolve(FIXTURE_DIR, 'package.json'),
+      'utf8',
+    );
+    const newPackageJsonFile = fs.readFileSync(
+      path.resolve(testPath, 'package.json'),
+      'utf8',
+    );
+
+    expect(
+      snapshotDiff(oldPackageJsonFile, newPackageJsonFile, {contextLines: 1}),
+    ).toMatchSnapshot();
+  });
 });

--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -124,3 +124,26 @@ test('should edit template with custom title', () => {
     snapshotDiff(oldJavaFile, newJavaFile, {contextLines: 1}),
   ).toMatchSnapshot();
 });
+
+test('should edit package.json template', () => {
+  jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
+  changePlaceholderInTemplate({
+    projectName: PROJECT_NAME,
+    placeholderName: PLACEHOLDER_NAME,
+  });
+
+  const oldPackageJsonFile = fs.readFileSync(
+    path.resolve(FIXTURE_DIR, 'package.json'),
+    'utf8',
+  );
+  const newPackageJsonFile = fs.readFileSync(
+    path.resolve(testPath, 'package.json'),
+    'utf8',
+  );
+
+  console.log(oldPackageJsonFile);
+
+  expect(
+    snapshotDiff(oldPackageJsonFile, newPackageJsonFile, {contextLines: 1}),
+  ).toMatchSnapshot();
+});

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -22,6 +22,7 @@ function replaceNameInUTF8File(
   templateName: string,
 ) {
   logger.debug(`Replacing in ${filePath}`);
+  const packageJsonFile = path.basename(filePath) === 'package.json';
   const fileContent = fs.readFileSync(filePath, 'utf8');
   const replacedFileContent = fileContent
     .replace(new RegExp(templateName, 'g'), projectName)
@@ -32,6 +33,14 @@ function replaceNameInUTF8File(
 
   if (fileContent !== replacedFileContent) {
     fs.writeFileSync(filePath, replacedFileContent, 'utf8');
+  }
+
+  if (packageJsonFile) {
+    fs.writeFileSync(
+      filePath,
+      fileContent.replace(templateName, projectName.toLowerCase()),
+      'utf8',
+    );
   }
 }
 

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -22,7 +22,7 @@ function replaceNameInUTF8File(
   templateName: string,
 ) {
   logger.debug(`Replacing in ${filePath}`);
-  const packageJsonFile = path.basename(filePath) === 'package.json';
+  const isPackageJson = path.basename(filePath) === 'package.json';
   const fileContent = fs.readFileSync(filePath, 'utf8');
   const replacedFileContent = fileContent
     .replace(new RegExp(templateName, 'g'), projectName)
@@ -35,7 +35,7 @@ function replaceNameInUTF8File(
     fs.writeFileSync(filePath, replacedFileContent, 'utf8');
   }
 
-  if (packageJsonFile) {
+  if (isPackageJson) {
     fs.writeFileSync(
       filePath,
       fileContent.replace(templateName, projectName.toLowerCase()),


### PR DESCRIPTION
Summary:
---------
Fixes: https://github.com/react-native-community/cli/issues/814

That PR introduces the fix and make the project name _lowercased_ in `package.json` within freshly initialised project. 
Introduced part is covered by test case.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

Locally run `init` command and expect that name in package.json within new project is lowercased.


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
