### PR TITLE
fix #1462

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/getAdbPath.ts
+++ b/packages/platform-android/src/commands/runAndroid/getAdbPath.ts
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import path from 'path';
 
 function getAdbPath() {
   return process.env.ANDROID_HOME
-    ? `${process.env.ANDROID_HOME}/platform-tools/adb`
+    ? path.join(process.env.ANDROID_HOME, 'platform-tools', 'adb')
     : 'adb';
 }
 


### PR DESCRIPTION
Summary:
---------

This is a simple fix for #1462 
By simply using nodes build in path.join method instead of hard-coding path separators


Test Plan:
----------

See #1462 to reproduce the fix
