### PR TITLE
fix: doctor breaks in newer versions of Windows

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/androidStudio.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidStudio.ts
@@ -26,8 +26,9 @@ export default {
         'bin',
         'studio.exe',
       ).replace(/\\/g, '\\\\');
+      const powershell = `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
       const {stdout} = await executeCommand(
-        `wmic datafile where name="${androidStudioPath}" get Version`,
+        `${powershell} -Command "& { (Get-ChildItem \\"${androidStudioPath}\\").VersionInfo.FileVersionRaw.ToString() }"`,
       );
       const version = stdout.replace(/(\r\n|\n|\r)/gm, '').trim();
 


### PR DESCRIPTION
Fixes #1513 

Summary:
---------

wmic is deprecated (removed) in newer version of Windows. Use powershell to find out the version of android studio

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
