### PR TITLE
fix(cli-hermes): profile-hermes doesn't work on Win

### DIFF
--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -16,7 +16,7 @@ import {
  */
 function getLatestFile(packageName: string): string {
   try {
-    const file = execSync(`adb shell run-as ${packageName} ls cache/ -tp | grep -v /$ | egrep '.cpuprofile' | head -1
+    const file = execSync(`adb shell run-as ${packageName} ls cache/ -tp | grep -v /$ | grep -E '.cpuprofile' | head -1
         `);
     return file.toString().trim();
   } catch (e) {


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
The command `profile-hermes` does not work on Windows, but replacing `egrep` with `grep -E` would at least 
allow it to work in git bash on Windows
Fixes #1431 

https://www.computerhope.com/unix/uegrep.htm
> Running egrep is equivalent to running grep with the -E option.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you 
verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I've tested this by manually running the `profile-hermes` on git bash.
- Before the change I would get an error  - "'egrep' is not recognized as an internal or external command"
- After the change the script finishes successfully and produces a `-converted.json` file