### PR TITLE
Fixed NullPointer in native_modules.gradle

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -272,7 +272,7 @@ class ReactNativeModules {
         reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
         reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
         reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
-        if (!androidConfig["buildTypes"].isEmpty()) {
+        if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
         }
         if(androidConfig.containsKey("dependencyConfiguration")) {


### PR DESCRIPTION
Resolved NullPointer issue described in #1489

On lib version 6.2.0 with the environment described below, we had NullPointer during the project build.

**Environment:**
Android Studio: Artic Fox 2020| 3.1.0 Patch 3
ANDROID GRADLE PLUGIN: 7.0+
minSdk : 21
targetSdk : 30,
compileSdk : 30

You can test & verify changes on the simple project.
