### PR TITLE
fix: bootSimulator to use simclt instead of deprecated instruments

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -398,11 +398,7 @@ function bootSimulator(selectedSimulator: Device) {
   const simulatorFullName = formattedDeviceName(selectedSimulator);
   logger.info(`Launching ${simulatorFullName}`);
 
-  child_process.spawnSync('xcrun', [
-    'simctl',
-    'boot',
-    selectedSimulator.udid,
-  ]);
+  child_process.spawnSync('xcrun', ['simctl', 'boot', selectedSimulator.udid]);
 }
 
 function getTargetPaths(buildSettings: string) {


### PR DESCRIPTION
Should fix #1474 and https://github.com/facebook/react-native/issues/32255#issuecomment-932039063

Summary:
---------

With Xcode 13 `react-native run-ios --simulator [simulatorName]` won't boot a new simulator if Simulator.app is already running but the selected sim is not booted.
This PR should fix this  (instrument is deprecated in Xcode 13, we replace it with a simctl command )

Test Plan:
----------

**How to reproduce the issue:**
 
- run `yarn run react-native run-ios --simulator='iPhone 11 Pro'`
- close the simulator but DON'T close the Simulator.app (it should be on but no simulator present in the window menu)
- run again `yarn run react-native run-ios --simulator='iPhone 11 Pro'`

The simulator will not boot again


Or

- run `yarn run react-native run-ios --simulator='iPhone 11 Pro'`
- leave the simulator open
- run `yarn run react-native run-ios --simulator='iPhone 7'`

The new iPhone 7 simulator won't boot. 

**With this PR**

Both cases from above should work fine



