### PR TITLE
Fix for 'No iOS devices connected.' 

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -88,7 +88,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   let devices;
   try {
     devices = parseXctraceIOSDevicesList(
-      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stderr,
+      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stdout,
     );
   } catch (e) {
     logger.warn(

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -89,7 +89,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   try {
     const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
     devices = parseXctraceIOSDevicesList(
-    // Xcode 12.5 introduced a change to output the list to stdout instead of stderr
+      // Xcode 12.5 introduced a change to output the list to stdout instead of stderr
       out.stderr === "" ? out.stdout : out.stderr,
     );
   } catch (e) {

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -88,9 +88,15 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   let devices;
   try {
     const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
-    devices = parseXctraceIOSDevicesList(
-      out.stderr || out.stdout
-    );
+    if (out === "") {
+      devices = parseXctraceIOSDevicesList(
+        out.stout,
+      );
+    } else {
+      devices = parseXctraceIOSDevicesList(
+        out.stderr,
+      );
+    }
   } catch (e) {
     logger.warn(
       'Support for Xcode 11 and older is deprecated. Please upgrade to Xcode 12.',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -87,8 +87,9 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   let devices;
   try {
+    const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
     devices = parseXctraceIOSDevicesList(
-      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stdout,
+      out.stderr || out.stdout
     );
   } catch (e) {
     logger.warn(

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -88,15 +88,9 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   let devices;
   try {
     const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
-    if (out === "") {
-      devices = parseXctraceIOSDevicesList(
-        out.stout,
-      );
-    } else {
-      devices = parseXctraceIOSDevicesList(
-        out.stderr,
-      );
-    }
+    devices = parseXctraceIOSDevicesList(
+      out.stderr === "" ? out.stdout : out.stderr,
+    );
   } catch (e) {
     logger.warn(
       'Support for Xcode 11 and older is deprecated. Please upgrade to Xcode 12.',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -89,6 +89,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   try {
     const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
     devices = parseXctraceIOSDevicesList(
+    // Xcode 12.5 introduced a change to output the list to stdout instead of stderr
       out.stderr === "" ? out.stdout : out.stderr,
     );
   } catch (e) {

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -90,7 +90,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     const out = execa.sync('xcrun', ['xctrace', 'list', 'devices']);
     devices = parseXctraceIOSDevicesList(
       // Xcode 12.5 introduced a change to output the list to stdout instead of stderr
-      out.stderr === "" ? out.stdout : out.stderr,
+      out.stderr === '' ? out.stdout : out.stderr,
     );
   } catch (e) {
     logger.warn(


### PR DESCRIPTION

Fixes #1404

Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
Fix for 'No iOS devices connected.' error when using 'run-ios --device' on XCode 12.5 with backwards compatibility. Checks output using stderr and uses stdout when blank text is returned.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
