### PR TITLE
chore: add homepage and repository fields to package.json

### DIFF
--- a/packages/cli-hermes/package.json
+++ b/packages/cli-hermes/package.json
@@ -22,5 +22,11 @@
   "devDependencies": {
     "@react-native-community/cli-types": "^5.0.1-alpha.1",
     "@types/ip": "^1.1.0"
+  },
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-hermes",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/cli-hermes"
   }
 }

--- a/packages/cli-server-api/package.json
+++ b/packages/cli-server-api/package.json
@@ -26,5 +26,11 @@
   "files": [
     "build",
     "!*.map"
-  ]
+  ],
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-server-api",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/cli-server-api"
+  }
 }

--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -13,5 +13,11 @@
     "!*.map"
   ],
   "types": "build/index.d.ts",
-  "license": "MIT"
+  "license": "MIT",
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-types",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/cli-types"
+  }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,10 +20,6 @@
   "engines": {
     "node": ">=12"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/react-native-community/react-native-cli.git"
-  },
   "jest": {
     "testEnvironment": "node"
   },
@@ -84,5 +80,11 @@
     "@types/wcwidth": "^1.0.0",
     "slash": "^3.0.0",
     "snapshot-diff": "^0.7.0"
+  },
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/cli"
   }
 }

--- a/packages/debugger-ui/package.json
+++ b/packages/debugger-ui/package.json
@@ -19,5 +19,11 @@
   },
   "dependencies": {
     "serve-static": "^1.13.1"
+  },
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/debugger-ui",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/debugger-ui"
   }
 }

--- a/packages/global-cli/package.json
+++ b/packages/global-cli/package.json
@@ -7,6 +7,10 @@
   "engines": {
     "node": ">=4"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/react-native-cli.git"
+  },
   "scripts": {
     "test": "mocha"
   },
@@ -21,11 +25,5 @@
   },
   "jest": {
     "displayName": "global-cli"
-  },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/global-cli",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/react-native-community/cli.git",
-    "directory": "packages/global-cli"
   }
 }

--- a/packages/global-cli/package.json
+++ b/packages/global-cli/package.json
@@ -7,10 +7,6 @@
   "engines": {
     "node": ">=4"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/react-native-community/react-native-cli.git"
-  },
   "scripts": {
     "test": "mocha"
   },
@@ -25,5 +21,11 @@
   },
   "jest": {
     "displayName": "global-cli"
+  },
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/global-cli",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/global-cli"
   }
 }

--- a/packages/platform-android/package.json
+++ b/packages/platform-android/package.json
@@ -31,5 +31,11 @@
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.149",
     "@types/xmldoc": "^1.1.4"
+  },
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/platform-android",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/platform-android"
   }
 }

--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -28,5 +28,11 @@
     "!*.d.ts",
     "!*.map",
     "native_modules.rb"
-  ]
+  ],
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/platform-ios",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/platform-ios"
+  }
 }

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -23,5 +23,11 @@
     "build",
     "!*.d.ts",
     "!*.map"
-  ]
+  ],
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/tools",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/tools"
+  }
 }


### PR DESCRIPTION
Summary:
---------

Fixes: https://github.com/react-native-community/cli/issues/1380

Test Plan:
----------

No testing needed, as only homepage and repository fields were added in package.json to make GitHub repo discoverable on npmjs website.

Docs:
* homepage https://docs.npmjs.com/cli/v7/configuring-npm/package-json#homepage
* repository https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository