### PR TITLE
feat: look for Podfile in the source directory too

### DIFF
--- a/packages/platform-ios/src/config/index.ts
+++ b/packages/platform-ios/src/config/index.ts
@@ -54,7 +54,7 @@ export function projectConfig(folder: string, userConfig: IOSProjectParams) {
     sourceDir,
     folder,
     pbxprojPath: path.join(projectPath, 'project.pbxproj'),
-    podfile: findPodfilePath(projectPath),
+    podfile: findPodfilePath(projectPath) || findPodfilePath(sourceDir),
     podspecPath:
       userConfig.podspecPath ||
       // podspecs are usually placed in the root dir of the library or in the


### PR DESCRIPTION
Summary:
---------

I'm adding React Native to an existing native project. The project is fairly large, so it is split up into multiple subprojects and does not follow the typical React Native directory structure. Instead this is how it is setup:

```
ios/
| | | |_ Pods/
| | |__ **Podfile**
| |___ Project/Project.xcodeproj/
|____ ProjectReactNativeFramework/

... // Other subprojects
```

Currently, `cli` assumes that `Podfile` is a sibling of `Project.xcodeproj`. This change adds a feature enabling it to look for the `Podfile` from the source directory, if it is not found in the project directory.

Test Plan:
----------

- When I run `yarn react-native config`, the `Podfile` configuration value is no longer `null`.
- Running `yarn react-native run-ios` no longer throws the following error:

```
error Could not find "Podfile.lock" at null.lock. Did you run "pod install" in iOS directory?
```
