### PR TITLE
Init project in existing directory

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -39,12 +39,46 @@ afterEach(() => {
   cleanupSync(DIR);
 });
 
-test('init fails if the directory already exists', () => {
-  fs.mkdirSync(path.join(DIR, 'TestInit'));
+test('init fails if the directory already contains conflicting files/sub-directories', () => {
+  const projectName = 'TestInit';
+  const directoryName = 'custom-path';
+  const someValidFiles = {
+    'Thumbs.db': '',
+    '.idea': '',
+    '.npmignore': '',
+    '.git': '',
+    '.travis.yml': '',
+    '.gitlab-ci.yml': '',
+    '.hgignore': '',
+    '.gitattributes': '',
+    docs: '',
+  };
+  const someInvalidFiles = {
+    'package.json': '',
+    'package-lock.json': '',
+    'yarn.lock': '',
+    node_modules: '',
+    'babel.config.js': '',
+    'android/gradlew': '',
+    [`ios/${projectName}/AppDelegate.h`]: '',
+  };
+  // pre existing directory structure
+  writeFiles(path.resolve(DIR, directoryName), {
+    ...someValidFiles,
+    ...someInvalidFiles,
+  });
 
-  const {stderr} = runCLI(DIR, ['init', 'TestInit'], {expectedFailure: true});
-  expect(stderr).toBe(
-    'error Cannot initialize new project because directory "TestInit" already exists.',
+  const {stderr} = runCLI(
+    DIR,
+    ['init', '--directory', directoryName, projectName],
+    {expectedFailure: true},
+  );
+
+  expect(stderr).toContain(
+    `The directory ${directoryName} contains files that could conflict:`,
+  );
+  expect(stderr).toContain(
+    'Either try using a new directory name, or remove the files listed above.',
   );
 });
 

--- a/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
@@ -1,7 +1,0 @@
-export default class DirectoryAlreadyExistsError extends Error {
-  constructor(directory: string) {
-    super(
-      `Cannot initialize new project because directory "${directory}" already exists.`,
-    );
-  }
-}

--- a/packages/cli/src/commands/init/errors/DirectoryContainsConflictingFilesError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryContainsConflictingFilesError.ts
@@ -1,17 +1,9 @@
-import fs from 'fs';
-import path from 'path';
-
 export default class DirectoryContainsConflictingFilesError extends Error {
   constructor(directory: string, conflicts: string[]) {
     let errorString = `The directory ${directory} contains files that could conflict:\n`;
 
     for (const file of conflicts) {
-      try {
-        const stats = fs.lstatSync(path.join(directory, file));
-        errorString += `  ${file}${stats.isDirectory() ? '/' : ''}`;
-      } catch (e) {
-        errorString += `  ${file}`;
-      }
+      errorString += `  ${file}`;
     }
     errorString +=
       '\nEither try using a new directory name, or remove the files listed above.';

--- a/packages/cli/src/commands/init/errors/DirectoryContainsConflictingFilesError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryContainsConflictingFilesError.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+
+export default class DirectoryContainsConflictingFilesError extends Error {
+  constructor(directory: string, conflicts: string[]) {
+    let errorString = `The directory ${directory} contains files that could conflict:\n`;
+
+    for (const file of conflicts) {
+      try {
+        const stats = fs.lstatSync(path.join(directory, file));
+        errorString += `  ${file}${stats.isDirectory() ? '/' : ''}`;
+      } catch (e) {
+        errorString += `  ${file}`;
+      }
+    }
+    errorString +=
+      '\nEither try using a new directory name, or remove the files listed above.';
+
+    super(errorString);
+  }
+}

--- a/packages/cli/src/commands/init/errors/DirectoryContainsConflictingFilesError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryContainsConflictingFilesError.ts
@@ -3,7 +3,7 @@ export default class DirectoryContainsConflictingFilesError extends Error {
     let errorString = `The directory ${directory} contains files that could conflict:\n`;
 
     for (const file of conflicts) {
-      errorString += `  ${file}`;
+      errorString += `  ${file}\n`;
     }
     errorString +=
       '\nEither try using a new directory name, or remove the files listed above.';

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -60,13 +60,19 @@ function validateProjectDirectory(directory: string) {
     'Thumbs.db',
   ];
 
-  const conflicts = fs.readdirSync(directory).filter((file) => {
-    return (
-      !validFiles.includes(file) &&
-      // IntelliJ IDEA creates module files before CRA is launched
-      !/\.iml$/.test(file)
-    );
-  });
+  const conflicts = fs
+    .readdirSync(directory)
+    .filter((file) => {
+      return (
+        !validFiles.includes(file) &&
+        // IntelliJ IDEA creates module files before CRA is launched
+        !/\.iml$/.test(file)
+      );
+    })
+    .map((file) => {
+      const stats = fs.lstatSync(path.join(directory, file));
+      return `${file}${stats.isDirectory() ? '/' : ''}`;
+    });
 
   if (conflicts.length > 0) {
     throw new DirectoryContainsConflictingFilesError(directory, conflicts);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -5,7 +5,7 @@ import minimist from 'minimist';
 import ora from 'ora';
 import mkdirp from 'mkdirp';
 import {validateProjectName} from './validate';
-import DirectoryAlreadyExistsError from './errors/DirectoryAlreadyExistsError';
+import DirectoryContainsConflictingFilesError from './errors/DirectoryContainsConflictingFilesError';
 import printRunInstructions from './printRunInstructions';
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import {
@@ -40,14 +40,41 @@ interface TemplateOptions {
   skipInstall?: boolean;
 }
 
-function doesDirectoryExist(dir: string) {
-  return fs.existsSync(dir);
+function validateProjectDirectory(directory: string) {
+  const validFiles = [
+    '.DS_Store',
+    '.git',
+    '.gitattributes',
+    '.gitignore',
+    '.gitlab-ci.yml',
+    '.hg',
+    '.hgcheck',
+    '.hgignore',
+    '.idea',
+    '.npmignore',
+    '.travis.yml',
+    'docs',
+    'LICENSE',
+    'README.md',
+    'mkdocs.yml',
+    'Thumbs.db',
+  ];
+
+  const conflicts = fs.readdirSync(directory).filter((file) => {
+    return (
+      !validFiles.includes(file) &&
+      // IntelliJ IDEA creates module files before CRA is launched
+      !/\.iml$/.test(file)
+    );
+  });
+
+  if (conflicts.length > 0) {
+    throw new DirectoryContainsConflictingFilesError(directory, conflicts);
+  }
 }
 
 async function setProjectDirectory(directory: string) {
-  if (doesDirectoryExist(directory)) {
-    throw new DirectoryAlreadyExistsError(directory);
-  }
+  validateProjectDirectory(directory);
 
   try {
     mkdirp.sync(directory);
@@ -199,15 +226,28 @@ export default (async function initialize(
 ) {
   const root = process.cwd();
 
-  validateProjectName(projectName);
-
   /**
    * Commander is stripping `version` from options automatically.
    * We have to use `minimist` to take that directly from `process.argv`
    */
   const version: string = minimist(process.argv).version || DEFAULT_VERSION;
 
-  const directoryName = path.relative(root, options.directory || projectName);
+  // handles the case when '.' is passed as for projectDirectory
+  const tempDirectoryName = path.relative(
+    root,
+    options.directory || projectName,
+  );
+  const directoryName = tempDirectoryName === '' ? '.' : tempDirectoryName;
+
+  if (!options.directory) {
+    /**
+     * `path.basename` requires resolved paths
+     * eg: `path.basename('.') === '.'`, instead we need the directory name
+     */
+    projectName = path.basename(path.resolve(directoryName));
+  }
+
+  validateProjectName(projectName);
 
   try {
     await createProject(projectName, directoryName, version, options);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -5,7 +5,7 @@ import minimist from 'minimist';
 import ora from 'ora';
 import mkdirp from 'mkdirp';
 import {validateProjectName} from './validate';
-import DirectoryContainsConflictingFilesError from './errors/DirectoryContainsConflictingFilesError';
+import {validateProjectDirectory} from './validateProjectDirectory';
 import printRunInstructions from './printRunInstructions';
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import {
@@ -38,45 +38,6 @@ interface TemplateOptions {
   directory: string;
   projectTitle?: string;
   skipInstall?: boolean;
-}
-
-function validateProjectDirectory(directory: string) {
-  const validFiles = [
-    '.DS_Store',
-    '.git',
-    '.gitattributes',
-    '.gitignore',
-    '.gitlab-ci.yml',
-    '.hg',
-    '.hgcheck',
-    '.hgignore',
-    '.idea',
-    '.npmignore',
-    '.travis.yml',
-    'docs',
-    'LICENSE',
-    'README.md',
-    'mkdocs.yml',
-    'Thumbs.db',
-  ];
-
-  const conflicts = fs
-    .readdirSync(directory)
-    .filter((file) => {
-      return (
-        !validFiles.includes(file) &&
-        // IntelliJ IDEA creates module files before CRA is launched
-        !/\.iml$/.test(file)
-      );
-    })
-    .map((file) => {
-      const stats = fs.lstatSync(path.join(directory, file));
-      return `${file}${stats.isDirectory() ? '/' : ''}`;
-    });
-
-  if (conflicts.length > 0) {
-    throw new DirectoryContainsConflictingFilesError(directory, conflicts);
-  }
 }
 
 async function setProjectDirectory(directory: string) {

--- a/packages/cli/src/commands/init/validateProjectDirectory.ts
+++ b/packages/cli/src/commands/init/validateProjectDirectory.ts
@@ -22,6 +22,10 @@ const validFiles = [
 ];
 
 export function validateProjectDirectory(directory: string) {
+  if (!fs.existsSync(directory)) {
+    return;
+  }
+
   const conflicts = fs
     .readdirSync(directory)
     .filter((file) => {

--- a/packages/cli/src/commands/init/validateProjectDirectory.ts
+++ b/packages/cli/src/commands/init/validateProjectDirectory.ts
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+import DirectoryContainsConflictingFilesError from './errors/DirectoryContainsConflictingFilesError';
+
+const validFiles = [
+  '.DS_Store',
+  '.git',
+  '.gitattributes',
+  '.gitignore',
+  '.gitlab-ci.yml',
+  '.hg',
+  '.hgcheck',
+  '.hgignore',
+  '.idea',
+  '.npmignore',
+  '.travis.yml',
+  'docs',
+  'LICENSE',
+  'README.md',
+  'mkdocs.yml',
+  'Thumbs.db',
+];
+
+export function validateProjectDirectory(directory: string) {
+  const conflicts = fs
+    .readdirSync(directory)
+    .filter((file) => {
+      return (
+        !validFiles.includes(file) &&
+        // IntelliJ IDEA creates module files before CRA is launched
+        !/\.iml$/.test(file)
+      );
+    })
+    .map((file) => {
+      const stats = fs.lstatSync(path.join(directory, file));
+      return `${file}${stats.isDirectory() ? '/' : ''}`;
+    });
+
+  if (conflicts.length > 0) {
+    throw new DirectoryContainsConflictingFilesError(directory, conflicts);
+  }
+}


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
This PR makes changes to allow initializing a new react-native project in an already existing directory, only if there aren't any conflicting files/sub-directories

This behavior is directly influenced by create-react-app

Test Plan:
----------
tested on local machine(windows). All these commands work properly
- `npx react-native init --directory dummydir app`
    - directory: `.\dummydir`
    - projectName: `app`
- `npx-react-native init --directory dummydir\dir1\dir2 app`
    - directory: `.\dummydir\dir1\dir2`
    - projectName: `app`
- `npx react-native init dummydir\dir1\dir2`
    - directory: `.\dummydir\dir1\dir2`
    - projectName: `dir2`
- `npx react-native init app`
    - directory: `.\app`
    - projectName: `app`

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Refs: #1418
