### PR TITLE
fix(cli-hermes): avoid copying profile to /sdcard

### DIFF
--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -66,12 +66,11 @@ export async function downloadProfile(
 
     logger.debug('Internal commands run to pull the file:');
 
-    // Copy the file from device's data to sdcard, then pull the file to a temp directory
-    execSyncWithLog(`adb shell run-as ${packageName} cp cache/${file} /sdcard`);
-
     // If --raw, pull the hermes profile to dstPath
     if (raw) {
-      execSyncWithLog(`adb pull /sdcard/${file} ${dstPath}`);
+      execSyncWithLog(
+        `adb shell run-as ${packageName} cat cache/${file} > ${dstPath}/${file}`,
+      );
       logger.success(`Successfully pulled the file to ${dstPath}/${file}`);
     }
 
@@ -80,8 +79,9 @@ export async function downloadProfile(
       const osTmpDir = os.tmpdir();
       const tempFilePath = path.join(osTmpDir, file);
 
-      execSyncWithLog(`adb pull /sdcard/${file} ${tempFilePath}`);
-
+      execSyncWithLog(
+        `adb shell run-as ${packageName} cat cache/${file} > ${tempFilePath}`
+      );
       // If path to source map is not given
       if (!sourcemapPath) {
         // Get or generate the source map

--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -80,7 +80,7 @@ export async function downloadProfile(
       const tempFilePath = path.join(osTmpDir, file);
 
       execSyncWithLog(
-        `adb shell run-as ${packageName} cat cache/${file} > ${tempFilePath}`
+        `adb shell run-as ${packageName} cat cache/${file} > ${tempFilePath}`,
       );
       // If path to source map is not given
       if (!sourcemapPath) {


### PR DESCRIPTION
Summary:
---------

It appears that on most android devices, including emulators, `/sdcard` is not writeable, resulting in the issue described in #1379 

This change avoids copying, and instead just `cat`s the file to STDOUT which is then piped to a file. Since the profile text is text/json, this shouldn't be an issue.

Fixes #1379

Test Plan:
----------

1. Open a RN app that uses Hermes on Android
2. In the development menu, enable profiling
3. Disable profiling after some time
4. Run `react-native profile-hermes .`

Output should be:
```
➜ yarn react-native profile-hermes .       
info Downloading a Hermes Sampling Profiler from your Android device...
info No filename is provided, pulling latest file
info File to be pulled: sampling-profiler-trace8710561212640121744.cpuprofile
success Successfully converted to Chrome tracing format and pulled the file to ./sampling-profiler-trace8710561212640121744-converted.json
```
