### PR TITLE
Prevent type mismatch exception thrown in Gradle 7

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -128,7 +128,7 @@ class ReactNativeModules {
    * @param generatedFileContentsTemplate
    */
   void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
-    ArrayList<HashMap<String, String>>[] packages = this.reactNativeModules
+    ArrayList<HashMap<String, String>> packages = this.reactNativeModules
     String packageName = this.packageName
 
     String packageImports = ""


### PR DESCRIPTION
Summary:
---------

An illegal argument exception is thrown when attempting to build RN Android apps using Gradle 7.0-rc-1 due to a type mismatch. This is down to a typo in `native_modules.gradle` which mistakenly makes `packages` an array of `ArrayList`.

Gradle 7 updated Groovy from 2 to 3 which is presumably why the behaviour doesn't occur when using Gradle 6.X.

I've tested the change locally and this changeset resolves the issue for me.

Test Plan:
----------

- Generate a fresh react-native app
- Update the gradle wrapper to 7.0-rc-1
- Build the app with `./gradlew assemble`, observe that an exception occurs
