### PR TITLE
feat: Allow the upgrade command to support the TV repo

### DIFF
--- a/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade-tv.test.ts.snap
+++ b/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade-tv.test.ts.snap
@@ -1,0 +1,85 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -1,9 +1,9 @@
+- diff --git a/RnDiffApp/android/app/src/main/AndroidManifest.xml b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ diff --git a/TestApp/android/app/src/main/AndroidManifest.xml b/TestApp/android/app/src/main/AndroidManifest.xml
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/AndroidManifest.xml
+- +++ b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ --- a/TestApp/android/app/src/main/AndroidManifest.xml
++ +++ b/TestApp/android/app/src/main/AndroidManifest.xml
+  @@ -1,8 +1,7 @@
+   <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+- -    package=\\"com.rndiffapp\\">
+- +  package=\\"com.rndiffapp\\">
++ -    package=\\"com.testapp\\">
++ +  package=\\"com.testapp\\">
+
+@@ -14,6 +14,6 @@
+         android:name=\\".MainApplication\\"
+- diff --git a/RnDiffApp/ios/RnDiffApp/AppDelegate.h b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ diff --git a/TestApp/ios/TestApp/AppDelegate.h b/TestApp/ios/TestApp/AppDelegate.h
+  index 4b5644f2..2726d5e1 100644
+- --- a/RnDiffApp/ios/RnDiffApp/AppDelegate.h
+- +++ b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ --- a/TestApp/ios/TestApp/AppDelegate.h
++ +++ b/TestApp/ios/TestApp/AppDelegate.h
+  @@ -5,9 +5,10 @@
+@@ -29,6 +29,6 @@
+   @property (nonatomic, strong) UIWindow *window;
+- diff --git a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ diff --git a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
+- +++ b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ --- a/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
++ +++ b/TestApp/android/app/src/main/java/com/testapp/MainApplication.java
+"
+`;
+
+exports[`works with --name-ios and --name-android: RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app) 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -1,9 +1,9 @@
+- diff --git a/RnDiffApp/android/app/src/main/AndroidManifest.xml b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ diff --git a/CustomIos/android/app/src/main/AndroidManifest.xml b/CustomIos/android/app/src/main/AndroidManifest.xml
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/AndroidManifest.xml
+- +++ b/RnDiffApp/android/app/src/main/AndroidManifest.xml
++ --- a/CustomIos/android/app/src/main/AndroidManifest.xml
++ +++ b/CustomIos/android/app/src/main/AndroidManifest.xml
+  @@ -1,8 +1,7 @@
+   <manifest xmlns:android=\\"http://schemas.android.com/apk/res/android\\"
+- -    package=\\"com.rndiffapp\\">
+- +  package=\\"com.rndiffapp\\">
++ -    package=\\"co.uk.customandroid.app\\">
++ +  package=\\"co.uk.customandroid.app\\">
+
+@@ -14,6 +14,6 @@
+         android:name=\\".MainApplication\\"
+- diff --git a/RnDiffApp/ios/RnDiffApp/AppDelegate.h b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ diff --git a/CustomIos/ios/CustomIos/AppDelegate.h b/CustomIos/ios/CustomIos/AppDelegate.h
+  index 4b5644f2..2726d5e1 100644
+- --- a/RnDiffApp/ios/RnDiffApp/AppDelegate.h
+- +++ b/RnDiffApp/ios/RnDiffApp/AppDelegate.h
++ --- a/CustomIos/ios/CustomIos/AppDelegate.h
++ +++ b/CustomIos/ios/CustomIos/AppDelegate.h
+  @@ -5,9 +5,10 @@
+@@ -29,6 +29,6 @@
+   @property (nonatomic, strong) UIWindow *window;
+- diff --git a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ diff --git a/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java b/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java
+  index bc3a9310..f3e0d155 100644
+- --- a/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
+- +++ b/RnDiffApp/android/app/src/main/java/com/rndiffapp/MainApplication.java
++ --- a/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java
++ +++ b/CustomIos/android/app/src/main/java/co/uk/customandroid/app/MainApplication.java
+"
+`;

--- a/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade-tv.test.ts.snap
+++ b/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade-tv.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cleans up if patching fails, 1`] = `
+exports[`Upgrade tests for react-native-tvos repo cleans up if patching fails, 1`] = `
 "info Fetching diff between v0.62.2-1 and v0.64.2-4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -27,7 +27,7 @@ info You may find these resources helpful:
 • Git diff: https://raw.githubusercontent.com/react-native-tvos/rn-diff-purge-tv/diffs/diffs/0.62.2-1..0.64.2-4.diff"
 `;
 
-exports[`fetches empty patch and installs deps 1`] = `
+exports[`Upgrade tests for react-native-tvos repo fetches empty patch and installs deps 1`] = `
 "info Fetching diff between v0.62.2-1 and v0.64.2-4...
 info Diff has no changes to apply, proceeding further
 info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
@@ -40,7 +40,7 @@ info Installing CocoaPods dependencies (this may take a few minutes)
 success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
 `;
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory 1`] = `
+exports[`Upgrade tests for react-native-tvos repo fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory 1`] = `
 "info Fetching diff between v0.62.2-1 and v0.64.2-4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -61,7 +61,7 @@ $ execa git status
 success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
 `;
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote, 1`] = `
+exports[`Upgrade tests for react-native-tvos repo fetches regular patch, adds remote, applies patch, installs deps, removes remote, 1`] = `
 "info Fetching diff between v0.62.2-1 and v0.64.2-4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -82,7 +82,7 @@ $ execa git status
 success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
 `;
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
+exports[`Upgrade tests for react-native-tvos repo fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
 "Snapshot Diff:
 - First value
 + Second value
@@ -124,7 +124,7 @@ exports[`fetches regular patch, adds remote, applies patch, installs deps, remov
 "
 `;
 
-exports[`works with --name-ios and --name-android: RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app) 1`] = `
+exports[`Upgrade tests for react-native-tvos repo works with --name-ios and --name-android: RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app) 1`] = `
 "Snapshot Diff:
 - First value
 + Second value

--- a/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade-tv.test.ts.snap
+++ b/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade-tv.test.ts.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cleans up if patching fails, 1`] = `
+"info Fetching diff between v0.62.2-1 and v0.64.2-4...
+[fs] write tmp-upgrade-rn.patch
+$ execa git rev-parse --show-prefix
+$ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+info Applying diff...
+warn Excluding files that exist in the template, but not in your project:
+  - .flowconfig
+error Excluding files that failed to apply the diff:
+  - ios/MyApp.xcodeproj/project.pbxproj
+Please make sure to check the actual changes after the upgrade command is finished.
+You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
+$ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
+debug \\"git apply\\" failed. Error output:
+error: .flowconfig: does not exist in index
+error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
+error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
+[fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
+error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
+warn After resolving conflicts don't forget to run \\"pod install\\" inside \\"ios\\" directory
+info You may find these resources helpful:
+• Release notes: https://github.com/facebook/react-native/releases/tag/v0.64.2-4
+• Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
+• Git diff: https://raw.githubusercontent.com/react-native-tvos/rn-diff-purge-tv/diffs/diffs/0.62.2-1..0.64.2-4.diff"
+`;
+
+exports[`fetches empty patch and installs deps 1`] = `
+"info Fetching diff between v0.62.2-1 and v0.64.2-4...
+info Diff has no changes to apply, proceeding further
+info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
+$ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
+$ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
+$ execa git add package.json
+$ execa git add yarn.lock
+$ execa git add package-lock.json
+info Installing CocoaPods dependencies (this may take a few minutes)
+success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
+`;
+
+exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory 1`] = `
+"info Fetching diff between v0.62.2-1 and v0.64.2-4...
+[fs] write tmp-upgrade-rn.patch
+$ execa git rev-parse --show-prefix
+$ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+info Applying diff...
+$ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+[fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
+info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
+$ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
+$ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
+$ execa git add package.json
+$ execa git add yarn.lock
+$ execa git add package-lock.json
+info Installing CocoaPods dependencies (this may take a few minutes)
+info Running \\"git status\\" to check what changed...
+$ execa git status
+success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
+`;
+
+exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote, 1`] = `
+"info Fetching diff between v0.62.2-1 and v0.64.2-4...
+[fs] write tmp-upgrade-rn.patch
+$ execa git rev-parse --show-prefix
+$ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+info Applying diff...
+$ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+[fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
+info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
+$ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
+$ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
+$ execa git add package.json
+$ execa git add yarn.lock
+$ execa git add package-lock.json
+info Installing CocoaPods dependencies (this may take a few minutes)
+info Running \\"git status\\" to check what changed...
+$ execa git status
+success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
+`;
+
 exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
 "Snapshot Diff:
 - First value

--- a/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade.test.ts.snap
+++ b/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade.test.ts.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`cleans up if patching fails, 1`] = `
+"info Fetching diff between v0.57.8 and v0.58.4...
+[fs] write tmp-upgrade-rn.patch
+$ execa git rev-parse --show-prefix
+$ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+info Applying diff...
+warn Excluding files that exist in the template, but not in your project:
+  - .flowconfig
+error Excluding files that failed to apply the diff:
+  - ios/MyApp.xcodeproj/project.pbxproj
+Please make sure to check the actual changes after the upgrade command is finished.
+You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
+$ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
+debug \\"git apply\\" failed. Error output:
+error: .flowconfig: does not exist in index
+error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
+error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
+[fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
+error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
+warn After resolving conflicts don't forget to run \\"pod install\\" inside \\"ios\\" directory
+info You may find these resources helpful:
+• Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
+• Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
+• Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
+`;
+
+exports[`fetches empty patch and installs deps 1`] = `
+"info Fetching diff between v0.57.8 and v0.58.4...
+info Diff has no changes to apply, proceeding further
+info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+$ execa npm info react-native@0.58.4 peerDependencies --json
+$ yarn add react-native@0.58.4 react@16.6.3
+$ execa git add package.json
+$ execa git add yarn.lock
+$ execa git add package-lock.json
+info Installing CocoaPods dependencies (this may take a few minutes)
+success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+`;
+
+exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory 1`] = `
+"info Fetching diff between v0.57.8 and v0.58.4...
+[fs] write tmp-upgrade-rn.patch
+$ execa git rev-parse --show-prefix
+$ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+info Applying diff...
+$ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+[fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
+info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+$ execa npm info react-native@0.58.4 peerDependencies --json
+$ yarn add react-native@0.58.4 react@16.6.3
+$ execa git add package.json
+$ execa git add yarn.lock
+$ execa git add package-lock.json
+info Installing CocoaPods dependencies (this may take a few minutes)
+info Running \\"git status\\" to check what changed...
+$ execa git status
+success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+`;
+
+exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote, 1`] = `
+"info Fetching diff between v0.57.8 and v0.58.4...
+[fs] write tmp-upgrade-rn.patch
+$ execa git rev-parse --show-prefix
+$ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+info Applying diff...
+$ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+[fs] unlink tmp-upgrade-rn.patch
+$ execa git status -s
+info Installing \\"react-native@0.58.4\\" and its peer dependencies...
+$ execa npm info react-native@0.58.4 peerDependencies --json
+$ yarn add react-native@0.58.4 react@16.6.3
+$ execa git add package.json
+$ execa git add yarn.lock
+$ execa git add package-lock.json
+info Installing CocoaPods dependencies (this may take a few minutes)
+info Running \\"git status\\" to check what changed...
+$ execa git status
+success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
+`;
+
 exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
 "Snapshot Diff:
 - First value

--- a/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade.test.ts.snap
+++ b/packages/cli/src/commands/upgrade/__tests__/__snapshots__/upgrade.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`cleans up if patching fails, 1`] = `
+exports[`Upgrade tests for react-native repo cleans up if patching fails, 1`] = `
 "info Fetching diff between v0.57.8 and v0.58.4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -27,7 +27,7 @@ info You may find these resources helpful:
 • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
 `;
 
-exports[`fetches empty patch and installs deps 1`] = `
+exports[`Upgrade tests for react-native repo fetches empty patch and installs deps 1`] = `
 "info Fetching diff between v0.57.8 and v0.58.4...
 info Diff has no changes to apply, proceeding further
 info Installing \\"react-native@0.58.4\\" and its peer dependencies...
@@ -40,7 +40,7 @@ info Installing CocoaPods dependencies (this may take a few minutes)
 success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
 `;
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory 1`] = `
+exports[`Upgrade tests for react-native repo fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory 1`] = `
 "info Fetching diff between v0.57.8 and v0.58.4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -61,7 +61,7 @@ $ execa git status
 success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
 `;
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote, 1`] = `
+exports[`Upgrade tests for react-native repo fetches regular patch, adds remote, applies patch, installs deps, removes remote, 1`] = `
 "info Fetching diff between v0.57.8 and v0.58.4...
 [fs] write tmp-upgrade-rn.patch
 $ execa git rev-parse --show-prefix
@@ -82,7 +82,7 @@ $ execa git status
 success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
 `;
 
-exports[`fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
+exports[`Upgrade tests for react-native repo fetches regular patch, adds remote, applies patch, installs deps, removes remote,: RnDiffApp is replaced with app name (TestApp and com.testapp) 1`] = `
 "Snapshot Diff:
 - First value
 + Second value
@@ -124,7 +124,7 @@ exports[`fetches regular patch, adds remote, applies patch, installs deps, remov
 "
 `;
 
-exports[`works with --name-ios and --name-android: RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app) 1`] = `
+exports[`Upgrade tests for react-native repo works with --name-ios and --name-android: RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app) 1`] = `
 "Snapshot Diff:
 - First value
 + Second value

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-testing-methods.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-testing-methods.ts
@@ -1,0 +1,220 @@
+const usesLatestVersionWhenNonePassed = async (
+  upgrade,
+  ctx,
+  execa,
+  repoName,
+) => {
+  await upgrade.func([], ctx);
+  expect(execa).toBeCalledWith('npm', ['info', repoName, 'version']);
+};
+
+const appliesPatchInCwdWhenNested = async (
+  mockFetch,
+  samplePatch,
+  execa,
+  mockExecaNested,
+  ctx,
+  upgrade,
+  newVersion,
+) => {
+  mockFetch(samplePatch, 200);
+  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
+  const config = {...ctx, root: '/project/root/NestedApp'};
+  await upgrade.func([newVersion], config);
+
+  expect(execa).toBeCalledWith('git', [
+    'apply',
+    'tmp-upgrade-rn.patch',
+    '--exclude=NestedApp/package.json',
+    '-p2',
+    '--3way',
+    '--directory=NestedApp/',
+  ]);
+};
+
+const errorsWhenInvalidVersionPassed = async (upgrade, ctx, logger) => {
+  await upgrade.func(['next'], ctx);
+  expect(logger.error).toBeCalledWith(
+    'Provided version "next" is not allowed. Please pass a valid semver version',
+  );
+};
+
+const errorsWhenOlderVersionPassed = async (
+  upgrade,
+  olderVersion,
+  lessOlderVersion,
+  ctx,
+  currentVersion,
+  logger,
+) => {
+  await upgrade.func([olderVersion], ctx);
+  expect(logger.error).toBeCalledWith(
+    `Trying to upgrade from newer version "${currentVersion}" to older "${olderVersion}"`,
+  );
+  await upgrade.func([lessOlderVersion], ctx);
+  expect(logger.error).not.toBeCalledWith(
+    `Trying to upgrade from newer version "${currentVersion}" to older "${lessOlderVersion}"`,
+  );
+};
+
+const warnsWhenDependencyInSemverRange = async (
+  upgrade,
+  currentVersion,
+  ctx,
+  logger,
+) => {
+  await upgrade.func([currentVersion], ctx);
+  expect(logger.warn).toBeCalledWith(
+    `Specified version "${currentVersion}" is already installed in node_modules and it satisfies "^${currentVersion}" semver range. No need to upgrade`,
+  );
+};
+
+const fetchesEmptyPatchAndInstallsDeps = async (
+  mockFetch,
+  upgrade,
+  newVersion,
+  ctx,
+  flushOutput,
+) => {
+  mockFetch();
+  await upgrade.func([newVersion], ctx);
+  expect(flushOutput()).toMatchSnapshot();
+};
+
+const fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote = async (
+  mockFetch,
+  samplePatch,
+  upgrade,
+  newVersion,
+  merge,
+  ctx,
+  flushOutput,
+  snapshotDiff,
+  fs,
+) => {
+  mockFetch(samplePatch, 200);
+  await upgrade.func(
+    [newVersion],
+    merge(ctx, {
+      project: {
+        ios: {projectName: 'TestApp.xcodeproj'},
+        android: {packageName: 'com.testapp'},
+      },
+    }),
+  );
+  expect(flushOutput()).toMatchSnapshot();
+  expect(
+    snapshotDiff(
+      samplePatch,
+      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
+      {
+        contextLines: 1,
+      },
+    ),
+  ).toMatchSnapshot(
+    'RnDiffApp is replaced with app name (TestApp and com.testapp)',
+  );
+};
+
+const fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested = async (
+  samplePatch,
+  mockFetch,
+  execa,
+  mockExecaNested,
+  ctx,
+  upgrade,
+  newVersion,
+  flushOutput,
+) => {
+  mockFetch(samplePatch, 200);
+  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
+  const config = {...ctx, root: '/project/root/NestedApp'};
+  await upgrade.func([newVersion], config);
+  expect(flushOutput()).toMatchSnapshot();
+};
+
+const cleansUpIfPatchingFails = async (
+  mockFetch,
+  samplePatch,
+  execa,
+  mockPushLog,
+  upgrade,
+  newVersion,
+  ctx,
+  flushOutput,
+) => {
+  mockFetch(samplePatch, 200);
+  ((execa as unknown) as jest.Mock).mockImplementation((command, args) => {
+    mockPushLog('$', 'execa', command, args);
+    if (command === 'npm' && args[3] === '--json') {
+      return Promise.resolve({
+        stdout: '{"react": "16.6.3"}',
+      });
+    }
+    if (command === 'git' && args[0] === 'apply') {
+      return Promise.reject({
+        code: 1,
+        stderr:
+          'error: .flowconfig: does not exist in index\nerror: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply',
+      });
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return Promise.resolve({stdout: ''});
+    }
+    return Promise.resolve({stdout: ''});
+  });
+  try {
+    await upgrade.func([newVersion], ctx);
+  } catch (error) {
+    expect(error.message).toBe(
+      'Upgrade failed. Please see the messages above for details',
+    );
+  }
+  expect(flushOutput()).toMatchSnapshot();
+};
+
+const worksWithNameIosAndNameAndroid = async (
+  mockFetch,
+  samplePatch,
+  upgrade,
+  newVersion,
+  merge,
+  ctx,
+  snapshotDiff,
+  fs,
+) => {
+  mockFetch(samplePatch, 200);
+  await upgrade.func(
+    [newVersion],
+    merge(ctx, {
+      project: {
+        ios: {projectName: 'CustomIos.xcodeproj'},
+        android: {packageName: 'co.uk.customandroid.app'},
+      },
+    }),
+  );
+  expect(
+    snapshotDiff(
+      samplePatch,
+      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
+      {
+        contextLines: 1,
+      },
+    ),
+  ).toMatchSnapshot(
+    'RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app)',
+  );
+};
+
+export default {
+  usesLatestVersionWhenNonePassed,
+  appliesPatchInCwdWhenNested,
+  errorsWhenInvalidVersionPassed,
+  errorsWhenOlderVersionPassed,
+  warnsWhenDependencyInSemverRange,
+  fetchesEmptyPatchAndInstallsDeps,
+  fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote,
+  fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested,
+  cleansUpIfPatchingFails,
+  worksWithNameIosAndNameAndroid,
+};

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
@@ -296,7 +296,7 @@ test('cleans up if patching fails,', async () => {
     info You may find these resources helpful:
     • Release notes: https://github.com/facebook/react-native/releases/tag/v0.64.2-4
     • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
-    • Git diff: https://raw.githubusercontent.com/douglowder/rn-diff-purge-tv/diffs/diffs/0.62.2-1..0.64.2-4.diff"
+    • Git diff: https://raw.githubusercontent.com/react-native-tvos/rn-diff-purge-tv/diffs/diffs/0.62.2-1..0.64.2-4.diff"
   `);
 }, 60000);
 test('works with --name-ios and --name-android', async () => {

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
@@ -296,7 +296,7 @@ test('cleans up if patching fails,', async () => {
     info You may find these resources helpful:
     • Release notes: https://github.com/facebook/react-native/releases/tag/v0.64.2-4
     • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
-    • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.62.2-1..0.64.2-4.diff"
+    • Git diff: https://raw.githubusercontent.com/douglowder/rn-diff-purge-tv/diffs/diffs/0.62.2-1..0.64.2-4.diff"
   `);
 }, 60000);
 test('works with --name-ios and --name-android', async () => {

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
@@ -33,58 +33,62 @@ const newVersion = '0.64.2-4';
 const olderVersion = '0.60.2-1';
 const lessOlderVersion = '0.63.3-0';
 
-beforeEach(() => {
-  UpgradeTestingMethods.setup();
+describe('Upgrade tests for react-native-tvos repo', () => {
+  beforeEach(() => {
+    UpgradeTestingMethods.setup();
+  });
+
+  afterEach(() => {
+    UpgradeTestingMethods.teardown();
+  });
+
+  test('uses latest version of react-native when none passed', async () => {
+    await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(repoName);
+  }, 60000);
+
+  test('applies patch in current working directory when nested', async () => {
+    await UpgradeTestingMethods.appliesPatchInCwdWhenNested(newVersion);
+  });
+
+  test('errors when invalid version passed', async () => {
+    await UpgradeTestingMethods.errorsWhenInvalidVersionPassed();
+  }, 60000);
+
+  test('errors when older version passed', async () => {
+    await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
+      olderVersion,
+      lessOlderVersion,
+      currentVersion,
+    );
+  }, 60000);
+
+  test('warns when dependency upgrade version is in semver range', async () => {
+    await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(
+      currentVersion,
+    );
+  }, 60000);
+
+  test('fetches empty patch and installs deps', async () => {
+    await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(newVersion);
+  }, 60000);
+
+  test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
+    await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
+      newVersion,
+    );
+  }, 60000);
+
+  test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
+    await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
+      newVersion,
+    );
+  }, 60000);
+
+  test('cleans up if patching fails,', async () => {
+    await UpgradeTestingMethods.cleansUpIfPatchingFails(newVersion);
+  }, 60000);
+
+  test('works with --name-ios and --name-android', async () => {
+    await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(newVersion);
+  }, 60000);
 });
-
-afterEach(() => {
-  UpgradeTestingMethods.teardown();
-});
-
-test('uses latest version of react-native when none passed', async () => {
-  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(repoName);
-}, 60000);
-
-test('applies patch in current working directory when nested', async () => {
-  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(newVersion);
-});
-
-test('errors when invalid version passed', async () => {
-  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed();
-}, 60000);
-
-test('errors when older version passed', async () => {
-  await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
-    olderVersion,
-    lessOlderVersion,
-    currentVersion,
-  );
-}, 60000);
-
-test('warns when dependency upgrade version is in semver range', async () => {
-  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(currentVersion);
-}, 60000);
-
-test('fetches empty patch and installs deps', async () => {
-  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(newVersion);
-}, 60000);
-
-test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
-  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
-    newVersion,
-  );
-}, 60000);
-
-test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
-  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
-    newVersion,
-  );
-}, 60000);
-
-test('cleans up if patching fails,', async () => {
-  await UpgradeTestingMethods.cleansUpIfPatchingFails(newVersion);
-}, 60000);
-
-test('works with --name-ios and --name-android', async () => {
-  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(newVersion);
-}, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
@@ -7,6 +7,7 @@ import upgrade from '../upgrade';
 import {fetch, logger} from '@react-native-community/cli-tools';
 import loadConfig from '../../../tools/config';
 import merge from '../../../tools/merge';
+import UpgradeTestingMethods from './upgrade-testing-methods';
 
 jest.mock('https');
 jest.mock('fs');
@@ -85,9 +86,12 @@ const mockExecaNested = (command, args) => {
   return Promise.resolve({stdout: ''});
 };
 
+const repoName = 'react-native-tvos';
 const currentVersion = '0.62.2-1';
 const newVersion = '0.64.2-4';
 const olderVersion = '0.60.2-1';
+const lessOlderVersion = '0.63.3-0';
+
 const ctx = loadConfig();
 
 const samplePatch = jest
@@ -117,208 +121,113 @@ afterEach(() => {
 });
 
 test('uses latest version of react-native when none passed', async () => {
-  await upgrade.func([], ctx);
-  expect(execa).toBeCalledWith('npm', ['info', 'react-native-tvos', 'version']);
+  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(
+    upgrade,
+    ctx,
+    execa,
+    repoName,
+  );
 }, 60000);
 
 test('applies patch in current working directory when nested', async () => {
-  mockFetch(samplePatch, 200);
-  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
-  const config = {...ctx, root: '/project/root/NestedApp'};
-  await upgrade.func([newVersion], config);
-
-  expect(execa).toBeCalledWith('git', [
-    'apply',
-    'tmp-upgrade-rn.patch',
-    '--exclude=NestedApp/package.json',
-    '-p2',
-    '--3way',
-    '--directory=NestedApp/',
-  ]);
+  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(
+    mockFetch,
+    samplePatch,
+    execa,
+    mockExecaNested,
+    ctx,
+    upgrade,
+    newVersion,
+  );
 });
 
 test('errors when invalid version passed', async () => {
-  await upgrade.func(['next'], ctx);
-  expect(logger.error).toBeCalledWith(
-    'Provided version "next" is not allowed. Please pass a valid semver version',
+  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed(
+    upgrade,
+    ctx,
+    logger,
   );
 }, 60000);
 
 test('errors when older version passed', async () => {
-  await upgrade.func([olderVersion], ctx);
-  expect(logger.error).toBeCalledWith(
-    `Trying to upgrade from newer version "${currentVersion}" to older "${olderVersion}"`,
+  await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
+    upgrade,
+    olderVersion,
+    lessOlderVersion,
+    ctx,
+    currentVersion,
+    logger,
   );
 }, 60000);
 
 test('warns when dependency upgrade version is in semver range', async () => {
-  await upgrade.func([currentVersion], ctx);
-  expect(logger.warn).toBeCalledWith(
-    `Specified version "${currentVersion}" is already installed in node_modules and it satisfies "^0.62.2-1" semver range. No need to upgrade`,
+  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(
+    upgrade,
+    currentVersion,
+    ctx,
+    logger,
   );
 }, 60000);
 
 test('fetches empty patch and installs deps', async () => {
-  mockFetch();
-  await upgrade.func([newVersion], ctx);
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
-    info Diff has no changes to apply, proceeding further
-    info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
-    $ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
-    $ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Installing CocoaPods dependencies (this may take a few minutes)
-    success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
-  `);
+  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(
+    mockFetch,
+    upgrade,
+    newVersion,
+    ctx,
+    flushOutput,
+  );
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
-  mockFetch(samplePatch, 200);
-  await upgrade.func(
-    [newVersion],
-    merge(ctx, {
-      project: {
-        ios: {projectName: 'TestApp.xcodeproj'},
-        android: {packageName: 'com.testapp'},
-      },
-    }),
-  );
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    info Applying diff...
-    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
-    $ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
-    $ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Installing CocoaPods dependencies (this may take a few minutes)
-    info Running \\"git status\\" to check what changed...
-    $ execa git status
-    success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
-  `);
-  expect(
-    snapshotDiff(
-      samplePatch,
-      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
-      {
-        contextLines: 1,
-      },
-    ),
-  ).toMatchSnapshot(
-    'RnDiffApp is replaced with app name (TestApp and com.testapp)',
+  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
+    mockFetch,
+    samplePatch,
+    upgrade,
+    newVersion,
+    merge,
+    ctx,
+    flushOutput,
+    snapshotDiff,
+    fs,
   );
 }, 60000);
+
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
-  mockFetch(samplePatch, 200);
-  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
-  const config = {...ctx, root: '/project/root/NestedApp'};
-  await upgrade.func([newVersion], config);
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-    info Applying diff...
-    $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
-    $ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
-    $ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Installing CocoaPods dependencies (this may take a few minutes)
-    info Running \\"git status\\" to check what changed...
-    $ execa git status
-    success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
-  `);
-}, 60000);
-test('cleans up if patching fails,', async () => {
-  mockFetch(samplePatch, 200);
-  ((execa as unknown) as jest.Mock).mockImplementation((command, args) => {
-    mockPushLog('$', 'execa', command, args);
-    if (command === 'npm' && args[3] === '--json') {
-      return Promise.resolve({
-        stdout: '{"react": "16.6.3"}',
-      });
-    }
-    if (command === 'git' && args[0] === 'apply') {
-      return Promise.reject({
-        code: 1,
-        stderr:
-          'error: .flowconfig: does not exist in index\nerror: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply',
-      });
-    }
-    if (command === 'git' && args[0] === 'rev-parse') {
-      return Promise.resolve({stdout: ''});
-    }
-    return Promise.resolve({stdout: ''});
-  });
-  try {
-    await upgrade.func([newVersion], ctx);
-  } catch (error) {
-    expect(error.message).toBe(
-      'Upgrade failed. Please see the messages above for details',
-    );
-  }
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    info Applying diff...
-    warn Excluding files that exist in the template, but not in your project:
-      - .flowconfig
-    error Excluding files that failed to apply the diff:
-      - ios/MyApp.xcodeproj/project.pbxproj
-    Please make sure to check the actual changes after the upgrade command is finished.
-    You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
-    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
-    debug \\"git apply\\" failed. Error output:
-    error: .flowconfig: does not exist in index
-    error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
-    error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
-    warn After resolving conflicts don't forget to run \\"pod install\\" inside \\"ios\\" directory
-    info You may find these resources helpful:
-    • Release notes: https://github.com/facebook/react-native/releases/tag/v0.64.2-4
-    • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
-    • Git diff: https://raw.githubusercontent.com/react-native-tvos/rn-diff-purge-tv/diffs/diffs/0.62.2-1..0.64.2-4.diff"
-  `);
-}, 60000);
-test('works with --name-ios and --name-android', async () => {
-  mockFetch(samplePatch, 200);
-  await upgrade.func(
-    [newVersion],
-    merge(ctx, {
-      project: {
-        ios: {projectName: 'CustomIos.xcodeproj'},
-        android: {packageName: 'co.uk.customandroid.app'},
-      },
-    }),
+  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
+    samplePatch,
+    mockFetch,
+    execa,
+    mockExecaNested,
+    ctx,
+    upgrade,
+    newVersion,
+    flushOutput,
   );
-  expect(
-    snapshotDiff(
-      samplePatch,
-      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
-      {
-        contextLines: 1,
-      },
-    ),
-  ).toMatchSnapshot(
-    'RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app)',
+}, 60000);
+
+test('cleans up if patching fails,', async () => {
+  await UpgradeTestingMethods.cleansUpIfPatchingFails(
+    mockFetch,
+    samplePatch,
+    execa,
+    mockPushLog,
+    upgrade,
+    newVersion,
+    ctx,
+    flushOutput,
+  );
+}, 60000);
+
+test('works with --name-ios and --name-android', async () => {
+  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(
+    mockFetch,
+    samplePatch,
+    upgrade,
+    newVersion,
+    merge,
+    ctx,
+    snapshotDiff,
+    fs,
   );
 }, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
@@ -1,0 +1,324 @@
+import execa from 'execa';
+import path from 'path';
+import fs from 'fs';
+import snapshotDiff from 'snapshot-diff';
+import stripAnsi from 'strip-ansi';
+import upgrade from '../upgrade';
+import {fetch, logger} from '@react-native-community/cli-tools';
+import loadConfig from '../../../tools/config';
+import merge from '../../../tools/merge';
+
+jest.mock('https');
+jest.mock('fs');
+jest.mock('path');
+jest.mock('execa');
+jest.mock(
+  '/project/root/node_modules/react-native/package.json',
+  () => ({name: 'react-native-tvos', version: '0.62.2-1'}),
+  {virtual: true},
+);
+jest.mock(
+  '/project/root/package.json',
+  () => ({
+    name: 'TestApp',
+    dependencies: {'react-native': 'npm:react-native-tvos@^0.62.2-1'},
+  }),
+  {virtual: true},
+);
+jest.mock(
+  '/project/root/NestedApp/node_modules/react-native/package.json',
+  () => ({name: 'react-native-tvos', version: '0.62.2-1'}),
+  {virtual: true},
+);
+jest.mock(
+  '/project/root/NestedApp/package.json',
+  () => ({
+    name: 'TestAppNested',
+    dependencies: {'react-native': 'npm:react-native-tvos@^0.62.2-1'},
+  }),
+  {virtual: true},
+);
+jest.mock('../../../tools/config');
+jest.mock('../../../tools/packageManager', () => ({
+  install: (args) => {
+    mockPushLog('$ yarn add', ...args);
+  },
+}));
+jest.mock('@react-native-community/cli-tools', () => ({
+  ...jest.requireActual('@react-native-community/cli-tools'),
+  fetch: jest.fn(),
+  logger: {
+    info: jest.fn((...args) => mockPushLog('info', args)),
+    error: jest.fn((...args) => mockPushLog('error', args)),
+    warn: jest.fn((...args) => mockPushLog('warn', args)),
+    success: jest.fn((...args) => mockPushLog('success', args)),
+    debug: jest.fn((...args) => mockPushLog('debug', args)),
+    log: jest.fn((...args) => mockPushLog(args)),
+  },
+}));
+
+const mockFetch = (value = '', status = 200) => {
+  (fetch as jest.Mock).mockImplementation(() =>
+    Promise.resolve({data: value, status}),
+  );
+};
+
+const mockExecaDefault = (command, args) => {
+  mockPushLog('$', 'execa', command, args);
+  if (command === 'npm' && args[3] === '--json') {
+    return Promise.resolve({stdout: '{"react": "16.6.3"}'});
+  }
+  if (command === 'git' && args[0] === 'rev-parse') {
+    return Promise.resolve({stdout: ''});
+  }
+  return Promise.resolve({stdout: ''});
+};
+
+const mockExecaNested = (command, args) => {
+  mockPushLog('$', 'execa', command, args);
+  if (command === 'npm' && args[3] === '--json') {
+    return Promise.resolve({stdout: '{"react": "16.6.3"}'});
+  }
+  if (command === 'git' && args[0] === 'rev-parse') {
+    return Promise.resolve({stdout: 'NestedApp/'});
+  }
+  return Promise.resolve({stdout: ''});
+};
+
+const currentVersion = '0.62.2-1';
+const newVersion = '0.64.2-4';
+const olderVersion = '0.60.2-1';
+const ctx = loadConfig();
+
+const samplePatch = jest
+  .requireActual('fs')
+  .readFileSync(path.join(__dirname, './sample.patch'), 'utf8');
+
+let logs = [];
+const mockPushLog = (...args) =>
+  logs.push(args.map((x) => (Array.isArray(x) ? x.join(' ') : x)).join(' '));
+const flushOutput = () => stripAnsi(logs.join('\n'));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+  fs.writeFileSync = jest.fn((filename) => mockPushLog('[fs] write', filename));
+  fs.unlinkSync = jest.fn((...args) => mockPushLog('[fs] unlink', args));
+  logs = [];
+  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaDefault);
+  Object.defineProperty(process, 'platform', {
+    value: 'darwin',
+  });
+});
+
+afterEach(() => {
+  fs.writeFileSync = jest.requireMock('fs').writeFileSync;
+  fs.unlinkSync = jest.requireMock('fs').unlinkSync;
+});
+
+test('uses latest version of react-native when none passed', async () => {
+  await upgrade.func([], ctx);
+  expect(execa).toBeCalledWith('npm', ['info', 'react-native-tvos', 'version']);
+}, 60000);
+
+test('applies patch in current working directory when nested', async () => {
+  mockFetch(samplePatch, 200);
+  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
+  const config = {...ctx, root: '/project/root/NestedApp'};
+  await upgrade.func([newVersion], config);
+
+  expect(execa).toBeCalledWith('git', [
+    'apply',
+    'tmp-upgrade-rn.patch',
+    '--exclude=NestedApp/package.json',
+    '-p2',
+    '--3way',
+    '--directory=NestedApp/',
+  ]);
+});
+
+test('errors when invalid version passed', async () => {
+  await upgrade.func(['next'], ctx);
+  expect(logger.error).toBeCalledWith(
+    'Provided version "next" is not allowed. Please pass a valid semver version',
+  );
+}, 60000);
+
+test('errors when older version passed', async () => {
+  await upgrade.func([olderVersion], ctx);
+  expect(logger.error).toBeCalledWith(
+    `Trying to upgrade from newer version "${currentVersion}" to older "${olderVersion}"`,
+  );
+}, 60000);
+
+test('warns when dependency upgrade version is in semver range', async () => {
+  await upgrade.func([currentVersion], ctx);
+  expect(logger.warn).toBeCalledWith(
+    `Specified version "${currentVersion}" is already installed in node_modules and it satisfies "^0.62.2-1" semver range. No need to upgrade`,
+  );
+}, 60000);
+
+test('fetches empty patch and installs deps', async () => {
+  mockFetch();
+  await upgrade.func([newVersion], ctx);
+  expect(flushOutput()).toMatchInlineSnapshot(`
+    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
+    info Diff has no changes to apply, proceeding further
+    info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
+    $ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
+    $ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Installing CocoaPods dependencies (this may take a few minutes)
+    success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
+  `);
+}, 60000);
+
+test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
+  mockFetch(samplePatch, 200);
+  await upgrade.func(
+    [newVersion],
+    merge(ctx, {
+      project: {
+        ios: {projectName: 'TestApp.xcodeproj'},
+        android: {packageName: 'com.testapp'},
+      },
+    }),
+  );
+  expect(flushOutput()).toMatchInlineSnapshot(`
+    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    info Applying diff...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
+    $ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
+    $ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Installing CocoaPods dependencies (this may take a few minutes)
+    info Running \\"git status\\" to check what changed...
+    $ execa git status
+    success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
+  `);
+  expect(
+    snapshotDiff(
+      samplePatch,
+      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
+      {
+        contextLines: 1,
+      },
+    ),
+  ).toMatchSnapshot(
+    'RnDiffApp is replaced with app name (TestApp and com.testapp)',
+  );
+}, 60000);
+test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
+  mockFetch(samplePatch, 200);
+  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
+  const config = {...ctx, root: '/project/root/NestedApp'};
+  await upgrade.func([newVersion], config);
+  expect(flushOutput()).toMatchInlineSnapshot(`
+    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    info Applying diff...
+    $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    info Installing \\"react-native@0.64.2-4\\" and its peer dependencies...
+    $ execa npm info react-native-tvos@0.64.2-4 peerDependencies --json
+    $ yarn add react-native@npm:react-native-tvos@0.64.2-4 react@16.6.3
+    $ execa git add package.json
+    $ execa git add yarn.lock
+    $ execa git add package-lock.json
+    info Installing CocoaPods dependencies (this may take a few minutes)
+    info Running \\"git status\\" to check what changed...
+    $ execa git status
+    success Upgraded React Native to v0.64.2-4 🎉. Now you can review and commit the changes"
+  `);
+}, 60000);
+test('cleans up if patching fails,', async () => {
+  mockFetch(samplePatch, 200);
+  ((execa as unknown) as jest.Mock).mockImplementation((command, args) => {
+    mockPushLog('$', 'execa', command, args);
+    if (command === 'npm' && args[3] === '--json') {
+      return Promise.resolve({
+        stdout: '{"react": "16.6.3"}',
+      });
+    }
+    if (command === 'git' && args[0] === 'apply') {
+      return Promise.reject({
+        code: 1,
+        stderr:
+          'error: .flowconfig: does not exist in index\nerror: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply',
+      });
+    }
+    if (command === 'git' && args[0] === 'rev-parse') {
+      return Promise.resolve({stdout: ''});
+    }
+    return Promise.resolve({stdout: ''});
+  });
+  try {
+    await upgrade.func([newVersion], ctx);
+  } catch (error) {
+    expect(error.message).toBe(
+      'Upgrade failed. Please see the messages above for details',
+    );
+  }
+  expect(flushOutput()).toMatchInlineSnapshot(`
+    "info Fetching diff between v0.62.2-1 and v0.64.2-4...
+    [fs] write tmp-upgrade-rn.patch
+    $ execa git rev-parse --show-prefix
+    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
+    info Applying diff...
+    warn Excluding files that exist in the template, but not in your project:
+      - .flowconfig
+    error Excluding files that failed to apply the diff:
+      - ios/MyApp.xcodeproj/project.pbxproj
+    Please make sure to check the actual changes after the upgrade command is finished.
+    You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
+    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
+    debug \\"git apply\\" failed. Error output:
+    error: .flowconfig: does not exist in index
+    error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
+    error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
+    [fs] unlink tmp-upgrade-rn.patch
+    $ execa git status -s
+    error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
+    warn After resolving conflicts don't forget to run \\"pod install\\" inside \\"ios\\" directory
+    info You may find these resources helpful:
+    • Release notes: https://github.com/facebook/react-native/releases/tag/v0.64.2-4
+    • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.62.2-1&to=0.64.2-4
+    • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.62.2-1..0.64.2-4.diff"
+  `);
+}, 60000);
+test('works with --name-ios and --name-android', async () => {
+  mockFetch(samplePatch, 200);
+  await upgrade.func(
+    [newVersion],
+    merge(ctx, {
+      project: {
+        ios: {projectName: 'CustomIos.xcodeproj'},
+        android: {packageName: 'co.uk.customandroid.app'},
+      },
+    }),
+  );
+  expect(
+    snapshotDiff(
+      samplePatch,
+      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
+      {
+        contextLines: 1,
+      },
+    ),
+  ).toMatchSnapshot(
+    'RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app)',
+  );
+}, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade-tv.test.ts
@@ -1,18 +1,5 @@
-import execa from 'execa';
-import path from 'path';
-import fs from 'fs';
-import snapshotDiff from 'snapshot-diff';
-import stripAnsi from 'strip-ansi';
-import upgrade from '../upgrade';
-import {fetch, logger} from '@react-native-community/cli-tools';
-import loadConfig from '../../../tools/config';
-import merge from '../../../tools/merge';
 import UpgradeTestingMethods from './upgrade-testing-methods';
 
-jest.mock('https');
-jest.mock('fs');
-jest.mock('path');
-jest.mock('execa');
 jest.mock(
   '/project/root/node_modules/react-native/package.json',
   () => ({name: 'react-native-tvos', version: '0.62.2-1'}),
@@ -39,52 +26,6 @@ jest.mock(
   }),
   {virtual: true},
 );
-jest.mock('../../../tools/config');
-jest.mock('../../../tools/packageManager', () => ({
-  install: (args) => {
-    mockPushLog('$ yarn add', ...args);
-  },
-}));
-jest.mock('@react-native-community/cli-tools', () => ({
-  ...jest.requireActual('@react-native-community/cli-tools'),
-  fetch: jest.fn(),
-  logger: {
-    info: jest.fn((...args) => mockPushLog('info', args)),
-    error: jest.fn((...args) => mockPushLog('error', args)),
-    warn: jest.fn((...args) => mockPushLog('warn', args)),
-    success: jest.fn((...args) => mockPushLog('success', args)),
-    debug: jest.fn((...args) => mockPushLog('debug', args)),
-    log: jest.fn((...args) => mockPushLog(args)),
-  },
-}));
-
-const mockFetch = (value = '', status = 200) => {
-  (fetch as jest.Mock).mockImplementation(() =>
-    Promise.resolve({data: value, status}),
-  );
-};
-
-const mockExecaDefault = (command, args) => {
-  mockPushLog('$', 'execa', command, args);
-  if (command === 'npm' && args[3] === '--json') {
-    return Promise.resolve({stdout: '{"react": "16.6.3"}'});
-  }
-  if (command === 'git' && args[0] === 'rev-parse') {
-    return Promise.resolve({stdout: ''});
-  }
-  return Promise.resolve({stdout: ''});
-};
-
-const mockExecaNested = (command, args) => {
-  mockPushLog('$', 'execa', command, args);
-  if (command === 'npm' && args[3] === '--json') {
-    return Promise.resolve({stdout: '{"react": "16.6.3"}'});
-  }
-  if (command === 'git' && args[0] === 'rev-parse') {
-    return Promise.resolve({stdout: 'NestedApp/'});
-  }
-  return Promise.resolve({stdout: ''});
-};
 
 const repoName = 'react-native-tvos';
 const currentVersion = '0.62.2-1';
@@ -92,142 +33,58 @@ const newVersion = '0.64.2-4';
 const olderVersion = '0.60.2-1';
 const lessOlderVersion = '0.63.3-0';
 
-const ctx = loadConfig();
-
-const samplePatch = jest
-  .requireActual('fs')
-  .readFileSync(path.join(__dirname, './sample.patch'), 'utf8');
-
-let logs = [];
-const mockPushLog = (...args) =>
-  logs.push(args.map((x) => (Array.isArray(x) ? x.join(' ') : x)).join(' '));
-const flushOutput = () => stripAnsi(logs.join('\n'));
-
 beforeEach(() => {
-  jest.clearAllMocks();
-  jest.restoreAllMocks();
-  fs.writeFileSync = jest.fn((filename) => mockPushLog('[fs] write', filename));
-  fs.unlinkSync = jest.fn((...args) => mockPushLog('[fs] unlink', args));
-  logs = [];
-  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaDefault);
-  Object.defineProperty(process, 'platform', {
-    value: 'darwin',
-  });
+  UpgradeTestingMethods.setup();
 });
 
 afterEach(() => {
-  fs.writeFileSync = jest.requireMock('fs').writeFileSync;
-  fs.unlinkSync = jest.requireMock('fs').unlinkSync;
+  UpgradeTestingMethods.teardown();
 });
 
 test('uses latest version of react-native when none passed', async () => {
-  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(
-    upgrade,
-    ctx,
-    execa,
-    repoName,
-  );
+  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(repoName);
 }, 60000);
 
 test('applies patch in current working directory when nested', async () => {
-  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(
-    mockFetch,
-    samplePatch,
-    execa,
-    mockExecaNested,
-    ctx,
-    upgrade,
-    newVersion,
-  );
+  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(newVersion);
 });
 
 test('errors when invalid version passed', async () => {
-  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed(
-    upgrade,
-    ctx,
-    logger,
-  );
+  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed();
 }, 60000);
 
 test('errors when older version passed', async () => {
   await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
-    upgrade,
     olderVersion,
     lessOlderVersion,
-    ctx,
     currentVersion,
-    logger,
   );
 }, 60000);
 
 test('warns when dependency upgrade version is in semver range', async () => {
-  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(
-    upgrade,
-    currentVersion,
-    ctx,
-    logger,
-  );
+  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(currentVersion);
 }, 60000);
 
 test('fetches empty patch and installs deps', async () => {
-  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(
-    mockFetch,
-    upgrade,
-    newVersion,
-    ctx,
-    flushOutput,
-  );
+  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(newVersion);
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
   await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
-    mockFetch,
-    samplePatch,
-    upgrade,
     newVersion,
-    merge,
-    ctx,
-    flushOutput,
-    snapshotDiff,
-    fs,
   );
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
   await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
-    samplePatch,
-    mockFetch,
-    execa,
-    mockExecaNested,
-    ctx,
-    upgrade,
     newVersion,
-    flushOutput,
   );
 }, 60000);
 
 test('cleans up if patching fails,', async () => {
-  await UpgradeTestingMethods.cleansUpIfPatchingFails(
-    mockFetch,
-    samplePatch,
-    execa,
-    mockPushLog,
-    upgrade,
-    newVersion,
-    ctx,
-    flushOutput,
-  );
+  await UpgradeTestingMethods.cleansUpIfPatchingFails(newVersion);
 }, 60000);
 
 test('works with --name-ios and --name-android', async () => {
-  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(
-    mockFetch,
-    samplePatch,
-    upgrade,
-    newVersion,
-    merge,
-    ctx,
-    snapshotDiff,
-    fs,
-  );
+  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(newVersion);
 }, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.ts
@@ -1,18 +1,6 @@
-import execa from 'execa';
-import path from 'path';
-import fs from 'fs';
-import snapshotDiff from 'snapshot-diff';
-import stripAnsi from 'strip-ansi';
-import upgrade from '../upgrade';
-import {fetch, logger} from '@react-native-community/cli-tools';
-import loadConfig from '../../../tools/config';
-import merge from '../../../tools/merge';
+import {setupMaster} from 'cluster';
 import UpgradeTestingMethods from './upgrade-testing-methods';
 
-jest.mock('https');
-jest.mock('fs');
-jest.mock('path');
-jest.mock('execa');
 jest.mock(
   '/project/root/node_modules/react-native/package.json',
   () => ({name: 'react-native', version: '0.57.8'}),
@@ -36,52 +24,6 @@ jest.mock(
   }),
   {virtual: true},
 );
-jest.mock('../../../tools/config');
-jest.mock('../../../tools/packageManager', () => ({
-  install: (args) => {
-    mockPushLog('$ yarn add', ...args);
-  },
-}));
-jest.mock('@react-native-community/cli-tools', () => ({
-  ...jest.requireActual('@react-native-community/cli-tools'),
-  fetch: jest.fn(),
-  logger: {
-    info: jest.fn((...args) => mockPushLog('info', args)),
-    error: jest.fn((...args) => mockPushLog('error', args)),
-    warn: jest.fn((...args) => mockPushLog('warn', args)),
-    success: jest.fn((...args) => mockPushLog('success', args)),
-    debug: jest.fn((...args) => mockPushLog('debug', args)),
-    log: jest.fn((...args) => mockPushLog(args)),
-  },
-}));
-
-const mockFetch = (value = '', status = 200) => {
-  (fetch as jest.Mock).mockImplementation(() =>
-    Promise.resolve({data: value, status}),
-  );
-};
-
-const mockExecaDefault = (command, args) => {
-  mockPushLog('$', 'execa', command, args);
-  if (command === 'npm' && args[3] === '--json') {
-    return Promise.resolve({stdout: '{"react": "16.6.3"}'});
-  }
-  if (command === 'git' && args[0] === 'rev-parse') {
-    return Promise.resolve({stdout: ''});
-  }
-  return Promise.resolve({stdout: ''});
-};
-
-const mockExecaNested = (command, args) => {
-  mockPushLog('$', 'execa', command, args);
-  if (command === 'npm' && args[3] === '--json') {
-    return Promise.resolve({stdout: '{"react": "16.6.3"}'});
-  }
-  if (command === 'git' && args[0] === 'rev-parse') {
-    return Promise.resolve({stdout: 'NestedApp/'});
-  }
-  return Promise.resolve({stdout: ''});
-};
 
 const repoName = 'react-native';
 const currentVersion = '0.57.8';
@@ -89,142 +31,58 @@ const newVersion = '0.58.4';
 const olderVersion = '0.56.0';
 const lessOlderVersion = '0.57.10';
 
-const ctx = loadConfig();
-
-const samplePatch = jest
-  .requireActual('fs')
-  .readFileSync(path.join(__dirname, './sample.patch'), 'utf8');
-
-let logs = [];
-const mockPushLog = (...args) =>
-  logs.push(args.map((x) => (Array.isArray(x) ? x.join(' ') : x)).join(' '));
-const flushOutput = () => stripAnsi(logs.join('\n'));
-
 beforeEach(() => {
-  jest.clearAllMocks();
-  jest.restoreAllMocks();
-  fs.writeFileSync = jest.fn((filename) => mockPushLog('[fs] write', filename));
-  fs.unlinkSync = jest.fn((...args) => mockPushLog('[fs] unlink', args));
-  logs = [];
-  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaDefault);
-  Object.defineProperty(process, 'platform', {
-    value: 'darwin',
-  });
+  UpgradeTestingMethods.setup();
 });
 
 afterEach(() => {
-  fs.writeFileSync = jest.requireMock('fs').writeFileSync;
-  fs.unlinkSync = jest.requireMock('fs').unlinkSync;
+  UpgradeTestingMethods.teardown();
 });
 
 test('uses latest version of react-native when none passed', async () => {
-  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(
-    upgrade,
-    ctx,
-    execa,
-    repoName,
-  );
+  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(repoName);
 }, 60000);
 
 test('applies patch in current working directory when nested', async () => {
-  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(
-    mockFetch,
-    samplePatch,
-    execa,
-    mockExecaNested,
-    ctx,
-    upgrade,
-    newVersion,
-  );
+  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(newVersion);
 });
 
 test('errors when invalid version passed', async () => {
-  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed(
-    upgrade,
-    ctx,
-    logger,
-  );
+  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed();
 }, 60000);
 
 test('errors when older version passed', async () => {
   await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
-    upgrade,
     olderVersion,
     lessOlderVersion,
-    ctx,
     currentVersion,
-    logger,
   );
 }, 60000);
 
 test('warns when dependency upgrade version is in semver range', async () => {
-  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(
-    upgrade,
-    currentVersion,
-    ctx,
-    logger,
-  );
+  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(currentVersion);
 }, 60000);
 
 test('fetches empty patch and installs deps', async () => {
-  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(
-    mockFetch,
-    upgrade,
-    newVersion,
-    ctx,
-    flushOutput,
-  );
+  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(newVersion);
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
   await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
-    mockFetch,
-    samplePatch,
-    upgrade,
     newVersion,
-    merge,
-    ctx,
-    flushOutput,
-    snapshotDiff,
-    fs,
   );
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
   await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
-    samplePatch,
-    mockFetch,
-    execa,
-    mockExecaNested,
-    ctx,
-    upgrade,
     newVersion,
-    flushOutput,
   );
 }, 60000);
 
 test('cleans up if patching fails,', async () => {
-  await UpgradeTestingMethods.cleansUpIfPatchingFails(
-    mockFetch,
-    samplePatch,
-    execa,
-    mockPushLog,
-    upgrade,
-    newVersion,
-    ctx,
-    flushOutput,
-  );
+  await UpgradeTestingMethods.cleansUpIfPatchingFails(newVersion);
 }, 60000);
 
 test('works with --name-ios and --name-android', async () => {
-  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(
-    mockFetch,
-    samplePatch,
-    upgrade,
-    newVersion,
-    merge,
-    ctx,
-    snapshotDiff,
-    fs,
-  );
+  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(newVersion);
 }, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.ts
@@ -31,58 +31,62 @@ const newVersion = '0.58.4';
 const olderVersion = '0.56.0';
 const lessOlderVersion = '0.57.10';
 
-beforeEach(() => {
-  UpgradeTestingMethods.setup();
+describe('Upgrade tests for react-native repo', () => {
+  beforeEach(() => {
+    UpgradeTestingMethods.setup();
+  });
+
+  afterEach(() => {
+    UpgradeTestingMethods.teardown();
+  });
+
+  test('uses latest version of react-native when none passed', async () => {
+    await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(repoName);
+  }, 60000);
+
+  test('applies patch in current working directory when nested', async () => {
+    await UpgradeTestingMethods.appliesPatchInCwdWhenNested(newVersion);
+  });
+
+  test('errors when invalid version passed', async () => {
+    await UpgradeTestingMethods.errorsWhenInvalidVersionPassed();
+  }, 60000);
+
+  test('errors when older version passed', async () => {
+    await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
+      olderVersion,
+      lessOlderVersion,
+      currentVersion,
+    );
+  }, 60000);
+
+  test('warns when dependency upgrade version is in semver range', async () => {
+    await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(
+      currentVersion,
+    );
+  }, 60000);
+
+  test('fetches empty patch and installs deps', async () => {
+    await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(newVersion);
+  }, 60000);
+
+  test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
+    await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
+      newVersion,
+    );
+  }, 60000);
+
+  test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
+    await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
+      newVersion,
+    );
+  }, 60000);
+
+  test('cleans up if patching fails,', async () => {
+    await UpgradeTestingMethods.cleansUpIfPatchingFails(newVersion);
+  }, 60000);
+
+  test('works with --name-ios and --name-android', async () => {
+    await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(newVersion);
+  }, 60000);
 });
-
-afterEach(() => {
-  UpgradeTestingMethods.teardown();
-});
-
-test('uses latest version of react-native when none passed', async () => {
-  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(repoName);
-}, 60000);
-
-test('applies patch in current working directory when nested', async () => {
-  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(newVersion);
-});
-
-test('errors when invalid version passed', async () => {
-  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed();
-}, 60000);
-
-test('errors when older version passed', async () => {
-  await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
-    olderVersion,
-    lessOlderVersion,
-    currentVersion,
-  );
-}, 60000);
-
-test('warns when dependency upgrade version is in semver range', async () => {
-  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(currentVersion);
-}, 60000);
-
-test('fetches empty patch and installs deps', async () => {
-  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(newVersion);
-}, 60000);
-
-test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
-  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
-    newVersion,
-  );
-}, 60000);
-
-test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
-  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
-    newVersion,
-  );
-}, 60000);
-
-test('cleans up if patching fails,', async () => {
-  await UpgradeTestingMethods.cleansUpIfPatchingFails(newVersion);
-}, 60000);
-
-test('works with --name-ios and --name-android', async () => {
-  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(newVersion);
-}, 60000);

--- a/packages/cli/src/commands/upgrade/__tests__/upgrade.test.ts
+++ b/packages/cli/src/commands/upgrade/__tests__/upgrade.test.ts
@@ -7,6 +7,7 @@ import upgrade from '../upgrade';
 import {fetch, logger} from '@react-native-community/cli-tools';
 import loadConfig from '../../../tools/config';
 import merge from '../../../tools/merge';
+import UpgradeTestingMethods from './upgrade-testing-methods';
 
 jest.mock('https');
 jest.mock('fs');
@@ -82,9 +83,12 @@ const mockExecaNested = (command, args) => {
   return Promise.resolve({stdout: ''});
 };
 
+const repoName = 'react-native';
 const currentVersion = '0.57.8';
 const newVersion = '0.58.4';
 const olderVersion = '0.56.0';
+const lessOlderVersion = '0.57.10';
+
 const ctx = loadConfig();
 
 const samplePatch = jest
@@ -114,212 +118,113 @@ afterEach(() => {
 });
 
 test('uses latest version of react-native when none passed', async () => {
-  await upgrade.func([], ctx);
-  expect(execa).toBeCalledWith('npm', ['info', 'react-native', 'version']);
+  await UpgradeTestingMethods.usesLatestVersionWhenNonePassed(
+    upgrade,
+    ctx,
+    execa,
+    repoName,
+  );
 }, 60000);
 
 test('applies patch in current working directory when nested', async () => {
-  mockFetch(samplePatch, 200);
-  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
-  const config = {...ctx, root: '/project/root/NestedApp'};
-  await upgrade.func([newVersion], config);
-
-  expect(execa).toBeCalledWith('git', [
-    'apply',
-    'tmp-upgrade-rn.patch',
-    '--exclude=NestedApp/package.json',
-    '-p2',
-    '--3way',
-    '--directory=NestedApp/',
-  ]);
+  await UpgradeTestingMethods.appliesPatchInCwdWhenNested(
+    mockFetch,
+    samplePatch,
+    execa,
+    mockExecaNested,
+    ctx,
+    upgrade,
+    newVersion,
+  );
 });
 
 test('errors when invalid version passed', async () => {
-  await upgrade.func(['next'], ctx);
-  expect(logger.error).toBeCalledWith(
-    'Provided version "next" is not allowed. Please pass a valid semver version',
+  await UpgradeTestingMethods.errorsWhenInvalidVersionPassed(
+    upgrade,
+    ctx,
+    logger,
   );
 }, 60000);
 
 test('errors when older version passed', async () => {
-  await upgrade.func([olderVersion], ctx);
-  expect(logger.error).toBeCalledWith(
-    `Trying to upgrade from newer version "${currentVersion}" to older "${olderVersion}"`,
-  );
-  await upgrade.func(['0.57.10'], ctx);
-  expect(logger.error).not.toBeCalledWith(
-    `Trying to upgrade from newer version "${currentVersion}" to older "0.57.10"`,
+  await UpgradeTestingMethods.errorsWhenOlderVersionPassed(
+    upgrade,
+    olderVersion,
+    lessOlderVersion,
+    ctx,
+    currentVersion,
+    logger,
   );
 }, 60000);
 
 test('warns when dependency upgrade version is in semver range', async () => {
-  await upgrade.func([currentVersion], ctx);
-  expect(logger.warn).toBeCalledWith(
-    `Specified version "${currentVersion}" is already installed in node_modules and it satisfies "^0.57.8" semver range. No need to upgrade`,
+  await UpgradeTestingMethods.warnsWhenDependencyInSemverRange(
+    upgrade,
+    currentVersion,
+    ctx,
+    logger,
   );
 }, 60000);
 
 test('fetches empty patch and installs deps', async () => {
-  mockFetch();
-  await upgrade.func([newVersion], ctx);
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    info Diff has no changes to apply, proceeding further
-    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-    $ execa npm info react-native@0.58.4 peerDependencies --json
-    $ yarn add react-native@0.58.4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Installing CocoaPods dependencies (this may take a few minutes)
-    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-  `);
+  await UpgradeTestingMethods.fetchesEmptyPatchAndInstallsDeps(
+    mockFetch,
+    upgrade,
+    newVersion,
+    ctx,
+    flushOutput,
+  );
 }, 60000);
 
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote,', async () => {
-  mockFetch(samplePatch, 200);
-  await upgrade.func(
-    [newVersion],
-    merge(ctx, {
-      project: {
-        ios: {projectName: 'TestApp.xcodeproj'},
-        android: {packageName: 'com.testapp'},
-      },
-    }),
-  );
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    info Applying diff...
-    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-    $ execa npm info react-native@0.58.4 peerDependencies --json
-    $ yarn add react-native@0.58.4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Installing CocoaPods dependencies (this may take a few minutes)
-    info Running \\"git status\\" to check what changed...
-    $ execa git status
-    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-    `);
-  expect(
-    snapshotDiff(
-      samplePatch,
-      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
-      {
-        contextLines: 1,
-      },
-    ),
-  ).toMatchSnapshot(
-    'RnDiffApp is replaced with app name (TestApp and com.testapp)',
+  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemote(
+    mockFetch,
+    samplePatch,
+    upgrade,
+    newVersion,
+    merge,
+    ctx,
+    flushOutput,
+    snapshotDiff,
+    fs,
   );
 }, 60000);
+
 test('fetches regular patch, adds remote, applies patch, installs deps, removes remote when updated from nested directory', async () => {
-  mockFetch(samplePatch, 200);
-  ((execa as unknown) as jest.Mock).mockImplementation(mockExecaNested);
-  const config = {...ctx, root: '/project/root/NestedApp'};
-  await upgrade.func([newVersion], config);
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-    info Applying diff...
-    $ execa git apply tmp-upgrade-rn.patch --exclude=NestedApp/package.json -p2 --3way --directory=NestedApp/
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    info Installing \\"react-native@0.58.4\\" and its peer dependencies...
-    $ execa npm info react-native@0.58.4 peerDependencies --json
-    $ yarn add react-native@0.58.4 react@16.6.3
-    $ execa git add package.json
-    $ execa git add yarn.lock
-    $ execa git add package-lock.json
-    info Installing CocoaPods dependencies (this may take a few minutes)
-    info Running \\"git status\\" to check what changed...
-    $ execa git status
-    success Upgraded React Native to v0.58.4 🎉. Now you can review and commit the changes"
-  `);
-}, 60000);
-test('cleans up if patching fails,', async () => {
-  mockFetch(samplePatch, 200);
-  ((execa as unknown) as jest.Mock).mockImplementation((command, args) => {
-    mockPushLog('$', 'execa', command, args);
-    if (command === 'npm' && args[3] === '--json') {
-      return Promise.resolve({
-        stdout: '{"react": "16.6.3"}',
-      });
-    }
-    if (command === 'git' && args[0] === 'apply') {
-      return Promise.reject({
-        code: 1,
-        stderr:
-          'error: .flowconfig: does not exist in index\nerror: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply',
-      });
-    }
-    if (command === 'git' && args[0] === 'rev-parse') {
-      return Promise.resolve({stdout: ''});
-    }
-    return Promise.resolve({stdout: ''});
-  });
-  try {
-    await upgrade.func([newVersion], ctx);
-  } catch (error) {
-    expect(error.message).toBe(
-      'Upgrade failed. Please see the messages above for details',
-    );
-  }
-  expect(flushOutput()).toMatchInlineSnapshot(`
-    "info Fetching diff between v0.57.8 and v0.58.4...
-    [fs] write tmp-upgrade-rn.patch
-    $ execa git rev-parse --show-prefix
-    $ execa git apply --binary --check tmp-upgrade-rn.patch --exclude=package.json -p2 --3way --directory=
-    info Applying diff...
-    warn Excluding files that exist in the template, but not in your project:
-      - .flowconfig
-    error Excluding files that failed to apply the diff:
-      - ios/MyApp.xcodeproj/project.pbxproj
-    Please make sure to check the actual changes after the upgrade command is finished.
-    You can find them in our Upgrade Helper web app: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
-    $ execa git apply tmp-upgrade-rn.patch --exclude=package.json --exclude=.flowconfig --exclude=ios/MyApp.xcodeproj/project.pbxproj -p2 --3way --directory=
-    debug \\"git apply\\" failed. Error output:
-    error: .flowconfig: does not exist in index
-    error: ios/MyApp.xcodeproj/project.pbxproj: patch does not apply
-    error Automatically applying diff failed. We did our best to automatically upgrade as many files as possible
-    [fs] unlink tmp-upgrade-rn.patch
-    $ execa git status -s
-    error Patch failed to apply for unknown reason. Please fall back to manual way of upgrading
-    warn After resolving conflicts don't forget to run \\"pod install\\" inside \\"ios\\" directory
-    info You may find these resources helpful:
-    • Release notes: https://github.com/facebook/react-native/releases/tag/v0.58.4
-    • Manual Upgrade Helper: https://react-native-community.github.io/upgrade-helper/?from=0.57.8&to=0.58.4
-    • Git diff: https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs/0.57.8..0.58.4.diff"
-  `);
-}, 60000);
-test('works with --name-ios and --name-android', async () => {
-  mockFetch(samplePatch, 200);
-  await upgrade.func(
-    [newVersion],
-    merge(ctx, {
-      project: {
-        ios: {projectName: 'CustomIos.xcodeproj'},
-        android: {packageName: 'co.uk.customandroid.app'},
-      },
-    }),
+  await UpgradeTestingMethods.fetchesRegularPatchInstallRemoteAppliesPatchInstallsDepsRemovesRemoteNested(
+    samplePatch,
+    mockFetch,
+    execa,
+    mockExecaNested,
+    ctx,
+    upgrade,
+    newVersion,
+    flushOutput,
   );
-  expect(
-    snapshotDiff(
-      samplePatch,
-      (fs.writeFileSync as jest.Mock).mock.calls[0][1],
-      {
-        contextLines: 1,
-      },
-    ),
-  ).toMatchSnapshot(
-    'RnDiffApp is replaced with app name (CustomIos and co.uk.customandroid.app)',
+}, 60000);
+
+test('cleans up if patching fails,', async () => {
+  await UpgradeTestingMethods.cleansUpIfPatchingFails(
+    mockFetch,
+    samplePatch,
+    execa,
+    mockPushLog,
+    upgrade,
+    newVersion,
+    ctx,
+    flushOutput,
+  );
+}, 60000);
+
+test('works with --name-ios and --name-android', async () => {
+  await UpgradeTestingMethods.worksWithNameIosAndNameAndroid(
+    mockFetch,
+    samplePatch,
+    upgrade,
+    newVersion,
+    merge,
+    ctx,
+    snapshotDiff,
+    fs,
   );
 }, 60000);

--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -158,14 +158,16 @@ const getVersionToUpgradeTo = async (
       dependencies: {'react-native': version},
     } = require(path.join(projectDir, 'package.json'));
 
-    if (semver.satisfies(newVersion, version)) {
+    const parsedVersion = version.split('@')[version.split('@').length - 1];
+
+    if (semver.satisfies(newVersion, parsedVersion)) {
       logger.warn(
-        `Specified version "${newVersion}" is already installed in node_modules and it satisfies "${version}" semver range. No need to upgrade`,
+        `Specified version "${newVersion}" is already installed in node_modules and it satisfies "${parsedVersion}" semver range. No need to upgrade`,
       );
       return null;
     }
     logger.error(
-      `Dependency mismatch. Specified version "${newVersion}" is already installed in node_modules and it doesn't satisfy "${version}" semver range of your "react-native" dependency. Please re-install your dependencies`,
+      `Dependency mismatch. Specified version "${newVersion}" is already installed in node_modules and it doesn't satisfy "${parsedVersion}" semver range of your "react-native" dependency. Please re-install your dependencies`,
     );
     return null;
   }
@@ -322,21 +324,12 @@ const applyPatch = async (
 async function upgrade(argv: Array<string>, ctx: Config) {
   const tmpPatchFile = 'tmp-upgrade-rn.patch';
   const projectDir = ctx.root;
-  const {version: currentVersion} = require(path.join(
+  const {name: rnName, version: currentVersion} = require(path.join(
     projectDir,
     'node_modules/react-native/package.json',
   ));
 
-  let isTV = false;
-  const existingPackageJson = require(path.join(projectDir, 'package.json'));
-
-  if (
-    existingPackageJson.dependencies['react-native'].indexOf(
-      'react-native-tvos',
-    ) !== -1
-  ) {
-    isTV = true;
-  }
+  const isTV = rnName === 'react-native-tvos';
 
   const newVersion = await getVersionToUpgradeTo(
     argv,

--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -21,7 +21,7 @@ const forks = {
   },
   'react-native-tvos': {
     rawDiffUrl:
-      'https://raw.githubusercontent.com/douglowder/rn-diff-purge-tv/diffs/diffs',
+      'https://raw.githubusercontent.com/react-native-tvos/rn-diff-purge-tv/diffs/diffs',
     webDiffUrl: 'https://react-native-community.github.io/upgrade-helper',
     dependencyName: 'react-native@npm:react-native-tvos',
   },


### PR DESCRIPTION
Summary:
---------

The upgrade command does not currently work for Apple TV and Android TV projects, because they use `react-native-tvos`, a fork of the main repo. (Issue #1476) (https://github.com/react-native-tvos/react-native-tvos/issues/224)

Solution:
- Provide a version of https://github.com/react-native-community/rn-diff-purge that has the diffs for the TV repo
- Make `upgrade.ts` generic by detecting whether the project is using a forked repo, and having an easily extendable list of forks that are known to work.  This list includes the main repo as well.

```ts
type ForkNameType = 'react-native' | 'react-native-tvos';

const forks = {
  'react-native': {
    rawDiffUrl:
      'https://raw.githubusercontent.com/react-native-community/rn-diff-purge/diffs/diffs',
    webDiffUrl: 'https://react-native-community.github.io/upgrade-helper',
    dependencyName: 'react-native',
  },
  'react-native-tvos': {
    rawDiffUrl:
      'https://raw.githubusercontent.com/react-native-tvos/rn-diff-purge-tv/diffs/diffs',
    webDiffUrl: 'https://react-native-community.github.io/upgrade-helper',
    dependencyName: 'react-native@npm:react-native-tvos',
  },
};

```

All methods in `upgrade.ts` now refer to this structure in their implementations.


Test Plan:
----------

- I duplicated all the existing unit tests for `upgrade.ts` in a separate `upgrade-tv.test.ts` file so that all tests run against the TV repo
- I tested manually with a project generated with an older version of `react-native-tvos`

