### PR TITLE
Better Handle EPERM on Windows

### DIFF
--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -38,10 +38,10 @@ afterEach(() => {
   fs.removeSync(testPath);
 });
 
-test('should edit template', () => {
+test('should edit template', async () => {
   jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
 
-  changePlaceholderInTemplate({
+  await changePlaceholderInTemplate({
     projectName: PROJECT_NAME,
     placeholderName: PLACEHOLDER_NAME,
   });
@@ -90,10 +90,10 @@ test('should edit template', () => {
   ).toMatchSnapshot();
 });
 
-test('should edit template with custom title', () => {
+test('should edit template with custom title', async () => {
   jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
 
-  changePlaceholderInTemplate({
+  await changePlaceholderInTemplate({
     projectName: PROJECT_NAME,
     placeholderName: PLACEHOLDER_NAME,
     projectTitle: PROJECT_TITLE,
@@ -134,8 +134,8 @@ describe('changePlaceholderInTemplate', () => {
     jest.resetAllMocks();
   });
 
-  test(`should produce a lowercased version of "${PROJECT_NAME}" in package.json "name" field`, () => {
-    changePlaceholderInTemplate({
+  test(`should produce a lowercased version of "${PROJECT_NAME}" in package.json "name" field`, async () => {
+    await changePlaceholderInTemplate({
       projectName: PROJECT_NAME,
       placeholderName: PLACEHOLDER_NAME,
     });

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -111,6 +111,6 @@ export async function changePlaceholderInTemplate({
       );
     }
 
-    processDotfiles(filePath);
+    await processDotfiles(filePath);
   }
 }

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -1,7 +1,11 @@
-import fs from 'fs-extra';
 import path from 'path';
 import {logger} from '@react-native-community/cli-tools';
 import walk from '../../tools/walk';
+
+// We need `graceful-fs` behavior around async file renames on Win32.
+// `gracefulify` does not support patching `fs.promises`. Use `fs-extra`, which
+// exposes its own promise-based interface over `graceful-fs`.
+import fs from 'fs-extra';
 
 interface PlaceholderConfig {
   projectName: string;

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -1,4 +1,4 @@
-import {promises as fs} from 'fs';
+import fs from 'fs-extra';
 import path from 'path';
 import {logger} from '@react-native-community/cli-tools';
 import walk from '../../tools/walk';

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -1,4 +1,4 @@
-import fs from 'fs-extra';
+import {promises as fs} from 'fs';
 import path from 'path';
 import {logger} from '@react-native-community/cli-tools';
 import walk from '../../tools/walk';
@@ -96,7 +96,7 @@ export async function changePlaceholderInTemplate({
     if (shouldIgnoreFile(filePath)) {
       continue;
     }
-    if (!fs.statSync(filePath).isDirectory()) {
+    if (!(await fs.stat(filePath)).isDirectory()) {
       await replaceNameInUTF8File(filePath, projectName, placeholderName);
       await replaceNameInUTF8File(filePath, projectTitle, placeholderTitle);
     }

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -16,14 +16,14 @@ interface PlaceholderConfig {
 */
 const DEFAULT_TITLE_PLACEHOLDER = 'Hello App Display Name';
 
-function replaceNameInUTF8File(
+async function replaceNameInUTF8File(
   filePath: string,
   projectName: string,
   templateName: string,
 ) {
   logger.debug(`Replacing in ${filePath}`);
   const isPackageJson = path.basename(filePath) === 'package.json';
-  const fileContent = fs.readFileSync(filePath, 'utf8');
+  const fileContent = await fs.readFile(filePath, 'utf8');
   const replacedFileContent = fileContent
     .replace(new RegExp(templateName, 'g'), projectName)
     .replace(
@@ -32,11 +32,11 @@ function replaceNameInUTF8File(
     );
 
   if (fileContent !== replacedFileContent) {
-    fs.writeFileSync(filePath, replacedFileContent, 'utf8');
+    await fs.writeFile(filePath, replacedFileContent, 'utf8');
   }
 
   if (isPackageJson) {
-    fs.writeFileSync(
+    await fs.writeFile(
       filePath,
       fileContent.replace(templateName, projectName.toLowerCase()),
       'utf8',
@@ -94,11 +94,11 @@ export async function changePlaceholderInTemplate({
 
   for (const filePath of walk(process.cwd()).reverse()) {
     if (shouldIgnoreFile(filePath)) {
-      return;
+      continue;
     }
     if (!fs.statSync(filePath).isDirectory()) {
-      replaceNameInUTF8File(filePath, projectName, placeholderName);
-      replaceNameInUTF8File(filePath, projectTitle, placeholderTitle);
+      await replaceNameInUTF8File(filePath, projectName, placeholderName);
+      await replaceNameInUTF8File(filePath, projectTitle, placeholderTitle);
     }
     if (shouldRenameFile(filePath, placeholderName)) {
       await renameFile(filePath, placeholderName, projectName);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -111,7 +111,7 @@ async function createFromTemplate({
     loader.succeed();
     loader.start('Processing template');
 
-    changePlaceholderInTemplate({
+    await changePlaceholderInTemplate({
       projectName,
       projectTitle,
       placeholderName: templateConfig.placeholderName,


### PR DESCRIPTION
Summary:
---------

Use async `fs-extra` function for rename, which hooks into a `graceful-fs` implementation that can handle AV locked files on Windows. See https://github.com/isaacs/node-graceful-fs/blob/89dc1330dcd8fa218c5dff92a97d8792b7da6b12/polyfills.js#L96-L118 for details.


Test Plan:
----------

Existing test coverage.
