### PR TITLE
feat: less noisy run-ios build failures with xcpretty

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -360,7 +360,7 @@ function buildProject(
             logs further, consider building your app with Xcode.app, by opening
             ${xcodeProject.name}.
           `,
-            xcpretty ? undefined : buildOutput + '\n' + errorOutput,
+            xcodebuildOutputFormatter ? undefined : buildOutput + '\n' + errorOutput,
           ),
         );
         return;

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -360,7 +360,7 @@ function buildProject(
             logs further, consider building your app with Xcode.app, by opening
             ${xcodeProject.name}.
           `,
-            buildOutput + '\n' + errorOutput,
+            xcpretty ? undefined : buildOutput + '\n' + errorOutput,
           ),
         );
         return;


### PR DESCRIPTION
Summary:
---------

The run-ios command detects and uses xcpretty (https://github.com/xcpretty/xcpretty) if it's available. If it's not available it displays a loader/spinner animation until xcodebuild finishes.

If a build failure happens then the buildOutput and errorOutput are included in the raised CLIError and printed out to the terminal.

This makes sense when xcpretty isn't present as there has been no build output displayed up to now. However, if xcpretty is being used, this behaviour makes less sense:

Firstly, xcpretty has been doing coloured output, nicely highlighting warnings and errors as they happened. The raised CLIError will repeat the output but without colours which means you have to scroll back up past a potential mountain of monochrome xcodebuild output to find the xcpretty output (or attempt to pick out the error from the monochrome output).

Secondly, you will be prompted to "Run CLI with --verbose flag for more details." upon build failure anyway. If you use xcpretty then running the build again with the --verbose flag would force raw xcodebuild output (which would then including the buildOutput and errorOutput again).

Test Plan:
----------

Tested manually with and without xcpretty installed.