### PR TITLE
feat: add option to build only active architectures on android

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/adb.ts
+++ b/packages/platform-android/src/commands/runAndroid/adb.ts
@@ -67,7 +67,29 @@ function getAvailableCPUs(adbPath: string, device: string): Array<string> {
   }
 }
 
+/**
+ * Gets the CPU architecture of a device from ADB
+ */
+function getCPU(adbPath: string, device: string): string | null {
+  try {
+    const cpus = execFileSync(adbPath, [
+      '-s',
+      device,
+      'shell',
+      'getprop',
+      'ro.product.cpu.abi',
+    ])
+      .toString()
+      .trim();
+
+    return cpus.length > 0 ? cpus : null;
+  } catch (e) {
+    return null;
+  }
+}
+
 export default {
   getDevices,
   getAvailableCPUs,
+  getCPU,
 };

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -51,6 +51,7 @@ export interface Flags {
   port: number;
   terminal: string;
   jetifier: boolean;
+  activeArchOnly: boolean;
 }
 
 type AndroidProject = NonNullable<Config['project']['android']>;
@@ -379,6 +380,12 @@ export default {
       name: '--no-jetifier',
       description:
         'Do not run "jetifier" – the AndroidX transition tool. By default it runs before Gradle to ease working with libraries that don\'t support AndroidX yet. See more at: https://www.npmjs.com/package/jetifier.',
+    },
+    {
+      name: '--active-arch-only',
+      description:
+        'Build native libraries only for the current device architecture for debug builds.',
+      default: false,
     },
   ],
 };

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -63,6 +63,20 @@ async function runOnAllDevices(
       gradleArgs.push('-PreactNativeDevServerPort=' + args.port);
     }
 
+    if (args.activeArchOnly) {
+      const architectures = devices
+        .map((device) => {
+          return adb.getCPU(adbPath, device);
+        })
+        .filter((arch) => arch != null);
+      if (architectures.length > 0) {
+        logger.info(`Detected architectures ${architectures.join(', ')}`);
+        gradleArgs.push(
+          '-PreactNativeDebugArchitectures=' + architectures.join(','),
+        );
+      }
+    }
+
     logger.info('Installing the app...');
     logger.debug(
       `Running command "cd android && ${cmd} ${gradleArgs.join(' ')}"`,


### PR DESCRIPTION
Summary:
---------

Building from source in debug takes a very long time because native builds need to run for all supported architectures. It is possible to check which architecture the devices for which we are about to launch the app on are and build only for those. For most cases we can reduce the number of architectures we build for to 1 instead of 4, resulting in a large speedup of the build.

This is inspired by iOS which has a "Build for active architecture only" option. Since android doesn't really support this natively we can implement it here and also in react-native by reading the build properties that we pass and alter the abi we build for.

With fabric / codegen coming up I suspect that we might want to default to building c++ soon. This should ease the transition as builds won't be orders of magnitude slower.

For now this is enabled only behind a flag, I think this is better since for the common case of not building from source this change doesn't have any effect. If RN moves to building c++ by default on android we can consider changing the default.

RN PR to add support for reactNativeDebugArchitectures: https://github.com/facebook/react-native/pull/31232

Test Plan:
----------

Tested this change + an incoming PR to the react-native repo with a combinaison of simulators and physical devices. Checked the build logs to see which architectures are being built.

Clean build for x86 simulator
`react-native run-android`
824.41s
`react-native run-android --active-arch-only`
299.77s