### PR TITLE
feat: Added custom scope method for android dependencies

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -67,7 +67,7 @@ type DependencyParamsAndroidT = {
   packageImportPath?: string;
   packageInstance?: string;
   buildTypes?: string[];
-  dependencyConfiguration?: string;
+  customDependencyConfiguration?: string;
 };
 ```
 
@@ -136,7 +136,7 @@ For settings applicable on other platforms, please consult their respective docu
 
 An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. If you're working on a helper library that should only be included in development, such as a replacement for the React Native development menu, you should set this to `['debug']` to avoid shipping the library in a release build. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
 
-### platforms.android.dependencyConfiguration
+### platforms.android.customDependencyConfiguration
 
 A string that defines which method other than `implementation` do you want to use
 for autolinking inside `build.gradle` i.e: `'embed project(path: ":$dependencyName", configuration: "default")',` - `"dependencyName` will be replaced by the actual package's name. You can achieve the same result by directly defining this key per `dependency` _(without placeholder)_ and it will have higher priority than this option.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -20,7 +20,7 @@ module.exports = {
         project: './Custom.xcodeproj'
       }
     }
-    assets: ['./assets']
+    assets: ['./assets']e
   }
 };
 ```
@@ -67,6 +67,7 @@ type DependencyParamsAndroidT = {
   packageImportPath?: string;
   packageInstance?: string;
   buildTypes?: string[];
+  customDependencyConfiguration?: string;
 };
 ```
 
@@ -134,6 +135,11 @@ For settings applicable on other platforms, please consult their respective docu
 #### platforms.android.buildTypes
 
 An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. If you're working on a helper library that should only be included in development, such as a replacement for the React Native development menu, you should set this to `['debug']` to avoid shipping the library in a release build. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
+
+### platforms.android.customDependencyConfiguration
+
+A string that defines which method other than `implementation` do you want to use
+for autolinking inside `build.gradle` i.e: `'embed project(path: ":$dependencyName", configuration: "default")',` - `"dependencyName` will be replaced by the actual package's name. You can achieve the same result by directly defining this key per `dependency` _(without placeholder)_ and it will have higher priority than this option.
 
 ### assets
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -20,7 +20,7 @@ module.exports = {
         project: './Custom.xcodeproj'
       }
     }
-    assets: ['./assets']e
+    assets: ['./assets']
   }
 };
 ```

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -67,7 +67,7 @@ type DependencyParamsAndroidT = {
   packageImportPath?: string;
   packageInstance?: string;
   buildTypes?: string[];
-  customDependencyConfiguration?: string;
+  dependencyConfiguration?: string;
 };
 ```
 
@@ -136,7 +136,7 @@ For settings applicable on other platforms, please consult their respective docu
 
 An array of build variants or flavors which will include the dependency. If the array is empty, your dependency will be included in all build types. If you're working on a helper library that should only be included in development, such as a replacement for the React Native development menu, you should set this to `['debug']` to avoid shipping the library in a release build. For more details, see [`build variants`](https://developer.android.com/studio/build/build-variants#dependencies).
 
-### platforms.android.customDependencyConfiguration
+### platforms.android.dependencyConfiguration
 
 A string that defines which method other than `implementation` do you want to use
 for autolinking inside `build.gradle` i.e: `'embed project(path: ":$dependencyName", configuration: "default")',` - `"dependencyName` will be replaced by the actual package's name. You can achieve the same result by directly defining this key per `dependency` _(without placeholder)_ and it will have higher priority than this option.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -60,10 +60,9 @@ type PlatformConfig<ProjectParams, ProjectConfig, DependencyConfig> = {
 
 ### npmPackageName
 
-Returns the name of the npm package that should be used as the source for react-native JS code for platforms that provide platform specific overrides to core JS files.  This causes the default metro config to redirect imports of react-native to another package based when bundling for that platform.  The package specified should provide a complete react-native implementation for that platform.
+Returns the name of the npm package that should be used as the source for react-native JS code for platforms that provide platform specific overrides to core JS files. This causes the default metro config to redirect imports of react-native to another package based when bundling for that platform. The package specified should provide a complete react-native implementation for that platform.
 
 If this property is not specified, it is assumed that the code in core `react-native` works for the platform.
-
 
 ### projectConfig
 
@@ -112,6 +111,7 @@ type ProjectConfigAndroidT = {
   packageName: string;
   packageFolder: string;
   appName: string;
+  customDependencyConfiguration?: string;
 };
 ```
 
@@ -145,6 +145,7 @@ type DependencyConfigAndroidT = {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
+  customDependencyConfiguration?: string;
 };
 ```
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -111,7 +111,7 @@ type ProjectConfigAndroidT = {
   packageName: string;
   packageFolder: string;
   appName: string;
-  dependencyConfiguration?: string;
+  customDependencyConfiguration?: string;
 };
 ```
 
@@ -145,7 +145,7 @@ type DependencyConfigAndroidT = {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
-  dependencyConfiguration?: string;
+  customDependencyConfiguration?: string;
 };
 ```
 

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -111,7 +111,7 @@ type ProjectConfigAndroidT = {
   packageName: string;
   packageFolder: string;
   appName: string;
-  customDependencyConfiguration?: string;
+  dependencyConfiguration?: string;
 };
 ```
 
@@ -145,7 +145,7 @@ type DependencyConfigAndroidT = {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
-  customDependencyConfiguration?: string;
+  dependencyConfiguration?: string;
 };
 ```
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -41,7 +41,7 @@ type ProjectConfigT = {
       root: string,
       platforms: {
         [key: string]: PlatformSettingsT
-      };
+      },
       assets: string[],
       hooks: {
         [key: string]: string

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -77,7 +77,7 @@ type AndroidProjectParams = {
   assetsPath?: string;
   buildGradlePath?: string;
   appName?: string; // A name of the app in the Android `sourceDir`, equivalent to Gradle project name. By default it's `app`.
-  dependencyConfiguration?: string;
+  customDependencyConfiguration?: string;
 };
 
 type IOSProjectParams = {
@@ -130,7 +130,7 @@ module.exports = {
     'react-native-brownfield': {
       platforms: {
         android: {
-          dependencyConfiguration:
+          customDependencyConfiguration:
             'embed project(path: ":react-native-brownfield-bridge", configuration: "default")',
         },
       },

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -27,28 +27,28 @@ You can check all available options below.
 
 ```ts
 type ProjectConfigT = {
-  reactNativePath: ?string;
+  reactNativePath: ?string,
   project: {
-    android?: ProjectParamsAndroidT;
-    ios?: IOSProjectParams;
-    [key: string]: any;
+    android?: ProjectParamsAndroidT,
+    ios?: IOSProjectParams,
+    [key: string]: any,
   };
-  assets: string[];
-  platforms: PlatformT;
+  assets: string[],
+  platforms: PlatformT,
   dependencies: {
     [key: string]: {
-      name: string;
-      root: string;
+      name: string,
+      root: string,
       platforms: {
-        [key: string]: PlatformSettingsT;
+        [key: string]: PlatformSettingsT,
       };
-      assets: string[];
+      assets: string[],
       hooks: {
-        [key: string]: string;
-      };
-    };
-  };
-  commands: CommandT[];
+        [key: string]: string,
+      },
+    },
+  },
+  commands: CommandT[],
 };
 ```
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -27,28 +27,28 @@ You can check all available options below.
 
 ```ts
 type ProjectConfigT = {
-  reactNativePath: ?string,
+  reactNativePath: ?string;
   project: {
-    android?: ProjectParamsAndroidT,
-    ios?: IOSProjectParams,
-    [key: string]: any,
-  },
-  assets: string[],
-  platforms: PlatformT,
+    android?: ProjectParamsAndroidT;
+    ios?: IOSProjectParams;
+    [key: string]: any;
+  };
+  assets: string[];
+  platforms: PlatformT;
   dependencies: {
     [key: string]: {
-      name: string,
-      root: string,
+      name: string;
+      root: string;
       platforms: {
-        [key: string]: PlatformSettingsT
-      },
-      assets: string[],
+        [key: string]: PlatformSettingsT;
+      };
+      assets: string[];
       hooks: {
-        [key: string]: string
-      }
-    },
-  },
-  commands: CommandT[]
+        [key: string]: string;
+      };
+    };
+  };
+  commands: CommandT[];
 };
 ```
 
@@ -77,6 +77,7 @@ type AndroidProjectParams = {
   assetsPath?: string;
   buildGradlePath?: string;
   appName?: string; // A name of the app in the Android `sourceDir`, equivalent to Gradle project name. By default it's `app`.
+  customDependencyConfiguration?: string;
 };
 
 type IOSProjectParams = {
@@ -120,6 +121,25 @@ module.exports = {
 ```
 
 in order to disable linking of React Native WebView on iOS.
+
+or you could set:
+
+```js
+module.exports = {
+  dependencies: {
+    'react-native-brownfield': {
+      platforms: {
+        android: {
+          customDependencyConfiguration:
+            'embed project(path: ":react-native-brownfield-bridge", configuration: "default")',
+        },
+      },
+    },
+  },
+};
+```
+
+in order to use something else than `implementation` _(default scope method)_
 
 Another use-case would be supporting local libraries that are not discoverable for autolinking, since they're not part of your `dependencies` or `devDependencies`:
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -77,7 +77,7 @@ type AndroidProjectParams = {
   assetsPath?: string;
   buildGradlePath?: string;
   appName?: string; // A name of the app in the Android `sourceDir`, equivalent to Gradle project name. By default it's `app`.
-  customDependencyConfiguration?: string;
+  dependencyConfiguration?: string;
 };
 
 type IOSProjectParams = {
@@ -130,7 +130,7 @@ module.exports = {
     'react-native-brownfield': {
       platforms: {
         android: {
-          customDependencyConfiguration:
+          dependencyConfiguration:
             'embed project(path: ":react-native-brownfield-bridge", configuration: "default")',
         },
       },

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -32,7 +32,7 @@ type ProjectConfigT = {
     android?: ProjectParamsAndroidT,
     ios?: IOSProjectParams,
     [key: string]: any,
-  };
+  },
   assets: string[],
   platforms: PlatformT,
   dependencies: {
@@ -40,15 +40,15 @@ type ProjectConfigT = {
       name: string,
       root: string,
       platforms: {
-        [key: string]: PlatformSettingsT,
+        [key: string]: PlatformSettingsT
       };
       assets: string[],
       hooks: {
-        [key: string]: string,
-      },
+        [key: string]: string
+      }
     },
   },
-  commands: CommandT[],
+  commands: CommandT[]
 };
 ```
 

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -22,6 +22,7 @@ export interface AndroidDependencyConfig {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
+  customScope?: string;
   buildTypes: string[];
 }
 

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -11,7 +11,7 @@ export interface AndroidProjectConfig {
   packageName: string;
   packageFolder: string;
   appName: string;
-  customDependencyConfiguration?: string;
+  dependencyConfiguration?: string;
 }
 
 export type AndroidProjectParams = Partial<AndroidProjectConfig>;
@@ -23,7 +23,7 @@ export interface AndroidDependencyConfig {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
-  customDependencyConfiguration?: string;
+  dependencyConfiguration?: string;
   buildTypes: string[];
 }
 

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -11,6 +11,7 @@ export interface AndroidProjectConfig {
   packageName: string;
   packageFolder: string;
   appName: string;
+  customDependencyConfiguration?: string;
 }
 
 export type AndroidProjectParams = Partial<AndroidProjectConfig>;
@@ -22,7 +23,7 @@ export interface AndroidDependencyConfig {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
-  customScope?: string;
+  customDependencyConfiguration?: string;
   buildTypes: string[];
 }
 

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -11,7 +11,7 @@ export interface AndroidProjectConfig {
   packageName: string;
   packageFolder: string;
   appName: string;
-  dependencyConfiguration?: string;
+  customDependencyConfiguration?: string;
 }
 
 export type AndroidProjectParams = Partial<AndroidProjectConfig>;
@@ -23,7 +23,7 @@ export interface AndroidDependencyConfig {
   packageInstance: string;
   manifestPath: string;
   packageName: string;
-  dependencyConfiguration?: string;
+  customDependencyConfiguration?: string;
   buildTypes: string[];
 }
 

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -75,6 +75,7 @@ export const dependencyConfig = t
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
+                customScope: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .default({}),

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -75,7 +75,7 @@ export const dependencyConfig = t
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                dependencyConfiguration: t.string(),
+                customDependencyConfiguration: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .default({}),
@@ -141,7 +141,7 @@ export const projectConfig = t
                 folder: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                dependencyConfiguration: t.string(),
+                customDependencyConfiguration: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .allow(null),
@@ -180,7 +180,7 @@ export const projectConfig = t
             assetsPath: t.string(),
             buildGradlePath: t.string(),
             appName: t.string(),
-            dependencyConfiguration: t.string(),
+            customDependencyConfiguration: t.string(),
           })
           .default({}),
       })

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -75,7 +75,7 @@ export const dependencyConfig = t
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                customScope: t.string(),
+                customDependencyConfiguration: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .default({}),
@@ -141,6 +141,7 @@ export const projectConfig = t
                 folder: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
+                customDependencyConfiguration: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .allow(null),
@@ -179,6 +180,7 @@ export const projectConfig = t
             assetsPath: t.string(),
             buildGradlePath: t.string(),
             appName: t.string(),
+            customDependencyConfiguration: t.string(),
           })
           .default({}),
       })

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -75,7 +75,7 @@ export const dependencyConfig = t
                 manifestPath: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                customDependencyConfiguration: t.string(),
+                dependencyConfiguration: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .default({}),
@@ -141,7 +141,7 @@ export const projectConfig = t
                 folder: t.string(),
                 packageImportPath: t.string(),
                 packageInstance: t.string(),
-                customDependencyConfiguration: t.string(),
+                dependencyConfiguration: t.string(),
                 buildTypes: t.array().items(t.string()).default([]),
               })
               .allow(null),
@@ -180,7 +180,7 @@ export const projectConfig = t
             assetsPath: t.string(),
             buildGradlePath: t.string(),
             appName: t.string(),
-            customDependencyConfiguration: t.string(),
+            dependencyConfiguration: t.string(),
           })
           .default({}),
       })

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -105,21 +105,21 @@ class ReactNativeModules {
   void addReactNativeModuleDependencies(Project appProject) {
     reactNativeModules.forEach { reactNativeModule ->
       def nameCleansed = reactNativeModule["nameCleansed"]
-      def customDependencyConfiguration = reactNativeModule["customDependencyConfiguration"]
+      def dependencyConfiguration = reactNativeModule["dependencyConfiguration"]
       appProject.dependencies {
         if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
           reactNativeModulesBuildVariants
             .get(nameCleansed)
             .forEach { buildVariant -> 
-              if(customDependencyConfiguration != null) {
-                "${buildVariant}${customDependencyConfiguration}"
+              if(dependencyConfiguration != null) {
+                "${buildVariant}${dependencyConfiguration}"
               } else {
                 "${buildVariant}Implementation" project(path: ":${nameCleansed}")
               }
             }
         } else {
-          if(customDependencyConfiguration != null) {
-            "${customDependencyConfiguration}"
+          if(dependencyConfiguration != null) {
+            "${dependencyConfiguration}"
           } else {
              implementation project(path: ":${nameCleansed}")
           }
@@ -275,13 +275,13 @@ class ReactNativeModules {
         if (!androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
         }
-        if(androidConfig.containsKey("customDependencyConfiguration")) {
-          reactNativeModuleConfig.put("customDependencyConfiguration", androidConfig["customDependencyConfiguration"])
-        } else if (project.containsKey("customDependencyConfiguration")) {
+        if(androidConfig.containsKey("dependencyConfiguration")) {
+          reactNativeModuleConfig.put("dependencyConfiguration", androidConfig["dependencyConfiguration"])
+        } else if (project.containsKey("dependencyConfiguration")) {
           def bindings = ["dependencyName": nameCleansed]
-          def template = engine.createTemplate(project["customDependencyConfiguration"]).make(bindings)
+          def template = engine.createTemplate(project["dependencyConfiguration"]).make(bindings)
 
-          reactNativeModuleConfig.put("customDependencyConfiguration", template.toString())
+          reactNativeModuleConfig.put("dependencyConfiguration", template.toString())
         }
 
         this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -105,16 +105,25 @@ class ReactNativeModules {
   void addReactNativeModuleDependencies(Project appProject) {
     reactNativeModules.forEach { reactNativeModule ->
       def nameCleansed = reactNativeModule["nameCleansed"]
+      def customScope = reactNativeModule["customScope"]
       appProject.dependencies {
         if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
           reactNativeModulesBuildVariants
             .get(nameCleansed)
-            .forEach { buildVariant ->
-              "${buildVariant}Implementation" project(path: ":${nameCleansed}")
+            .forEach { buildVariant -> {
+              if(customScope != null) {
+                "${buildVariant}${customScope}"
+              } else {
+                "${buildVariant}Implementation" project(path: ":${nameCleansed}")
+              }
+              }
             }
         } else {
-          // TODO(salakar): are other dependency scope methods such as `api` required?
-          implementation project(path: ":${nameCleansed}")
+          if(customScope != null) {
+            "${customScope}"
+          } else {
+             implementation project(path: ":${nameCleansed}")
+          }
         }
       }
     }
@@ -264,6 +273,9 @@ class ReactNativeModules {
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
         if (!androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
+        }
+        if(androidConfig.containsKey("customScope")) {
+          reactNativeModuleConfig.put("customScope", androidConfig["customScope"])
         }
         this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
         

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -105,22 +105,21 @@ class ReactNativeModules {
   void addReactNativeModuleDependencies(Project appProject) {
     reactNativeModules.forEach { reactNativeModule ->
       def nameCleansed = reactNativeModule["nameCleansed"]
-      def customScope = reactNativeModule["customScope"]
+      def customDependencyConfiguration = reactNativeModule["customDependencyConfiguration"]
       appProject.dependencies {
         if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
           reactNativeModulesBuildVariants
             .get(nameCleansed)
-            .forEach { buildVariant -> {
-              if(customScope != null) {
-                "${buildVariant}${customScope}"
+            .forEach { buildVariant -> 
+              if(customDependencyConfiguration != null) {
+                "${buildVariant}${customDependencyConfiguration}"
               } else {
                 "${buildVariant}Implementation" project(path: ":${nameCleansed}")
               }
-              }
             }
         } else {
-          if(customScope != null) {
-            "${customScope}"
+          if(customDependencyConfiguration != null) {
+            "${customDependencyConfiguration}"
           } else {
              implementation project(path: ":${nameCleansed}")
           }
@@ -257,6 +256,8 @@ class ReactNativeModules {
       throw new Exception("React Native CLI failed to determine Android project configuration. This is likely due to misconfiguration. Config output:\n${json.toMapString()}")
     }
 
+    def engine = new groovy.text.SimpleTemplateEngine()
+
     dependencies.each { name, value ->
       def platformsConfig = value["platforms"];
       def androidConfig = platformsConfig["android"]
@@ -274,9 +275,15 @@ class ReactNativeModules {
         if (!androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
         }
-        if(androidConfig.containsKey("customScope")) {
-          reactNativeModuleConfig.put("customScope", androidConfig["customScope"])
+        if(androidConfig.containsKey("customDependencyConfiguration")) {
+          reactNativeModuleConfig.put("customDependencyConfiguration", androidConfig["customDependencyConfiguration"])
+        } else if (project.containsKey("customDependencyConfiguration")) {
+          def bindings = ["dependencyName": nameCleansed]
+          def template = engine.createTemplate(project["customDependencyConfiguration"]).make(bindings)
+
+          reactNativeModuleConfig.put("customDependencyConfiguration", template.toString())
         }
+
         this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
         
         reactNativeModules.add(reactNativeModuleConfig)

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -105,21 +105,21 @@ class ReactNativeModules {
   void addReactNativeModuleDependencies(Project appProject) {
     reactNativeModules.forEach { reactNativeModule ->
       def nameCleansed = reactNativeModule["nameCleansed"]
-      def dependencyConfiguration = reactNativeModule["dependencyConfiguration"]
+      def customDependencyConfiguration = reactNativeModule["customDependencyConfiguration"]
       appProject.dependencies {
         if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
           reactNativeModulesBuildVariants
             .get(nameCleansed)
             .forEach { buildVariant -> 
-              if(dependencyConfiguration != null) {
-                "${buildVariant}${dependencyConfiguration}"
+              if(customDependencyConfiguration != null) {
+                "${buildVariant}${customDependencyConfiguration}"
               } else {
                 "${buildVariant}Implementation" project(path: ":${nameCleansed}")
               }
             }
         } else {
-          if(dependencyConfiguration != null) {
-            "${dependencyConfiguration}"
+          if(customDependencyConfiguration != null) {
+            "${customDependencyConfiguration}"
           } else {
              implementation project(path: ":${nameCleansed}")
           }
@@ -275,13 +275,13 @@ class ReactNativeModules {
         if (!androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
         }
-        if(androidConfig.containsKey("dependencyConfiguration")) {
-          reactNativeModuleConfig.put("dependencyConfiguration", androidConfig["dependencyConfiguration"])
-        } else if (project.containsKey("dependencyConfiguration")) {
+        if(androidConfig.containsKey("customDependencyConfiguration")) {
+          reactNativeModuleConfig.put("customDependencyConfiguration", androidConfig["customDependencyConfiguration"])
+        } else if (project.containsKey("customDependencyConfiguration")) {
           def bindings = ["dependencyName": nameCleansed]
-          def template = engine.createTemplate(project["dependencyConfiguration"]).make(bindings)
+          def template = engine.createTemplate(project["customDependencyConfiguration"]).make(bindings)
 
-          reactNativeModuleConfig.put("dependencyConfiguration", template.toString())
+          reactNativeModuleConfig.put("customDependencyConfiguration", template.toString())
         }
 
         this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -84,6 +84,9 @@ export function projectConfig(
     userConfig.buildGradlePath || 'build.gradle',
   );
 
+  const customDependencyConfiguration =
+    userConfig.customDependencyConfiguration;
+
   return {
     sourceDir,
     isFlat,
@@ -97,6 +100,7 @@ export function projectConfig(
     packageName,
     packageFolder,
     appName,
+    customDependencyConfiguration,
   };
 }
 
@@ -155,7 +159,8 @@ export function dependencyConfig(
     userConfig.packageInstance || `new ${packageClassName}()`;
 
   const buildTypes = userConfig.buildTypes || [];
-  const customScope = userConfig.customScope;
+  const customDependencyConfiguration =
+    userConfig.customDependencyConfiguration;
 
   return {
     sourceDir,
@@ -163,6 +168,6 @@ export function dependencyConfig(
     packageImportPath,
     packageInstance,
     buildTypes,
-    customScope,
+    customDependencyConfiguration,
   };
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -84,8 +84,8 @@ export function projectConfig(
     userConfig.buildGradlePath || 'build.gradle',
   );
 
-  const customDependencyConfiguration =
-    userConfig.customDependencyConfiguration;
+  const dependencyConfiguration =
+    userConfig.dependencyConfiguration;
 
   return {
     sourceDir,
@@ -100,7 +100,7 @@ export function projectConfig(
     packageName,
     packageFolder,
     appName,
-    customDependencyConfiguration,
+    dependencyConfiguration,
   };
 }
 
@@ -159,8 +159,8 @@ export function dependencyConfig(
     userConfig.packageInstance || `new ${packageClassName}()`;
 
   const buildTypes = userConfig.buildTypes || [];
-  const customDependencyConfiguration =
-    userConfig.customDependencyConfiguration;
+  const dependencyConfiguration =
+    userConfig.dependencyConfiguration;
 
   return {
     sourceDir,
@@ -168,6 +168,6 @@ export function dependencyConfig(
     packageImportPath,
     packageInstance,
     buildTypes,
-    customDependencyConfiguration,
+    dependencyConfiguration,
   };
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -84,8 +84,8 @@ export function projectConfig(
     userConfig.buildGradlePath || 'build.gradle',
   );
 
-  const dependencyConfiguration =
-    userConfig.dependencyConfiguration;
+  const customDependencyConfiguration =
+    userConfig.customDependencyConfiguration;
 
   return {
     sourceDir,
@@ -100,7 +100,7 @@ export function projectConfig(
     packageName,
     packageFolder,
     appName,
-    dependencyConfiguration,
+    customDependencyConfiguration,
   };
 }
 
@@ -159,8 +159,8 @@ export function dependencyConfig(
     userConfig.packageInstance || `new ${packageClassName}()`;
 
   const buildTypes = userConfig.buildTypes || [];
-  const dependencyConfiguration =
-    userConfig.dependencyConfiguration;
+  const customDependencyConfiguration =
+    userConfig.customDependencyConfiguration;
 
   return {
     sourceDir,
@@ -168,6 +168,6 @@ export function dependencyConfig(
     packageImportPath,
     packageInstance,
     buildTypes,
-    dependencyConfiguration,
+    customDependencyConfiguration,
   };
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -155,6 +155,7 @@ export function dependencyConfig(
     userConfig.packageInstance || `new ${packageClassName}()`;
 
   const buildTypes = userConfig.buildTypes || [];
+  const customScope = userConfig.customScope;
 
   return {
     sourceDir,
@@ -162,5 +163,6 @@ export function dependencyConfig(
     packageImportPath,
     packageInstance,
     buildTypes,
+    customScope,
   };
 }


### PR DESCRIPTION
### Summary:
This PR continues idea from this previous [PR](https://github.com/react-native-community/cli/pull/1177)
It allows user to define `customDependencyConfiguration` per project(`project.android`) and also per module itself inside `dependencies[packageName].android` key
```js
module.exports = {
  project: {
    android: {
      customDependencyConfiguration:
        'embed project(path: ":$dependencyName", configuration: "default")',
    },
  },
  dependencies: {
    'react-native-brownfield': {
      platforms: {
        android: {
          customDependencyConfiguration:
            'embed project(path: ":react-native-brownfield-bridge", configuration: "default")',
        },
      },
    },
  },
};
```
Test Plan:
Init new project and checked whether applied config is correct.
