### PR TITLE
chore: update versions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Our release cycle is independent of `react-native`. We follow semver and here is
 
 | `@react-native-community/cli`                                              | `react-native` |
 | -------------------------------------------------------------------------- | -------------- |
-| [^5.0.0 (`next`)](https://github.com/react-native-community/cli/tree/next) | master         |
-| [^4.0.0 (`master`)](https://github.com/react-native-community/cli/)        | ^0.62.0        |
+| [^5.0.0 (`master`)](https://github.com/react-native-community/cli)         | ^0.64.0        |
+| [^4.0.0](https://github.com/react-native-community/cli/tree/4.x)           | ^0.62.0        |
 | [^3.0.0](https://github.com/react-native-community/cli/tree/3.x)           | ^0.61.0        |
 | [^2.0.0](https://github.com/react-native-community/cli/tree/2.x)           | ^0.60.0        |
 | [^1.0.0](https://github.com/react-native-community/cli/tree/1.x)           | ^0.59.0        |


### PR DESCRIPTION
Summary:
---------

Apart from updating 5.x, I also removed `next` - it looks like it's not up to date right now and definitely not tracking the upcoming 6.x.