### PR TITLE
fix: export `loadConfig` so it can be used for other purposes

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -255,4 +255,4 @@ async function setupAndRun() {
 
 const bin = require.resolve('./bin');
 
-export {run, init, bin};
+export {run, init, bin, loadConfig};


### PR DESCRIPTION
Summary:
---------

Exports `loadConfig` so it can be used by other libraries. Specifically, I'm working on adding the ability to target specific platforms in Jest. Being able to detect which platforms are available (especially out-of-tree ones) would be most useful.

Test Plan:
----------

There are no code changes to test.
