### PR TITLE
fix: remove unused --verbose option from start command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -499,10 +499,6 @@ Removes cached files
 
 Path to a JavaScript file that exports a log reporter as a replacement for TerminalReporter
 
-#### `--verbose`
-
-Enables logging
-
 #### `--https`
 
 Enables https connections to the server

--- a/packages/cli/src/commands/start/runServer.ts
+++ b/packages/cli/src/commands/start/runServer.ts
@@ -33,7 +33,6 @@ export type Args = {
   resetCache?: boolean;
   sourceExts?: string[];
   transformer?: string;
-  verbose?: boolean;
   watchFolders?: string[];
   config?: string;
   projectRoot?: string;

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -68,10 +68,6 @@ export default {
         'Path to a JavaScript file that exports a log reporter as a replacement for TerminalReporter',
     },
     {
-      name: '--verbose',
-      description: 'Enables logging',
-    },
-    {
       name: '--https',
       description: 'Enables https connections to the server',
     },


### PR DESCRIPTION
Summary:
---------

While investigating https://github.com/react-native-community/cli/issues/1391 I discovered that the start command had a `--verbose` option that didn't do anything. You _do_ get extra logging with `--verbose` but this comes from the parent react-native command, where it is already documented.

I had a look through the metro functions being called to see if `verbose` was meant to be passed to one of them and had been missed but couldn't find anywhere it would be relevant. The only one I could see that it would potentially apply to is the `loadMetroConfig` call. While `loadMetroConfig` doesn't document a verbose parameter of its own, it calls `loadConfig` in the `metro-config` package which *does* take a verbose parameter. However, all that does is kill the reporter if `verbose === false` (see https://github.com/facebook/metro/blob/master/packages/metro-config/src/loadConfig.js#L256), which would mean you get no output from the start command whatsoever. Currently, the loadMetroConfig code is reliant on the fact that verbose is `undefined` when calling `loadConfig` so its custom reporter isn't overwritten.

Test Plan:
----------

* Ran `react-native start --verbose` before making this change and observed extra logging
* Removed verbose option from the start command
* Ran `react-native start --verbose` again and still observed extra logging