### PR TITLE
have pod install error message show correct directory

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -133,10 +133,10 @@ async function createFromTemplate({
 
     if (!skipInstall) {
       await installDependencies({
-        projectName,
         npm,
         loader,
         root: projectDirectory,
+        directory,
       });
     } else {
       loader.succeed('Dependencies installation skipped');
@@ -150,12 +150,12 @@ async function createFromTemplate({
 }
 
 async function installDependencies({
-  projectName,
+  directory,
   npm,
   loader,
   root,
 }: {
-  projectName: string;
+  directory: string;
   npm?: boolean;
   loader: ora.Ora;
   root: string;
@@ -169,7 +169,7 @@ async function installDependencies({
   });
 
   if (process.platform === 'darwin') {
-    await installPods({projectName, loader});
+    await installPods({directory, loader});
   }
 
   loader.succeed();

--- a/packages/cli/src/commands/init/initCompat.ts
+++ b/packages/cli/src/commands/init/initCompat.ts
@@ -89,7 +89,7 @@ async function generateProject(
   if (process.platform === 'darwin') {
     logger.info('Installing required CocoaPods dependencies');
 
-    await installPods({projectName: newProjectName});
+    await installPods({directory: destinationRoot});
   }
 
   printRunInstructions(destinationRoot, newProjectName);

--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -201,7 +201,7 @@ const installCocoaPodsDeps = async (projectDir: string) => {
         )}`,
       );
       await installPods({
-        projectName: projectDir.split('/').pop() || '',
+        directory: projectDir.split('/').pop() || '',
       });
     } catch (error) {
       if (error.stderr) {

--- a/packages/cli/src/tools/installPods.ts
+++ b/packages/cli/src/tools/installPods.ts
@@ -16,7 +16,7 @@ type PromptCocoaPodsInstallation = {
 
 async function runPodInstall(
   loader: ora.Ora,
-  projectName: string,
+  directory: string,
   shouldHandleRepoUpdate: boolean = true,
 ) {
   try {
@@ -39,11 +39,11 @@ async function runPodInstall(
      */
     if (stderr.includes('pod repo update') && shouldHandleRepoUpdate) {
       await runPodUpdate(loader);
-      await runPodInstall(loader, projectName, false);
+      await runPodInstall(loader, directory, false);
     } else {
       loader.fail();
       throw new Error(
-        `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${projectName}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
+        `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${directory}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
           'https://cocoapods.org/',
         )}`,
       );
@@ -162,10 +162,10 @@ async function installCocoaPods(loader: ora.Ora) {
 }
 
 async function installPods({
-  projectName,
+  directory,
   loader,
 }: {
-  projectName: string;
+  directory: string;
   loader?: ora.Ora;
 }) {
   loader = loader || new NoopLoader();
@@ -192,7 +192,7 @@ async function installPods({
       await installCocoaPods(loader);
     }
 
-    await runPodInstall(loader, projectName);
+    await runPodInstall(loader, directory);
   } catch (error) {
     throw error;
   } finally {


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

When initialising a new project, if you set a `--directory` and then got an error during `pod install`, it would show the wrong command to fix it.

```sh
$ react-native init TestProject --directory test-project
# an error happens during pod install
error Error: Failed to install CocoaPods dependencies for iOS project, which is required by this template.
Please try again manually: "cd ./TestProject/ios && pod install".
```

after my change:

```sh
$ react-native init TestProject --directory test-project
# an error happens during pod install
error Error: Failed to install CocoaPods dependencies for iOS project, which is required by this template.
Please try again manually: "cd ./test-project/ios && pod install"
```

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

- Break `pod install` somehow (I just unset ruby in my ruby version manager - you could probably add `pod() { exit 1 }` to your shell init file tho)
- `yarn` in the root of the project
- `node packages/cli/build/bin.js init TestProject --directory test-project`
- observe the result.
