### PR TITLE
fix: bump dependency plist to 3.0.2 in order to resolve a CVE security alert

### DIFF
--- a/packages/platform-ios/package.json
+++ b/packages/platform-ios/package.json
@@ -12,7 +12,7 @@
     "glob": "^7.1.3",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.15",
-    "plist": "^3.0.1",
+    "plist": "^3.0.2",
     "xcode": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Summary:
---------

Previous version of `@react-native-community/cli-platform-ios` requires `xmldom@0.1.x` through `plist@3.0.1`, which has a CVE security alert: https://github.com/advisories/GHSA-h6q6-9hqw-rwfv

`plist` fixed its dependency in `3.0.2`, and upgrading `plist` version here can resolve the CVE security alert.

Fixes #1383.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

Test whether a sample iOS app can build and run.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
