### PR TITLE
chore: update peerDependencies to RN 0.65

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jest-circus": "^26.6.2",
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^3.22.1",
-    "metro-memory-fs": "^0.64.0",
+    "metro-memory-fs": "^0.66.0",
     "micromatch": "^3.1.10",
     "mkdirp": "^0.5.3",
     "rimraf": "^3.0.2",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,7 @@
     "wcwidth": "^1.0.1"
   },
   "peerDependencies": {
-    "react-native": ">=0.64.0-rc.0 || 0.0.0-*"
+    "react-native": ">=0.65.0-rc.0 || 0.0.0-*"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7985,10 +7985,10 @@ metro-inspector-proxy@0.66.0:
     ws "^1.1.5"
     yargs "^15.3.1"
 
-metro-memory-fs@^0.64.0:
-  version "0.64.0"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.64.0.tgz#9e6f8fc6d68952a34083647c733e9bfff6ae7da0"
-  integrity sha512-icuA1wiIVD3UgUZI2jQzf4wGW5RNegp4k55EuOjJL8Fi0l4DhxAv2Y0WLXIGiKoYIQLDTAnlXspJPnKvqeZFgQ==
+metro-memory-fs@^0.66.0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.66.0.tgz#634bfc7851f1c50acab3ac5097d5fe4d52424cf9"
+  integrity sha512-jk94Kbfv2cZeJdSxrI5CDbUxuvl1W3G+EQd0UV8gkSFvAqJHvglyg2OKbaMrtKGWqxUAKu0EQTU7PkhX7LF9kQ==
 
 metro-minify-uglify@0.66.0:
   version "0.66.0"


### PR DESCRIPTION
Summary:
---------

CLI v6 is intended to be used with RN 0.65, so let's keep that in sync

Test Plan:
----------

None