### PR TITLE
feat: add 'go to debugger-ui' link for packager index

### DIFF
--- a/packages/cli-server-api/src/index.html
+++ b/packages/cli-server-api/src/index.html
@@ -6,5 +6,6 @@
   <body>
     <p>React Native packager is running.</p>
     <p><a href="https://reactnative.dev">Visit documentation</a></p>
+    <p><a href="./debugger-ui/">Go to Debugger UI</a></p>
   </body>
 </html>


### PR DESCRIPTION
Summary:
---------

Added `Go to Debugger-UI` link so it's easier to find.


Test Plan:
----------

1. Run your project.
2. Visit `localhost:8081` (or the port you've configured).

![image](https://user-images.githubusercontent.com/5095527/111632521-d9c0e700-87f4-11eb-8427-d264acaa8ddc.png)
