### PR TITLE
fix: JDK version check wouldn't detect JDK 8 correctly

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
@@ -40,10 +40,20 @@ describe('jdk', () => {
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
-  it('returns false if JDK version is in range', async () => {
+  it('returns false if JDK version is in range (JDK 9+ version number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
-      version: '9',
+      version: '9.0.4',
+    };
+
+    const diagnostics = await jdk.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
+  it('returns false if JDK version is in range (JDK 8 version number format)', async () => {
+    // @ts-ignore
+    environmentInfo.Languages.Java = {
+      version: '1.8.0_282',
     };
 
     const diagnostics = await jdk.getDiagnostics(environmentInfo);

--- a/packages/cli/src/commands/doctor/versionRanges.ts
+++ b/packages/cli/src/commands/doctor/versionRanges.ts
@@ -4,7 +4,7 @@ export default {
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
   WATCHMAN: '4.x',
-  JAVA: '>= 8',
+  JAVA: '1.8.x || >= 9',
   // Android
   ANDROID_SDK: '>= 26.x',
   ANDROID_NDK: '>= 19.x',


### PR DESCRIPTION
Summary:
---------

`envinfo` uses `javac -version` to work out the JDK version number. The doctor command was looking for a semver range of `>= 8` but this won't work for JDK 8 as it uses the old style numbering scheme (e.g. `1.8.x` not `8.x.x`). JDKs 9+ use the new version numbering scheme.

Fixes #1255

Test Plan:
----------

On macOS, before applying this PR's changes:

* `brew install openjdk@8`
* `export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)`
* Confirm `javac -version` outputs something like `javac 1.8.0_282`
* `react-native doctor`

Observe doctor complains about the JDK version:

```
Android
 ✖ JDK
   - Version found: 1.8.0_282
   - Version supported: >= 8
```

Apply changes and run `react-native doctor` again, observe 8 is now correctly detected as supported:

```
Android
 ✓ JDK
```

Repeat the above steps with JDK 9+ to confirm they're still correctly detected.