### PR TITLE
Extend findPackageClassName to address TurboModules

### DIFF
--- a/packages/platform-android/src/config/__fixtures__/android.ts
+++ b/packages/platform-android/src/config/__fixtures__/android.ts
@@ -157,6 +157,10 @@ export const findPackagesClassNameKotlinValid = [
        return Collections.emptyList()
     }
   }`,
+  `
+  class SomeExampleKotlinPackage : TurboReactPackage {
+
+  }`,
 ];
 
 export const findPackagesClassNameKotlinNotValid = [
@@ -205,7 +209,28 @@ export const findPackagesClassNameJavaValid = [
     implements
     SomePackage,
     ReactPackage {
-    
+
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage extends TurboReactPackage {
+
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage
+    extends
+    TurboReactPackage {
+
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage
+    extends
+    TurboReactPackage
+    implements
+    ReactPackage {
+
   }
   `,
 ];

--- a/packages/platform-android/src/config/findPackageClassName.ts
+++ b/packages/platform-android/src/config/findPackageClassName.ts
@@ -23,7 +23,16 @@ export default function getPackageClassName(folder: string) {
 }
 
 export function matchClassName(file: string) {
-  return file.match(
+  const nativeModuleMatch = file.match(
     /class\s+(\w+[^(\s]*)[\s\w():]*(\s+implements\s+|:)[\s\w():,]*[^{]*ReactPackage/,
   );
+  // We first check for implementation of ReactPackage to find native
+  // modules and then for subclasses of TurboReactPackage to find turbo modules.
+  if (nativeModuleMatch) {
+    return nativeModuleMatch;
+  } else {
+    return file.match(
+      /class\s+(\w+[^(\s]*)[\s\w():]*(\s+extends\s+|:)[\s\w():,]*[^{]*TurboReactPackage/,
+    );
+  }
 }


### PR DESCRIPTION
Summary:
---------

This PR extends the `findPackageClassName` capability to address also TurboModules, which are implemented as subclasses of `TurboReactPackage` (see https://github.com/facebook/react-native/blob/2162bce44bbf40513bcf90b793810d05a67d2b7e/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java#L73-L111).
I didn't want to over-complicate the already existing Regex therefore I've created a separate one.


Test Plan:
----------

Tests are attached.