### PR TITLE
feat(cli-patform-ios): allow setting a path to a `Podfile` 

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -79,6 +79,10 @@ Custom path to `.xcodeproj`.
 
 Custom path to `.podspec` file to use when auto-linking. Example: `node_modules/react-native-module/ios/module.podspec`.
 
+#### platforms.ios.podfile
+
+Custom path to `Podfile` file to use when auto-linking. Example: `ios/Podfile`.
+
 #### platforms.ios.sharedLibraries
 
 An array of shared iOS libraries to link with the dependency. E.g. `libc++`. This is mostly a requirement of the native code that a dependency ships with.

--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -14,6 +14,7 @@ export interface IOSProjectParams {
    * @todo Log a warning when this is used.
    */
   podspecPath?: string;
+  podfile?: string;
   sharedLibraries?: string[];
   libraryFolder?: string;
   plist: Array<any>;

--- a/packages/cli/src/tools/config/schema.ts
+++ b/packages/cli/src/tools/config/schema.ts
@@ -164,6 +164,7 @@ export const projectConfig = t
         ios: t
           .object({
             project: t.string(),
+            podfile: t.string(),
             sharedLibraries: t.array().items(t.string()),
             libraryFolder: t.string(),
           })

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -618,7 +618,7 @@ export default {
       description:
         'Path relative to project root where the Xcode project ' +
         '(.xcodeproj) lives.',
-      default: 'ios',
+      default: (ctx: Config) => ctx.project.ios ? ctx.project.ios.sourceDir : 'ios',
     },
     {
       name: '--device [string]',

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -618,7 +618,7 @@ export default {
       description:
         'Path relative to project root where the Xcode project ' +
         '(.xcodeproj) lives.',
-      default: (ctx: Config) => ctx.project.ios ? ctx.project.ios.sourceDir : 'ios',
+      default: 'ios',
     },
     {
       name: '--device [string]',

--- a/packages/platform-ios/src/config/index.ts
+++ b/packages/platform-ios/src/config/index.ts
@@ -54,7 +54,7 @@ export function projectConfig(folder: string, userConfig: IOSProjectParams) {
     sourceDir,
     folder,
     pbxprojPath: path.join(projectPath, 'project.pbxproj'),
-    podfile: findPodfilePath(projectPath),
+    podfile: userConfig.podfile || findPodfilePath(sourceDir),
     podspecPath:
       userConfig.podspecPath ||
       // podspecs are usually placed in the root dir of the library or in the


### PR DESCRIPTION
Draft following explanation in https://github.com/react-native-community/cli/issues/1435#issuecomment-892999907

To be tested, CC @tido64 and @kelset, as I think I am not getting a successful project initialisation (`.xcworkspace` missing).

The `react-native.config.js` of my `example` has been customised as follows:

```js
ios: {
 project: "node_modules/react-native-test-app/ios/ReactTestApp.xcodeproj",
 podfile: "ios/Podfile"
},
```
