### PR TITLE
Fix React Native peer dep

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,7 +63,7 @@
     "wcwidth": "^1.0.1"
   },
   "peerDependencies": {
-    "react-native": ">=0.65.0-rc.0 || 0.0.0-*"
+    "react-native": "*"
   },
   "devDependencies": {
     "@types/command-exists": "^1.2.0",


### PR DESCRIPTION
There is an issue with peer deps when using NPM and 0.66.
Using '*' should be fine since the CLI is installed as a dependency of react-native, so as long as react-native install the correct version they should be fine with each other