### PR TITLE
Revert "fix: doctor breaks in newer versions of Windows"

### DIFF
--- a/packages/cli/src/commands/doctor/healthchecks/androidStudio.ts
+++ b/packages/cli/src/commands/doctor/healthchecks/androidStudio.ts
@@ -26,9 +26,8 @@ export default {
         'bin',
         'studio.exe',
       ).replace(/\\/g, '\\\\');
-      const powershell = `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
       const {stdout} = await executeCommand(
-        `${powershell} -Command "& { (Get-ChildItem \\"${androidStudioPath}\\").VersionInfo.FileVersionRaw.ToString() }"`,
+        `wmic datafile where name="${androidStudioPath}" get Version`,
       );
       const version = stdout.replace(/(\r\n|\n|\r)/gm, '').trim();
 


### PR DESCRIPTION
Reverts react-native-community/cli#1515

@asklar is out for the year, so we will not see an immediate fix. Reverting for now.

The hardcoded Powershell path causes failures on several current versions of Windows. This ends up also breaking the PR pipeline for `react-native-windows` regardless of whether we update, since we run `react-native doctor` on newly created user apps which hit the issue.