### PR TITLE
Allow prefixed template as option

### DIFF
--- a/packages/cli/src/tools/generator/templates.ts
+++ b/packages/cli/src/tools/generator/templates.ts
@@ -44,6 +44,8 @@ async function createProjectFromTemplate(
 /**
  * The following formats are supported for the template:
  * - 'demo' -> Fetch the package react-native-template-demo from npm
+ * - 'react-native-template-demo' -> Fetch the package
+ * react-native-template-demo from npm
  * - git://..., http://..., file://... or any other URL supported by npm
  */
 async function createFromRemoteTemplate(
@@ -58,8 +60,12 @@ async function createFromRemoteTemplate(
     installPackage = template;
     templateName = template.substr(template.lastIndexOf('/') + 1);
   } else {
-    // e.g 'demo'
-    installPackage = `react-native-template-${template}`;
+    const prefix = 'react-native-template-';
+
+    installPackage = template.includes(prefix)
+      ? template // e.g 'react-native-template-demo'
+      : prefix.concat(template); // e.g 'demo'
+
     templateName = installPackage;
   }
 


### PR DESCRIPTION
Summary:
---------
Templates have been referenced prefixed with `react-native-template` on documentation, e.g.: https://github.com/react-native-community/react-native-template-typescript#arrow_forward-usage. This PR introduces a fix for this kind of usage, but also keep the existing non prefixed way.

Test Plan:
----------
It should work by running the cli providing a template with and without the `react-native-template` prefix.
1. Using prefixed template: `npx react-native init MyApp --template react-native-template-typescript`
2. Using no prefixed template: `npx react-native init MyApp --template typescript`
