### PR TITLE
Print unsupported keypresses directly to console.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,15 @@ commands:
     steps:
       - attach_workspace:
           at: ~/react-native-cli
+      - restore_cache:
+          keys:
+            - v2-gradle-dependencies-{{ checksum "package.json" }}
+            - v2-gradle-dependencies-
       - run: yarn test:ci:e2e
+      - save_cache:
+          key: v2-gradle-dependencies-{{ checksum "package.json" }}
+          paths:
+            - ~/.gradle
 
 jobs:
   setup:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,17 +4,38 @@ trigger:
 pool:
   vmImage: 'windows-2019'
 
+variables:
+  YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+  GRADLE_USER_HOME: $(Pipeline.Workspace)/.gradle
+
 steps:
   - task: NodeTool@0
     inputs:
       versionSpec: '12.x'
     displayName: 'Install Node.js'
 
-  - script: yarn install
+  - task: Cache@2
+    inputs:
+      key: 'yarn | "$(Agent.OS)" | yarn.lock'
+      restoreKeys: |
+        yarn | "$(Agent.OS)"
+      path: $(YARN_CACHE_FOLDER)
+    displayName: Cache Yarn packages
+
+  - script: yarn --frozen-lockfile
     displayName: 'Install dependencies'
 
   - script: yarn test:ci:unit
     displayName: 'Unit tests'
+
+  - task: Cache@2
+    inputs:
+      key: 'gradle | "$(Agent.OS)" | **/package.json'
+      restoreKeys: |
+        gradle | "$(Agent.OS)"
+        gradle
+      path: $(GRADLE_USER_HOME)
+    displayName: Configure gradle caching
 
   - script: yarn test:ci:e2e
     displayName: 'E2E tests'

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidNDK.test.ts
@@ -13,7 +13,7 @@ describe('androidNDK', () => {
 
   beforeAll(async () => {
     environmentInfo = await getEnvironmentInfo();
-  }, 15000);
+  }, 60000);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidSDK.test.ts
@@ -50,7 +50,7 @@ describe('androidSDK', () => {
 
   beforeAll(async () => {
     environmentInfo = await getEnvironmentInfo();
-  }, 15000);
+  }, 60000);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/androidStudio.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/androidStudio.test.ts
@@ -17,7 +17,7 @@ describe('androidStudio', () => {
   beforeAll(async () => {
     environmentInfo = await getEnvironmentInfo();
     ((execa as unknown) as jest.Mock).mockResolvedValue({stdout: ''});
-  }, 15000);
+  }, 60000);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/__tests__/jdk.test.ts
@@ -27,7 +27,7 @@ describe('jdk', () => {
 
   beforeAll(async () => {
     environmentInfo = await getEnvironmentInfo();
-  }, 15000);
+  }, 60000);
 
   afterEach(() => {
     jest.resetAllMocks();

--- a/packages/cli/src/commands/start/watchMode.ts
+++ b/packages/cli/src/commands/start/watchMode.ts
@@ -48,6 +48,8 @@ function enableWatchMode(messageSocket: any) {
     } else if (name === 'd') {
       messageSocket.broadcast('devMenu', null);
       logger.info('Opening developer menu...');
+    } else {
+      console.log(_key);
     }
   });
 }

--- a/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli/src/tools/config/__tests__/__snapshots__/index-test.ts.snap
@@ -153,7 +153,7 @@ Object {
 
 exports[`should skip packages that have invalid configuration: dependencies config 1`] = `Object {}`;
 
-exports[`should skip packages that have invalid configuration: logged warning 1`] = `"Package [1mreact-native[22m has been ignored because it contains invalid configuration. Reason: [2m\\"dependency.invalidProperty\\" is not allowed[22m"`;
+exports[`should skip packages that have invalid configuration: logged warning 1`] = `"Package react-native has been ignored because it contains invalid configuration. Reason: \\"dependency.invalidProperty\\" is not allowed"`;
 
 exports[`supports dependencies from user configuration with custom build type 1`] = `
 Object {

--- a/packages/cli/src/tools/config/__tests__/index-test.ts
+++ b/packages/cli/src/tools/config/__tests__/index-test.ts
@@ -187,6 +187,7 @@ test('should load commands from "react-native-foo" and "react-native-bar" packag
 });
 
 test('should skip packages that have invalid configuration', () => {
+  process.env.FORCE_COLOR = '0'; // To disable chalk
   DIR = getTempDirectory('config_test_skip');
   writeFiles(DIR, {
     'node_modules/react-native/package.json': '{}',


### PR DESCRIPTION
Summary:
---------

Whenever you are reviewing logs for any app, adding a few blank lines in the console is an often used practice that stopped working with react-native in the recent releases. This was requested at https://github.com/facebook/metro/issues/663 a few months back and I recently faced this as I moved to Windows from Mac and clearing the console isn't a supported action yet (https://github.com/microsoft/terminal/issues/1882).

Test Plan:
----------

- Verified that existing handled actions (r, d, ctrl+c and ctrl+d) still work.
- All other keypresses are logged as it is to the screen.
