### PR TITLE
Add metro-config option

### DIFF
--- a/packages/cli/src/commands/bundle/buildBundle.ts
+++ b/packages/cli/src/commands/bundle/buildBundle.ts
@@ -48,7 +48,7 @@ async function buildBundle(
   const config = await loadMetroConfig(ctx, {
     maxWorkers: args.maxWorkers,
     resetCache: args.resetCache,
-    config: args.config,
+    config: args.metroConfig ?? args.config,
   });
 
   if (config.resolver.platforms.indexOf(args.platform) === -1) {

--- a/packages/cli/src/commands/bundle/bundleCommandLineArgs.ts
+++ b/packages/cli/src/commands/bundle/bundleCommandLineArgs.ts
@@ -15,6 +15,7 @@ export interface CommandLineArgs {
   resetGlobalCache: boolean;
   transformer?: string;
   minify?: boolean;
+  metroConfig?: string;
   config?: string;
   platform: string;
   dev: boolean;
@@ -113,8 +114,8 @@ export default [
     default: false,
   },
   {
-    name: '--config <string>',
-    description: 'Path to the CLI configuration file',
+    name: '--config, --metro-config <string>',
+    description: 'Path to the metro configuration file',
     parse: (val: string) => path.resolve(val),
   },
 ];

--- a/packages/cli/src/commands/start/runServer.ts
+++ b/packages/cli/src/commands/start/runServer.ts
@@ -34,6 +34,7 @@ export type Args = {
   sourceExts?: string[];
   transformer?: string;
   watchFolders?: string[];
+  metroConfig?: string;
   config?: string;
   projectRoot?: string;
   interactive: boolean;
@@ -54,7 +55,7 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
   };
 
   const metroConfig = await loadMetroConfig(ctx, {
-    config: args.config,
+    config: args.metroConfig ?? args.config,
     maxWorkers: args.maxWorkers,
     port: args.port,
     resetCache: args.resetCache,

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -80,8 +80,8 @@ export default {
       description: 'Path to custom SSL cert',
     },
     {
-      name: '--config <string>',
-      description: 'Path to the CLI configuration file',
+      name: '--config, --metro-config <string>',
+      description: 'Path to the metro configuration file',
       parse: (val: string) => path.resolve(val),
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3177,12 +3177,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base64-js@^1.0.2, base64-js@^1.2.3, base64-js@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
-base64-js@^1.5.1:
+base64-js@^1.0.2, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -9385,15 +9380,6 @@ plist@^3.0.1, plist@^3.0.2:
     xmlbuilder "^9.0.7"
     xmldom "^0.5.0"
 
-plist@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.2.tgz#74bbf011124b90421c22d15779cee60060ba95bc"
-  integrity sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==
-  dependencies:
-    base64-js "^1.5.1"
-    xmlbuilder "^9.0.7"
-    xmldom "^0.5.0"
-
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -12275,11 +12261,6 @@ xmldoc@^1.1.2:
   integrity sha512-ruPC/fyPNck2BD1dpz0AZZyrEwMOrWTO5lDdIXS91rs3wtm4j+T8Rp2o+zoOYkkAxJTZRPOSnOGei1egoRmKMQ==
   dependencies:
     sax "^1.2.1"
-
-xmldom@0.1.x:
-  version "0.1.31"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.31.tgz#b76c9a1bd9f0a9737e5a72dc37231cf38375e2ff"
-  integrity sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==
 
 xmldom@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Resolves https://github.com/react-native-community/cli/issues/1371

Summary:
---------

Hi 👋 

As explained in the attached issue this PR should resolve, when starting the metro bundler after running `run-android`, it cannot find the `metro.config.js` due to `react-native` being one level higher in the file hierarchy than expected.

Therefore, I have added `--metro-config` option that will allow users to specify the location of metro config when running `run-android`. Under the hood, I am creating a new launch packager script that will invoke `launchPackager.command` defined in `react-native` module - but, importantly - with `--metro-config xyz` if it was specified. `launchPackager.command` then runs `packager.sh` which then runs `"$NODE_BINARY" "$REACT_NATIVE_ROOT/cli.js" start "$@"`. Fortunately, it passes arguments by default, so our `--metro-config xyz` gets passed as well. cli is then run with the metro config specified and it doesn't fail to find it.

I don't like the fact that I have to create a temporary script to be actually able to pass commands to `launchPackager.command` as it's not possible to do that directly, so if you have ideas how to make this cleaner, I'd love to know!


Test Plan:
----------

I have tested that when I run `react-native run-android --metro-config path-to-metro.config.js`, it gets passed to the CLI when invoked from the launch packager scripts and is subsequently used. (when trying to load the bundle, I am getting `Error: Unable to resolve module @babel/runtime/helpers/interopRequireDefault` but that is IMHO unrelated to my changes and is rather tied to my local setup - if you know how to resolve this when contributing to this repo, do let me know, I'll continue investigating this further in the meantime)

If this PR is in the right direction, I should also probably add some unit tests.
