### PR TITLE
Init for current/existing folders

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -39,13 +39,12 @@ afterEach(() => {
   cleanupSync(DIR);
 });
 
-test('init fails if the directory already exists', () => {
+test('init passes if the directory already exists', () => {
   fs.mkdirSync(path.join(DIR, 'TestInit'));
 
-  const {stderr} = runCLI(DIR, ['init', 'TestInit'], {expectedFailure: true});
-  expect(stderr).toBe(
-    'error Cannot initialize new project because directory "TestInit" already exists.',
-  );
+  const {stdout} = runCLI(DIR, ['init', 'TestInit']);
+
+  expect(stdout).toContain('Run instructions');
 });
 
 test('init --template fails without package name', () => {

--- a/packages/cli/src/commands/init/errors/ConflictingFilesError.ts
+++ b/packages/cli/src/commands/init/errors/ConflictingFilesError.ts
@@ -1,0 +1,14 @@
+export default class ConflictingFilesError extends Error {
+  constructor(directoryName: string, files: string[]) {
+    let errorString = '';
+
+    errorString += `The directory ${directoryName} contains files that could conflict:\n`;
+    for (const file of files) {
+      errorString += `- ${file}\n`;
+    }
+    errorString +=
+      'Either try using a new directory name, or remove the files listed above.';
+
+    super(errorString);
+  }
+}

--- a/packages/cli/src/commands/init/getDirectoryFilesRecursive.ts
+++ b/packages/cli/src/commands/init/getDirectoryFilesRecursive.ts
@@ -8,25 +8,26 @@ export async function getDirectoryFilesRecursive(
   dir: string,
   startDir?: string,
 ): Promise<string[]> {
-  const entries = await readdir(dir, {
-    withFileTypes: true,
-  });
-
-  const files = entries
-    .filter((file) => !file.isDirectory())
-    .map((file) => dir + file.name);
-  const subdirs = entries
-    .filter((folder) => folder.isDirectory())
-    .map((folder) => folder.name);
-
-  for (const subdir of subdirs) {
-    files.push(
-      ...(await getDirectoryFilesRecursive(
-        path.join(dir, subdir),
-        startDir ?? dir,
-      )),
-    );
+  try {
+    const entries = await readdir(dir, {
+      withFileTypes: true,
+    });
+    const files = entries
+      .filter((file) => !file.isDirectory())
+      .map((file) => dir + file.name);
+    const subdirs = entries
+      .filter((folder) => folder.isDirectory())
+      .map((folder) => folder.name);
+    for (const subdir of subdirs) {
+      files.push(
+        ...(await getDirectoryFilesRecursive(
+          path.join(dir, subdir),
+          startDir ?? dir,
+        )),
+      );
+    }
+    return files.map((file) => file.replace(startDir ?? dir, ''));
+  } catch (err) {
+    return [];
   }
-
-  return files.map((file) => file.replace(startDir ?? dir, ''));
 }

--- a/packages/cli/src/commands/init/getDirectoryFilesRecursive.ts
+++ b/packages/cli/src/commands/init/getDirectoryFilesRecursive.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import {promisify} from 'util';
+
+const readdir = promisify(fs.readdir);
+
+export async function getDirectoryFilesRecursive(
+  dir: string,
+  startDir?: string,
+): Promise<string[]> {
+  const entries = await readdir(dir, {
+    withFileTypes: true,
+  });
+
+  const files = entries
+    .filter((file) => !file.isDirectory())
+    .map((file) => dir + file.name);
+  const subdirs = entries
+    .filter((folder) => folder.isDirectory())
+    .map((folder) => folder.name);
+
+  for (const subdir of subdirs) {
+    files.push(
+      ...(await getDirectoryFilesRecursive(
+        path.join(dir, subdir),
+        startDir ?? dir,
+      )),
+    );
+  }
+
+  return files.map((file) => file.replace(startDir ?? dir, ''));
+}

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -44,10 +44,10 @@ function doesDirectoryExist(dir: string) {
 }
 
 async function setProjectDirectory(directory: string) {
-  if (directory !== '' && !doesDirectoryExist(directory)) {
+  const projectDirectory = path.join(process.cwd(), directory);
+  if (!doesDirectoryExist(projectDirectory)) {
     try {
-      mkdirp.sync(directory);
-      process.chdir(directory);
+      mkdirp.sync(projectDirectory);
     } catch (error) {
       throw new CLIError(
         'Error occurred while trying to create project directory.',
@@ -55,7 +55,8 @@ async function setProjectDirectory(directory: string) {
       );
     }
   }
-  return process.cwd();
+  process.chdir(projectDirectory);
+  return projectDirectory;
 }
 
 function getTemplateName(cwd: string) {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -5,7 +5,6 @@ import minimist from 'minimist';
 import ora from 'ora';
 import mkdirp from 'mkdirp';
 import {validateProjectName} from './validate';
-import DirectoryAlreadyExistsError from './errors/DirectoryAlreadyExistsError';
 import printRunInstructions from './printRunInstructions';
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import {
@@ -45,20 +44,17 @@ function doesDirectoryExist(dir: string) {
 }
 
 async function setProjectDirectory(directory: string) {
-  if (doesDirectoryExist(directory)) {
-    throw new DirectoryAlreadyExistsError(directory);
+  if (directory !== '' && !doesDirectoryExist(directory)) {
+    try {
+      mkdirp.sync(directory);
+      process.chdir(directory);
+    } catch (error) {
+      throw new CLIError(
+        'Error occurred while trying to create project directory.',
+        error,
+      );
+    }
   }
-
-  try {
-    mkdirp.sync(directory);
-    process.chdir(directory);
-  } catch (error) {
-    throw new CLIError(
-      'Error occurred while trying to create project directory.',
-      error,
-    );
-  }
-
   return process.cwd();
 }
 

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -6,6 +6,8 @@ import copyFiles from '../../tools/copyFiles';
 import replacePathSepForRegex from '../../tools/replacePathSepForRegex';
 import fs from 'fs';
 import chalk from 'chalk';
+import ConflictingFilesError from './errors/ConflictingFilesError';
+import {getDirectoryFilesRecursive} from './getDirectoryFilesRecursive';
 
 export type TemplateConfig = {
   placeholderName: string;
@@ -68,10 +70,26 @@ export async function copyTemplate(
     templateName,
     templateDir,
   );
+  const projectDirectory = process.cwd();
+
+  const projectDirectoryFiles = await getDirectoryFilesRecursive(
+    projectDirectory,
+  );
+  const templatePathFiles = await getDirectoryFilesRecursive(templatePath);
+
+  const conflictingFiles: string[] = [];
+  for (const templatePathFile of templatePathFiles) {
+    if (projectDirectoryFiles.includes(templatePathFile)) {
+      conflictingFiles.push(path.join(projectDirectory, templatePathFile));
+    }
+  }
+  if (conflictingFiles.length > 0) {
+    throw new ConflictingFilesError(projectDirectory, conflictingFiles);
+  }
 
   logger.debug(`Copying template from ${templatePath}`);
   let regexStr = path.resolve(templatePath, 'node_modules');
-  await copyFiles(templatePath, process.cwd(), {
+  await copyFiles(templatePath, projectDirectory, {
     exclude: [new RegExp(replacePathSepForRegex(regexStr))],
   });
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -84,8 +84,7 @@ export function projectConfig(
     userConfig.buildGradlePath || 'build.gradle',
   );
 
-  const dependencyConfiguration =
-    userConfig.dependencyConfiguration;
+  const dependencyConfiguration = userConfig.dependencyConfiguration;
 
   return {
     sourceDir,
@@ -159,8 +158,7 @@ export function dependencyConfig(
     userConfig.packageInstance || `new ${packageClassName}()`;
 
   const buildTypes = userConfig.buildTypes || [];
-  const dependencyConfiguration =
-    userConfig.dependencyConfiguration;
+  const dependencyConfiguration = userConfig.dependencyConfiguration;
 
   return {
     sourceDir,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,6 +3182,11 @@ base64-js@^1.0.2, base64-js@^1.2.3:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
   integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
 
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -9372,6 +9377,15 @@ plist@^3.0.1:
     xmlbuilder "^9.0.7"
     xmldom "0.1.x"
 
+plist@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.2.tgz#74bbf011124b90421c22d15779cee60060ba95bc"
+  integrity sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==
+  dependencies:
+    base64-js "^1.5.1"
+    xmlbuilder "^9.0.7"
+    xmldom "^0.5.0"
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -12258,6 +12272,11 @@ xmldom@0.1.x:
   version "0.1.31"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
   integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
+
+xmldom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
+  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Summary:
---------

This PR brings the ability to create new apps in existing and/or current folder.

Issue: https://github.com/react-native-community/cli/issues/1418.

TBD:
- [x] Linter
- [x] Fix existing tests
- [ ] Cover new cases with tests


Test Plan:
----------

Current empty folder:

1. Create an empty folder `mkdir TestApp1`.
2. Go to a newly created folder `cd TestApp1`.
3. Init a new app `react-native init TestApp1 --directory .`
4. **As a result a new app gets created in `TestApp1` folder.**

Non-current empty existing folder:

1. Create an empty folder `mkdir TestApp2`.
3. Init a new app `react-native init TestApp2 --directory TestApp2`
4. **As a result a new app gets created in `TestApp2` folder.**

Current folder with conflicting files:

1. Create an empty folder `mkdir TestApp3`.
2. Go to a newly created folder `cd TestApp3`.
3. Create some conflicting files `mkdir android && touch android/gradlew && touch App.js && touch package.json`.
4. Init a new app `react-native init TestApp3 --directory .`
5. **As a result get a crash with corresponding error saying that some files are conflicting.**

<img width="663" alt="Screenshot 2021-07-15 at 00 31 28" src="https://user-images.githubusercontent.com/10009551/125695731-c99bb8a7-1ea0-44e2-9f67-db83977b780f.png">


