### PR TITLE
fix: Windows unknown command on build android

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/adb.ts
+++ b/packages/platform-android/src/commands/runAndroid/adb.ts
@@ -34,6 +34,11 @@ function parseDevicesResult(result: string): Array<string> {
  */
 function getDevices(adbPath: string): Array<string> {
   try {
+    //If the path includes spaces (for example, the name of the USER_NAME) in Windows...
+    if (adbPath.includes(' ') && process.platform.startsWith('win')) {
+      adbPath = `"${adbPath}"`;
+    }
+
     const devicesResult = execSync(`${adbPath} devices`);
     return parseDevicesResult(devicesResult.toString());
   } catch (e) {

--- a/packages/platform-android/src/commands/runAndroid/adb.ts
+++ b/packages/platform-android/src/commands/runAndroid/adb.ts
@@ -34,12 +34,7 @@ function parseDevicesResult(result: string): Array<string> {
  */
 function getDevices(adbPath: string): Array<string> {
   try {
-    //If the path includes spaces (for example, the name of the USER_NAME)
-    if (adbPath.includes(' ')) {
-      adbPath = `"${adbPath}"`;
-    }
-
-    const devicesResult = execSync(`${adbPath} devices`);
+    const devicesResult = execSync(`"${adbPath}" devices`);
     return parseDevicesResult(devicesResult.toString());
   } catch (e) {
     return [];


### PR DESCRIPTION
Summary:
---------

### In windows, when I execute `npx react-native run-android`, I got this problem:
![image](https://user-images.githubusercontent.com/47652130/134750958-1ef13ef1-68fa-460a-b436-f2fc2e425cb8.png)


### It's because my Windows name profile is "Rodrigo Maafs" (with a space)
![image](https://user-images.githubusercontent.com/47652130/134751013-761b105e-5178-4c69-94cd-973d8455cc2f.png)


### The error is caused from `getDevices(adbPath)`, adbPath have 3 arguments, looks like:
![image](https://user-images.githubusercontent.com/47652130/134751136-3abe59f6-3949-4e54-a5ab-55c708204778.png)

### So, I fixed this adding `"` in the adb path:
![image](https://user-images.githubusercontent.com/47652130/134751209-f56bbb92-6181-4790-958e-0532e238d27b.png)


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

1. Use Windows.
2. Use a "adb path" in folder with a space.
3. Check if the environment PATH, have the adb path correctly.
4. Execute the app, in my case I use `npx react-native run-android`

![image](https://user-images.githubusercontent.com/47652130/134751576-62124b2e-befe-4fc3-a235-3ebac39c7663.png)

After fixed it, looks like
![after](https://user-images.githubusercontent.com/47652130/134751790-51da604e-2971-46eb-a3ca-c9d9485643b6.png)
