### PR TITLE
Support renamed PreactNativeArchitectures

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -71,8 +71,13 @@ async function runOnAllDevices(
         .filter((arch) => arch != null);
       if (architectures.length > 0) {
         logger.info(`Detected architectures ${architectures.join(', ')}`);
+        // `reactNativeDebugArchitectures` was renamed to `reactNativeArchitectures` in 0.68.
+        // Can be removed when 0.67 no longer needs to be supported.
         gradleArgs.push(
           '-PreactNativeDebugArchitectures=' + architectures.join(','),
+        );
+        gradleArgs.push(
+          '-PreactNativeArchitectures=' + architectures.join(','),
         );
       }
     }


### PR DESCRIPTION
Summary:
---------

The `reactNativeDebugArchitectures` property was renamed to `reactNativeArchitectures` in https://github.com/facebook/react-native/commit/43c38cdc8e31910e0109f85d258fba22ec9469a0. This passes both flags to be compatible with both versions.

Test Plan:
----------

Test the change locally in an app.