### PR TITLE
feat: use xcbeautify for xcodebuild output if installed

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -443,7 +443,7 @@ Do not launch packager while building.
 
 #### `--verbose`
 
-Do not use `xcpretty` even if installed.
+Do not use `xcbeautify` or `xcpretty` even if installed.
 
 #### `--port <number>`
 

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -313,17 +313,14 @@ function buildProject(
     );
     let xcodebuildOutputFormatter: ChildProcess | any;
     if (!args.verbose) {
-      xcodebuildOutputFormatter =
-        xcbeautifyAvailable() &&
-        child_process.spawn('xcbeautify', [], {
+      if (xcbeautifyAvailable()) {
+        xcodebuildOutputFormatter = child_process.spawn('xcbeautify', [], {
           stdio: ['pipe', process.stdout, process.stderr],
         });
-      if (!xcodebuildOutputFormatter) {
-        xcodebuildOutputFormatter =
-          xcprettyAvailable() &&
-          child_process.spawn('xcpretty', [], {
-            stdio: ['pipe', process.stdout, process.stderr],
-          });
+      } else if (xcprettyAvailable()) {
+        xcodebuildOutputFormatter = child_process.spawn('xcpretty', [], {
+          stdio: ['pipe', process.stdout, process.stderr],
+        });
       }
     }
     const buildProcess = child_process.spawn(


### PR DESCRIPTION
Summary:
---------

The run-ios command already detects and uses xcpretty (https://github.com/xcpretty/xcpretty) if it's available.

This commit adds support for another xcodebuild output formatter, xcbeautify (https://github.com/thii/xcbeautify).

The logic for what is used is as follows:
1. If xcbeautify is available use it
2. If xcbeautify isn't available but xcpretty is use xcpretty
3. If neither are available fallback to raw xcodebuild output

Test Plan:
----------

Tested manually with the following scenarios;
* only xcbeautify installed (xcbeautify used)
* only xcpretty installed (xcpretty used)
* both installed (xcbeautify used)
* neither installed (xcodebuild used raw)