### PR TITLE
fix: check stdout for xcrun output

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -87,9 +87,8 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   let devices;
   try {
-    devices = parseXctraceIOSDevicesList(
-      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stderr,
-    );
+    const output = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
+    devices = parseXctraceIOSDevicesList(output.stderr || output.stdout);
   } catch (e) {
     logger.warn(
       'Support for Xcode 11 and older is deprecated. Please upgrade to Xcode 12.',


### PR DESCRIPTION
Summary:
---------

At some point the xcrun command for printing all available devices, `xcrun xctrace list devices` changed from outputting from `stderr` to `stdout`.

```bash
❯ xcrun --version
xcrun version 59.
❯ xcodebuild -version
Xcode 12.5
Build version 12E5244e
```


Test Plan:
----------

Run `react-native ios --device` with a newish (beta 3) version of Xcode and a physical device connected.