### PR TITLE
Fix for 'No iOS devices connected.'

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -88,7 +88,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   let devices;
   try {
     devices = parseXctraceIOSDevicesList(
-      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stderr,
+      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stdout,
     );
   } catch (e) {
     logger.warn(

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -87,8 +87,9 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   let devices;
   try {
+    const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
     devices = parseXctraceIOSDevicesList(
-      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stdout,
+      out.stderr || out.stdout
     );
   } catch (e) {
     logger.warn(


### PR DESCRIPTION
Changed stderr to stdout to fix 'No iOS devices connected.' when attempting run-ios with '--device' on XCode 12.5.

Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
