### PR TITLE
feat: allow configurable js root for android

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -69,243 +69,243 @@ public class PackageList {
 """
 
 class ReactNativeModules {
-    private Logger logger
-    private String packageName
-    private File root
-    private ArrayList<HashMap<String, String>> reactNativeModules
-    private HashMap<String, ArrayList> reactNativeModulesBuildVariants
+  private Logger logger
+  private String packageName
+  private File root
+  private ArrayList<HashMap<String, String>> reactNativeModules
+  private HashMap<String, ArrayList> reactNativeModulesBuildVariants
 
-    private static String LOG_PREFIX = ":ReactNative:"
+  private static String LOG_PREFIX = ":ReactNative:"
 
-    ReactNativeModules(Logger logger, File root) {
-        this.logger = logger
-        this.root = root
+  ReactNativeModules(Logger logger, File root) {
+    this.logger = logger
+    this.root = root
 
-        logger.info "root: ${root.getPath()}"
+    logger.info "root: ${root.getPath()}"
 
-        def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
-        this.reactNativeModules = nativeModules
-        this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
-        this.packageName = packageName
+    def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
+    this.reactNativeModules = nativeModules
+    this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
+    this.packageName = packageName
+  }
+
+  /**
+   * Include the react native modules android projects and specify their project directory
+   */
+  void addReactNativeModuleProjects(DefaultSettings defaultSettings) {
+    reactNativeModules.forEach { reactNativeModule ->
+      String nameCleansed = reactNativeModule["nameCleansed"]
+      String androidSourceDir = reactNativeModule["androidSourceDir"]
+      defaultSettings.include(":${nameCleansed}")
+      defaultSettings.project(":${nameCleansed}").projectDir = new File("${androidSourceDir}")
     }
+  }
 
-    /**
-     * Include the react native modules android projects and specify their project directory
-     */
-    void addReactNativeModuleProjects(DefaultSettings defaultSettings) {
-        reactNativeModules.forEach { reactNativeModule ->
-            String nameCleansed = reactNativeModule["nameCleansed"]
-            String androidSourceDir = reactNativeModule["androidSourceDir"]
-            defaultSettings.include(":${nameCleansed}")
-            defaultSettings.project(":${nameCleansed}").projectDir = new File("${androidSourceDir}")
-        }
-    }
-
-    /**
-     * Adds the react native modules as dependencies to the users `app` project
-     */
-    void addReactNativeModuleDependencies(Project appProject) {
-        reactNativeModules.forEach { reactNativeModule ->
-            def nameCleansed = reactNativeModule["nameCleansed"]
-            def dependencyConfiguration = reactNativeModule["dependencyConfiguration"]
-            appProject.dependencies {
-                if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
-                    reactNativeModulesBuildVariants
-                            .get(nameCleansed)
-                            .forEach { buildVariant ->
-                                if (dependencyConfiguration != null) {
-                                    "${buildVariant}${dependencyConfiguration}"
-                                } else {
-                                    "${buildVariant}Implementation" project(path: ":${nameCleansed}")
-                                }
-                            }
-                } else {
-                    if (dependencyConfiguration != null) {
-                        "${dependencyConfiguration}"
-                    } else {
-                        implementation project(path: ":${nameCleansed}")
-                    }
-                }
+  /**
+   * Adds the react native modules as dependencies to the users `app` project
+   */
+  void addReactNativeModuleDependencies(Project appProject) {
+    reactNativeModules.forEach { reactNativeModule ->
+      def nameCleansed = reactNativeModule["nameCleansed"]
+      def dependencyConfiguration = reactNativeModule["dependencyConfiguration"]
+      appProject.dependencies {
+        if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
+          reactNativeModulesBuildVariants
+            .get(nameCleansed)
+            .forEach { buildVariant ->
+              if (dependencyConfiguration != null) {
+                "${buildVariant}${dependencyConfiguration}"
+              } else {
+                "${buildVariant}Implementation" project(path: ":${nameCleansed}")
+              }
             }
+        } else {
+          if (dependencyConfiguration != null) {
+            "${dependencyConfiguration}"
+          } else {
+            implementation project(path: ":${nameCleansed}")
+          }
         }
+      }
+    }
+  }
+
+  /**
+   * Code-gen a java file with all the detected ReactNativePackage instances automatically added
+   *
+   * @param outputDir
+   * @param generatedFileName
+   * @param generatedFileContentsTemplate
+   */
+  void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
+    ArrayList<HashMap<String, String>> packages = this.reactNativeModules
+    String packageName = this.packageName
+
+    String packageImports = ""
+    String packageClassInstances = ""
+
+    if (packages.size() > 0) {
+      def interpolateDynamicValues = {
+        it
+        // Before adding the package replacement mechanism,
+        // BuildConfig and R classes were imported automatically
+        // into the scope of the file. We want to replace all
+        // non-FQDN references to those classes with the package name
+        // of the MainApplication.
+        //
+        // We want to match "R" or "BuildConfig":
+        //  - new Package(R.string…),
+        //  - Module.configure(BuildConfig);
+        //    ^ hence including (BuildConfig|R)
+        // but we don't want to match "R":
+        //  - new Package(getResources…),
+        //  - new PackageR…,
+        //  - new Royal…,
+        //    ^ hence excluding \w before and after matches
+        // and "BuildConfig" that has FQDN reference:
+        //  - Module.configure(com.acme.BuildConfig);
+        //    ^ hence excluding . before the match.
+          .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
+            wholeString, prefix, className, suffix ->
+              "${prefix}${packageName}.${className}${suffix}"
+          })
+      }
+      packageImports = packages.collect {
+        "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
+      }.join('\n')
+      packageClassInstances = ",\n      " + packages.collect {
+        interpolateDynamicValues(it.packageInstance)
+      }.join(",\n      ")
     }
 
+    String generatedFileContents = generatedFileContentsTemplate
+      .replace("{{ packageImports }}", packageImports)
+      .replace("{{ packageClassInstances }}", packageClassInstances)
+
+    outputDir.mkdirs()
+    final FileTreeBuilder treeBuilder = new FileTreeBuilder(outputDir)
+    treeBuilder.file(generatedFileName).newWriter().withWriter { w ->
+      w << generatedFileContents
+    }
+  }
+
+  /**
+   * Runs a specified command using Runtime exec() in a specified directory.
+   * Throws when the command result is empty.
+   */
+  String getCommandOutput(String[] command, File directory) {
+    try {
+      def output = ""
+      def cmdProcess = Runtime.getRuntime().exec(command, null, directory)
+      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
+      def buff = ""
+      def readBuffer = new StringBuffer()
+      while ((buff = bufferedReader.readLine()) != null) {
+        readBuffer.append(buff)
+      }
+      output = readBuffer.toString()
+      if (!output) {
+        this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
+        def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
+        def errBuff = ""
+        def readErrorBuffer = new StringBuffer()
+        while ((errBuff = bufferedErrorReader.readLine()) != null) {
+          readErrorBuffer.append(errBuff)
+        }
+        throw new Exception(readErrorBuffer.toString())
+      }
+      return output
+    } catch (Exception exception) {
+      this.logger.error("${LOG_PREFIX}Running '${command}' command failed.")
+      throw exception
+    }
+  }
+
+  /**
+   * Runs a process to call the React Native CLI Config command and parses the output
+   */
+  ArrayList<HashMap<String, String>> getReactNativeConfig() {
+    if (this.reactNativeModules != null) return this.reactNativeModules
+
+    ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
+    HashMap<String, ArrayList> reactNativeModulesBuildVariants = new HashMap<String, ArrayList>()
+
     /**
-     * Code-gen a java file with all the detected ReactNativePackage instances automatically added
+     * Resolve the CLI location from Gradle file
      *
-     * @param outputDir
-     * @param generatedFileName
-     * @param generatedFileContentsTemplate
+     * @todo: Sometimes Gradle can be called outside of the JavaScript hierarchy (-p flag) which
+     * will fail to resolve the script and the dependencies. We should resolve this soon.
+     *
+     * @todo: `fastlane` has been reported to not work too.
      */
-    void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
-        ArrayList<HashMap<String, String>> packages = this.reactNativeModules
-        String packageName = this.packageName
+    def cliResolveScript = "console.log(require('react-native/cli').bin);"
+    String[] nodeCommand = ["node", "-e", cliResolveScript]
+    def cliPath = this.getCommandOutput(nodeCommand, this.root)
 
-        String packageImports = ""
-        String packageClassInstances = ""
+    String[] reactNativeConfigCommand = ["node", cliPath, "config"]
+    def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand, this.root)
 
-        if (packages.size() > 0) {
-            def interpolateDynamicValues = {
-                it
-                // Before adding the package replacement mechanism,
-                // BuildConfig and R classes were imported automatically
-                // into the scope of the file. We want to replace all
-                // non-FQDN references to those classes with the package name 
-                // of the MainApplication.
-                //
-                // We want to match "R" or "BuildConfig":
-                //  - new Package(R.string…),
-                //  - Module.configure(BuildConfig);
-                //    ^ hence including (BuildConfig|R)
-                // but we don't want to match "R":
-                //  - new Package(getResources…),
-                //  - new PackageR…,
-                //  - new Royal…,
-                //    ^ hence excluding \w before and after matches
-                // and "BuildConfig" that has FQDN reference:
-                //  - Module.configure(com.acme.BuildConfig);
-                //    ^ hence excluding . before the match.
-                        .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
-                            wholeString, prefix, className, suffix ->
-                                "${prefix}${packageName}.${className}${suffix}"
-                        })
-            }
-            packageImports = packages.collect {
-                "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
-            }.join('\n')
-            packageClassInstances = ",\n      " + packages.collect {
-                interpolateDynamicValues(it.packageInstance)
-            }.join(",\n      ")
-        }
+    def json
+    try {
+      json = new JsonSlurper().parseText(reactNativeConfigOutput)
+    } catch (Exception exception) {
+      throw new Exception("Calling `${reactNativeConfigCommand}` finished with an exception. Error message: ${exception.toString()}. Output: ${reactNativeConfigOutput}");
+    }
+    def dependencies = json["dependencies"]
+    def project = json["project"]["android"]
 
-        String generatedFileContents = generatedFileContentsTemplate
-                .replace("{{ packageImports }}", packageImports)
-                .replace("{{ packageClassInstances }}", packageClassInstances)
-
-        outputDir.mkdirs()
-        final FileTreeBuilder treeBuilder = new FileTreeBuilder(outputDir)
-        treeBuilder.file(generatedFileName).newWriter().withWriter { w ->
-            w << generatedFileContents
-        }
+    if (project == null) {
+      throw new Exception("React Native CLI failed to determine Android project configuration. This is likely due to misconfiguration. Config output:\n${json.toMapString()}")
     }
 
-    /**
-     * Runs a specified command using Runtime exec() in a specified directory.
-     * Throws when the command result is empty.
-     */
-    String getCommandOutput(String[] command, File directory) {
-        try {
-            def output = ""
-            def cmdProcess = Runtime.getRuntime().exec(command, null, directory)
-            def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
-            def buff = ""
-            def readBuffer = new StringBuffer()
-            while ((buff = bufferedReader.readLine()) != null) {
-                readBuffer.append(buff)
-            }
-            output = readBuffer.toString()
-            if (!output) {
-                this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
-                def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
-                def errBuff = ""
-                def readErrorBuffer = new StringBuffer()
-                while ((errBuff = bufferedErrorReader.readLine()) != null) {
-                    readErrorBuffer.append(errBuff)
-                }
-                throw new Exception(readErrorBuffer.toString())
-            }
-            return output
-        } catch (Exception exception) {
-            this.logger.error("${LOG_PREFIX}Running '${command}' command failed.")
-            throw exception
+    def engine = new groovy.text.SimpleTemplateEngine()
+
+    dependencies.each { name, value ->
+      def platformsConfig = value["platforms"];
+      def androidConfig = platformsConfig["android"]
+
+      if (androidConfig != null && androidConfig["sourceDir"] != null) {
+        this.logger.info("${LOG_PREFIX}Automatically adding native module '${name}'")
+
+        HashMap reactNativeModuleConfig = new HashMap<String, String>()
+        def nameCleansed = name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_')
+        reactNativeModuleConfig.put("name", name)
+        reactNativeModuleConfig.put("nameCleansed", nameCleansed)
+        reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
+        reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
+        reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
+        if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
+          reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
         }
+        if (androidConfig.containsKey("dependencyConfiguration")) {
+          reactNativeModuleConfig.put("dependencyConfiguration", androidConfig["dependencyConfiguration"])
+        } else if (project.containsKey("dependencyConfiguration")) {
+          def bindings = ["dependencyName": nameCleansed]
+          def template = engine.createTemplate(project["dependencyConfiguration"]).make(bindings)
+
+          reactNativeModuleConfig.put("dependencyConfiguration", template.toString())
+        }
+
+        this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
+
+        reactNativeModules.add(reactNativeModuleConfig)
+      } else {
+        this.logger.info("${LOG_PREFIX}Skipping native module '${name}'")
+      }
     }
 
-    /**
-     * Runs a process to call the React Native CLI Config command and parses the output
-     */
-    ArrayList<HashMap<String, String>> getReactNativeConfig() {
-        if (this.reactNativeModules != null) return this.reactNativeModules
-
-        ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
-        HashMap<String, ArrayList> reactNativeModulesBuildVariants = new HashMap<String, ArrayList>()
-
-        /**
-         * Resolve the CLI location from Gradle file
-         *
-         * @todo: Sometimes Gradle can be called outside of the JavaScript hierarchy (-p flag) which
-         * will fail to resolve the script and the dependencies. We should resolve this soon.
-         *
-         * @todo: `fastlane` has been reported to not work too.
-         */
-        def cliResolveScript = "console.log(require('react-native/cli').bin);"
-        String[] nodeCommand = ["node", "-e", cliResolveScript]
-        def cliPath = this.getCommandOutput(nodeCommand, this.root)
-
-        String[] reactNativeConfigCommand = ["node", cliPath, "config"]
-        def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand, this.root)
-
-        def json
-        try {
-            json = new JsonSlurper().parseText(reactNativeConfigOutput)
-        } catch (Exception exception) {
-            throw new Exception("Calling `${reactNativeConfigCommand}` finished with an exception. Error message: ${exception.toString()}. Output: ${reactNativeConfigOutput}");
-        }
-        def dependencies = json["dependencies"]
-        def project = json["project"]["android"]
-
-        if (project == null) {
-            throw new Exception("React Native CLI failed to determine Android project configuration. This is likely due to misconfiguration. Config output:\n${json.toMapString()}")
-        }
-
-        def engine = new groovy.text.SimpleTemplateEngine()
-
-        dependencies.each { name, value ->
-            def platformsConfig = value["platforms"];
-            def androidConfig = platformsConfig["android"]
-
-            if (androidConfig != null && androidConfig["sourceDir"] != null) {
-                this.logger.info("${LOG_PREFIX}Automatically adding native module '${name}'")
-
-                HashMap reactNativeModuleConfig = new HashMap<String, String>()
-                def nameCleansed = name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_')
-                reactNativeModuleConfig.put("name", name)
-                reactNativeModuleConfig.put("nameCleansed", nameCleansed)
-                reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
-                reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
-                reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
-                if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
-                    reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
-                }
-                if (androidConfig.containsKey("dependencyConfiguration")) {
-                    reactNativeModuleConfig.put("dependencyConfiguration", androidConfig["dependencyConfiguration"])
-                } else if (project.containsKey("dependencyConfiguration")) {
-                    def bindings = ["dependencyName": nameCleansed]
-                    def template = engine.createTemplate(project["dependencyConfiguration"]).make(bindings)
-
-                    reactNativeModuleConfig.put("dependencyConfiguration", template.toString())
-                }
-
-                this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
-
-                reactNativeModules.add(reactNativeModuleConfig)
-            } else {
-                this.logger.info("${LOG_PREFIX}Skipping native module '${name}'")
-            }
-        }
-
-        return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]["packageName"]];
-    }
+    return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]["packageName"]];
+  }
 }
 
 class ReactNativeExtension {
-    File root
-    Logger logger
+  File root
+  Logger logger
 
-    ReactNativeExtension(Logger defaultLogger, File defaultRoot) {
-        root = defaultRoot
-        logger = defaultLogger
-    }
+  ReactNativeExtension(Logger defaultLogger, File defaultRoot) {
+    root = defaultRoot
+    logger = defaultLogger
+  }
 }
 
 // Add new extensions via the extension container
@@ -316,40 +316,40 @@ extensions.create('reactNative', ReactNativeExtension, logger, rootProject.proje
  * ------------------------ */
 
 ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String root = null ->
-    if (root != null) {
-        logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now.");
-        logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesSettingsGradle`.");
-    }
-    def modules = new ReactNativeModules(logger, reactNative.root)
-    modules.addReactNativeModuleProjects(defaultSettings)
+  if (root != null) {
+    logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now.");
+    logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesSettingsGradle`.");
+  }
+  def modules = new ReactNativeModules(logger, reactNative.root)
+  modules.addReactNativeModuleProjects(defaultSettings)
 }
 
 ext.applyNativeModulesAppBuildGradle = { Project project, String root = null ->
-    if (root != null) {
-        logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now");
-        logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesAppBuildGradle`.");
+  if (root != null) {
+    logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now");
+    logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesAppBuildGradle`.");
+  }
+  def modules = new ReactNativeModules(logger, reactNative.root)
+  modules.addReactNativeModuleDependencies(project)
+
+  def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
+  def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))
+
+  task generatePackageList {
+    doLast {
+      modules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
     }
-    def modules = new ReactNativeModules(logger, reactNative.root)
-    modules.addReactNativeModuleDependencies(project)
+  }
 
-    def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
-    def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))
+  preBuild.dependsOn generatePackageList
 
-    task generatePackageList {
-        doLast {
-            modules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
+  android {
+    sourceSets {
+      main {
+        java {
+          srcDirs += generatedSrcDir
         }
+      }
     }
-
-    preBuild.dependsOn generatePackageList
-
-    android {
-        sourceSets {
-            main {
-                java {
-                    srcDirs += generatedSrcDir
-                }
-            }
-        }
-    }
+  }
 }

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -81,8 +81,6 @@ class ReactNativeModules {
     this.logger = logger
     this.root = root
 
-    logger.info "root: ${root.getPath()}"
-
     def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
     this.reactNativeModules = nativeModules
     this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
@@ -146,26 +144,25 @@ class ReactNativeModules {
 
     if (packages.size() > 0) {
       def interpolateDynamicValues = {
-        it
-        // Before adding the package replacement mechanism,
-        // BuildConfig and R classes were imported automatically
-        // into the scope of the file. We want to replace all
-        // non-FQDN references to those classes with the package name
-        // of the MainApplication.
-        //
-        // We want to match "R" or "BuildConfig":
-        //  - new Package(R.string…),
-        //  - Module.configure(BuildConfig);
-        //    ^ hence including (BuildConfig|R)
-        // but we don't want to match "R":
-        //  - new Package(getResources…),
-        //  - new PackageR…,
-        //  - new Royal…,
-        //    ^ hence excluding \w before and after matches
-        // and "BuildConfig" that has FQDN reference:
-        //  - Module.configure(com.acme.BuildConfig);
-        //    ^ hence excluding . before the match.
-          .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
+          // Before adding the package replacement mechanism,
+          // BuildConfig and R classes were imported automatically
+          // into the scope of the file. We want to replace all
+          // non-FQDN references to those classes with the package name
+          // of the MainApplication.
+          //
+          // We want to match "R" or "BuildConfig":
+          //  - new Package(R.string…),
+          //  - Module.configure(BuildConfig);
+          //    ^ hence including (BuildConfig|R)
+          // but we don't want to match "R":
+          //  - new Package(getResources…),
+          //  - new PackageR…,
+          //  - new Royal…,
+          //    ^ hence excluding \w before and after matches
+          // and "BuildConfig" that has FQDN reference:
+          //  - Module.configure(com.acme.BuildConfig);
+          //    ^ hence excluding . before the match.
+          it.replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
             wholeString, prefix, className, suffix ->
               "${prefix}${packageName}.${className}${suffix}"
           })

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -69,82 +69,84 @@ public class PackageList {
 """
 
 class ReactNativeModules {
-  private Logger logger
-  private String packageName
-  private File root
-  private ArrayList<HashMap<String, String>> reactNativeModules
-  private HashMap<String, ArrayList> reactNativeModulesBuildVariants
+    private Logger logger
+    private String packageName
+    private File root
+    private ArrayList<HashMap<String, String>> reactNativeModules
+    private HashMap<String, ArrayList> reactNativeModulesBuildVariants
 
-  private static String LOG_PREFIX = ":ReactNative:"
+    private static String LOG_PREFIX = ":ReactNative:"
 
-  ReactNativeModules(Logger logger, File root) {
-    this.logger = logger
-    this.root = root
+    ReactNativeModules(Logger logger, File root) {
+        this.logger = logger
+        this.root = root
 
-    def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
-    this.reactNativeModules = nativeModules
-    this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
-    this.packageName = packageName
-  }
+        logger.info "root: ${root.getPath()}"
 
-  /**
-   * Include the react native modules android projects and specify their project directory
-   */
-  void addReactNativeModuleProjects(DefaultSettings defaultSettings) {
-    reactNativeModules.forEach { reactNativeModule ->
-      String nameCleansed = reactNativeModule["nameCleansed"]
-      String androidSourceDir = reactNativeModule["androidSourceDir"]
-      defaultSettings.include(":${nameCleansed}")
-      defaultSettings.project(":${nameCleansed}").projectDir = new File("${androidSourceDir}")
+        def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
+        this.reactNativeModules = nativeModules
+        this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
+        this.packageName = packageName
     }
-  }
 
-  /**
-   * Adds the react native modules as dependencies to the users `app` project
-   */
-  void addReactNativeModuleDependencies(Project appProject) {
-    reactNativeModules.forEach { reactNativeModule ->
-      def nameCleansed = reactNativeModule["nameCleansed"]
-      def dependencyConfiguration = reactNativeModule["dependencyConfiguration"]
-      appProject.dependencies {
-        if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
-          reactNativeModulesBuildVariants
-            .get(nameCleansed)
-            .forEach { buildVariant -> 
-              if(dependencyConfiguration != null) {
-                "${buildVariant}${dependencyConfiguration}"
-              } else {
-                "${buildVariant}Implementation" project(path: ":${nameCleansed}")
-              }
-            }
-        } else {
-          if(dependencyConfiguration != null) {
-            "${dependencyConfiguration}"
-          } else {
-             implementation project(path: ":${nameCleansed}")
-          }
+    /**
+     * Include the react native modules android projects and specify their project directory
+     */
+    void addReactNativeModuleProjects(DefaultSettings defaultSettings) {
+        reactNativeModules.forEach { reactNativeModule ->
+            String nameCleansed = reactNativeModule["nameCleansed"]
+            String androidSourceDir = reactNativeModule["androidSourceDir"]
+            defaultSettings.include(":${nameCleansed}")
+            defaultSettings.project(":${nameCleansed}").projectDir = new File("${androidSourceDir}")
         }
-      }
     }
-  }
 
-  /**
-   * Code-gen a java file with all the detected ReactNativePackage instances automatically added
-   *
-   * @param outputDir
-   * @param generatedFileName
-   * @param generatedFileContentsTemplate
-   */
-  void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
-    ArrayList<HashMap<String, String>> packages = this.reactNativeModules
-    String packageName = this.packageName
+    /**
+     * Adds the react native modules as dependencies to the users `app` project
+     */
+    void addReactNativeModuleDependencies(Project appProject) {
+        reactNativeModules.forEach { reactNativeModule ->
+            def nameCleansed = reactNativeModule["nameCleansed"]
+            def dependencyConfiguration = reactNativeModule["dependencyConfiguration"]
+            appProject.dependencies {
+                if (reactNativeModulesBuildVariants.containsKey(nameCleansed)) {
+                    reactNativeModulesBuildVariants
+                            .get(nameCleansed)
+                            .forEach { buildVariant ->
+                                if (dependencyConfiguration != null) {
+                                    "${buildVariant}${dependencyConfiguration}"
+                                } else {
+                                    "${buildVariant}Implementation" project(path: ":${nameCleansed}")
+                                }
+                            }
+                } else {
+                    if (dependencyConfiguration != null) {
+                        "${dependencyConfiguration}"
+                    } else {
+                        implementation project(path: ":${nameCleansed}")
+                    }
+                }
+            }
+        }
+    }
 
-    String packageImports = ""
-    String packageClassInstances = ""
+    /**
+     * Code-gen a java file with all the detected ReactNativePackage instances automatically added
+     *
+     * @param outputDir
+     * @param generatedFileName
+     * @param generatedFileContentsTemplate
+     */
+    void generatePackagesFile(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
+        ArrayList<HashMap<String, String>> packages = this.reactNativeModules
+        String packageName = this.packageName
 
-    if (packages.size() > 0) {
-      def interpolateDynamicValues = {
-        it
+        String packageImports = ""
+        String packageClassInstances = ""
+
+        if (packages.size() > 0) {
+            def interpolateDynamicValues = {
+                it
                 // Before adding the package replacement mechanism,
                 // BuildConfig and R classes were imported automatically
                 // into the scope of the file. We want to replace all
@@ -163,185 +165,191 @@ class ReactNativeModules {
                 // and "BuildConfig" that has FQDN reference:
                 //  - Module.configure(com.acme.BuildConfig);
                 //    ^ hence excluding . before the match.
-                .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
-                  wholeString, prefix, className, suffix ->
-                    "${prefix}${packageName}.${className}${suffix}"
-                })
-      }
-      packageImports = packages.collect {
-        "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
-      }.join('\n')
-      packageClassInstances = ",\n      " + packages.collect {
-        interpolateDynamicValues(it.packageInstance)
-      }.join(",\n      ")
-    }
-
-    String generatedFileContents = generatedFileContentsTemplate
-      .replace("{{ packageImports }}", packageImports)
-      .replace("{{ packageClassInstances }}", packageClassInstances)
-
-    outputDir.mkdirs()
-    final FileTreeBuilder treeBuilder = new FileTreeBuilder(outputDir)
-    treeBuilder.file(generatedFileName).newWriter().withWriter { w ->
-      w << generatedFileContents
-    }
-  }
-
-  /**
-   * Runs a specified command using Runtime exec() in a specified directory.
-   * Throws when the command result is empty.
-   */
-  String getCommandOutput(String[] command, File directory) {
-    try {
-      def output = ""
-      def cmdProcess = Runtime.getRuntime().exec(command, null, directory)
-      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
-      def buff = ""
-      def readBuffer = new StringBuffer()
-      while ((buff = bufferedReader.readLine()) != null) {
-        readBuffer.append(buff)
-      }
-      output = readBuffer.toString()
-      if (!output) {
-        this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
-        def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
-        def errBuff = ""
-        def readErrorBuffer = new StringBuffer()
-        while ((errBuff = bufferedErrorReader.readLine()) != null) {
-          readErrorBuffer.append(errBuff)
+                        .replaceAll(~/([^.\w])(BuildConfig|R)([^\w])/, {
+                            wholeString, prefix, className, suffix ->
+                                "${prefix}${packageName}.${className}${suffix}"
+                        })
+            }
+            packageImports = packages.collect {
+                "// ${it.name}\n${interpolateDynamicValues(it.packageImportPath)}"
+            }.join('\n')
+            packageClassInstances = ",\n      " + packages.collect {
+                interpolateDynamicValues(it.packageInstance)
+            }.join(",\n      ")
         }
-        throw new Exception(readErrorBuffer.toString())
-      }
-      return output
-    } catch (Exception exception) {
-      this.logger.error("${LOG_PREFIX}Running '${command}' command failed.")
-      throw exception
+
+        String generatedFileContents = generatedFileContentsTemplate
+                .replace("{{ packageImports }}", packageImports)
+                .replace("{{ packageClassInstances }}", packageClassInstances)
+
+        outputDir.mkdirs()
+        final FileTreeBuilder treeBuilder = new FileTreeBuilder(outputDir)
+        treeBuilder.file(generatedFileName).newWriter().withWriter { w ->
+            w << generatedFileContents
+        }
     }
-  }
 
-  /**
-   * Runs a process to call the React Native CLI Config command and parses the output
-   */
-  ArrayList<HashMap<String, String>> getReactNativeConfig() {
-    if (this.reactNativeModules != null) return this.reactNativeModules
-
-    ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
-    HashMap<String, ArrayList> reactNativeModulesBuildVariants = new HashMap<String, ArrayList>()
-    
     /**
-     * Resolve the CLI location from Gradle file
-     *
-     * @todo: Sometimes Gradle can be called outside of the JavaScript hierarchy (-p flag) which
-     * will fail to resolve the script and the dependencies. We should resolve this soon.
-     *
-     * @todo: `fastlane` has been reported to not work too.
+     * Runs a specified command using Runtime exec() in a specified directory.
+     * Throws when the command result is empty.
      */
-    def cliResolveScript = "console.log(require('react-native/cli').bin);"
-    String[] nodeCommand = ["node", "-e", cliResolveScript]
-    def cliPath = this.getCommandOutput(nodeCommand, this.root)
-
-    String[] reactNativeConfigCommand = ["node", cliPath, "config"]
-    def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand, this.root)
-
-    def json
-    try {
-      json = new JsonSlurper().parseText(reactNativeConfigOutput)
-    } catch (Exception exception) {
-      throw new Exception("Calling `${reactNativeConfigCommand}` finished with an exception. Error message: ${exception.toString()}. Output: ${reactNativeConfigOutput}");
-    }
-    def dependencies = json["dependencies"]
-    def project = json["project"]["android"]
-
-    if (project == null) {
-      throw new Exception("React Native CLI failed to determine Android project configuration. This is likely due to misconfiguration. Config output:\n${json.toMapString()}")
-    }
-
-    def engine = new groovy.text.SimpleTemplateEngine()
-
-    dependencies.each { name, value ->
-      def platformsConfig = value["platforms"];
-      def androidConfig = platformsConfig["android"]
-
-      if (androidConfig != null && androidConfig["sourceDir"] != null) {
-        this.logger.info("${LOG_PREFIX}Automatically adding native module '${name}'")
-        
-        HashMap reactNativeModuleConfig = new HashMap<String, String>()
-        def nameCleansed = name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_')
-        reactNativeModuleConfig.put("name", name)
-        reactNativeModuleConfig.put("nameCleansed", nameCleansed)
-        reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
-        reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
-        reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
-        if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
-          reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
+    String getCommandOutput(String[] command, File directory) {
+        try {
+            def output = ""
+            def cmdProcess = Runtime.getRuntime().exec(command, null, directory)
+            def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
+            def buff = ""
+            def readBuffer = new StringBuffer()
+            while ((buff = bufferedReader.readLine()) != null) {
+                readBuffer.append(buff)
+            }
+            output = readBuffer.toString()
+            if (!output) {
+                this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
+                def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
+                def errBuff = ""
+                def readErrorBuffer = new StringBuffer()
+                while ((errBuff = bufferedErrorReader.readLine()) != null) {
+                    readErrorBuffer.append(errBuff)
+                }
+                throw new Exception(readErrorBuffer.toString())
+            }
+            return output
+        } catch (Exception exception) {
+            this.logger.error("${LOG_PREFIX}Running '${command}' command failed.")
+            throw exception
         }
-        if(androidConfig.containsKey("dependencyConfiguration")) {
-          reactNativeModuleConfig.put("dependencyConfiguration", androidConfig["dependencyConfiguration"])
-        } else if (project.containsKey("dependencyConfiguration")) {
-          def bindings = ["dependencyName": nameCleansed]
-          def template = engine.createTemplate(project["dependencyConfiguration"]).make(bindings)
-
-          reactNativeModuleConfig.put("dependencyConfiguration", template.toString())
-        }
-
-        this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
-        
-        reactNativeModules.add(reactNativeModuleConfig)
-      } else {
-        this.logger.info("${LOG_PREFIX}Skipping native module '${name}'")
-      }
     }
 
-    return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]["packageName"]];
-  }
+    /**
+     * Runs a process to call the React Native CLI Config command and parses the output
+     */
+    ArrayList<HashMap<String, String>> getReactNativeConfig() {
+        if (this.reactNativeModules != null) return this.reactNativeModules
+
+        ArrayList<HashMap<String, String>> reactNativeModules = new ArrayList<HashMap<String, String>>()
+        HashMap<String, ArrayList> reactNativeModulesBuildVariants = new HashMap<String, ArrayList>()
+
+        /**
+         * Resolve the CLI location from Gradle file
+         *
+         * @todo: Sometimes Gradle can be called outside of the JavaScript hierarchy (-p flag) which
+         * will fail to resolve the script and the dependencies. We should resolve this soon.
+         *
+         * @todo: `fastlane` has been reported to not work too.
+         */
+        def cliResolveScript = "console.log(require('react-native/cli').bin);"
+        String[] nodeCommand = ["node", "-e", cliResolveScript]
+        def cliPath = this.getCommandOutput(nodeCommand, this.root)
+
+        String[] reactNativeConfigCommand = ["node", cliPath, "config"]
+        def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand, this.root)
+
+        def json
+        try {
+            json = new JsonSlurper().parseText(reactNativeConfigOutput)
+        } catch (Exception exception) {
+            throw new Exception("Calling `${reactNativeConfigCommand}` finished with an exception. Error message: ${exception.toString()}. Output: ${reactNativeConfigOutput}");
+        }
+        def dependencies = json["dependencies"]
+        def project = json["project"]["android"]
+
+        if (project == null) {
+            throw new Exception("React Native CLI failed to determine Android project configuration. This is likely due to misconfiguration. Config output:\n${json.toMapString()}")
+        }
+
+        def engine = new groovy.text.SimpleTemplateEngine()
+
+        dependencies.each { name, value ->
+            def platformsConfig = value["platforms"];
+            def androidConfig = platformsConfig["android"]
+
+            if (androidConfig != null && androidConfig["sourceDir"] != null) {
+                this.logger.info("${LOG_PREFIX}Automatically adding native module '${name}'")
+
+                HashMap reactNativeModuleConfig = new HashMap<String, String>()
+                def nameCleansed = name.replaceAll('[~*!\'()]+', '_').replaceAll('^@([\\w-.]+)/', '$1_')
+                reactNativeModuleConfig.put("name", name)
+                reactNativeModuleConfig.put("nameCleansed", nameCleansed)
+                reactNativeModuleConfig.put("androidSourceDir", androidConfig["sourceDir"])
+                reactNativeModuleConfig.put("packageInstance", androidConfig["packageInstance"])
+                reactNativeModuleConfig.put("packageImportPath", androidConfig["packageImportPath"])
+                if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
+                    reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])
+                }
+                if (androidConfig.containsKey("dependencyConfiguration")) {
+                    reactNativeModuleConfig.put("dependencyConfiguration", androidConfig["dependencyConfiguration"])
+                } else if (project.containsKey("dependencyConfiguration")) {
+                    def bindings = ["dependencyName": nameCleansed]
+                    def template = engine.createTemplate(project["dependencyConfiguration"]).make(bindings)
+
+                    reactNativeModuleConfig.put("dependencyConfiguration", template.toString())
+                }
+
+                this.logger.trace("${LOG_PREFIX}'${name}': ${reactNativeModuleConfig.toMapString()}")
+
+                reactNativeModules.add(reactNativeModuleConfig)
+            } else {
+                this.logger.info("${LOG_PREFIX}Skipping native module '${name}'")
+            }
+        }
+
+        return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]["packageName"]];
+    }
 }
 
+class ReactNativeExtension {
+    File root
+    Logger logger
 
-/*
- * Sometimes Gradle can be called outside of JavaScript hierarchy. Detect the directory
- * where build files of an active project are located.
- */
-def projectRoot = rootProject.projectDir
+    ReactNativeExtension(Logger defaultLogger, File defaultRoot) {
+        root = defaultRoot
+        logger = defaultLogger
+    }
+}
 
-def autoModules = new ReactNativeModules(logger, projectRoot)
+// Add new extensions via the extension container
+extensions.create('reactNative', ReactNativeExtension, logger, rootProject.projectDir)
 
 /** -----------------------
  *    Exported Extensions
  * ------------------------ */
 
 ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String root = null ->
-  if (root != null) {
-    logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now.");
-    logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesSettingsGradle`.");
-  }
-  autoModules.addReactNativeModuleProjects(defaultSettings)
+    if (root != null) {
+        logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now.");
+        logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesSettingsGradle`.");
+    }
+    def modules = new ReactNativeModules(logger, reactNative.root)
+    modules.addReactNativeModuleProjects(defaultSettings)
 }
 
 ext.applyNativeModulesAppBuildGradle = { Project project, String root = null ->
-  if (root != null) {
-    logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now");
-    logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesAppBuildGradle`.");
-  }
-  autoModules.addReactNativeModuleDependencies(project)
-
-  def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
-  def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))
-
-  task generatePackageList {
-    doLast {
-      autoModules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
+    if (root != null) {
+        logger.warn("${ReactNativeModules.LOG_PREFIX}Passing custom root is deprecated. CLI detects root automatically now");
+        logger.warn("${ReactNativeModules.LOG_PREFIX}Please remove second argument to `applyNativeModulesAppBuildGradle`.");
     }
-  }
+    def modules = new ReactNativeModules(logger, reactNative.root)
+    modules.addReactNativeModuleDependencies(project)
 
-  preBuild.dependsOn generatePackageList
+    def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
+    def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))
 
-  android {
-    sourceSets {
-      main {
-        java {
-          srcDirs += generatedSrcDir
+    task generatePackageList {
+        doLast {
+            modules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
         }
-      }
     }
-  }
+
+    preBuild.dependsOn generatePackageList
+
+    android {
+        sourceSets {
+            main {
+                java {
+                    srcDirs += generatedSrcDir
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Summary:
---------

Currently, it is impossible to set up a React Native project where the Android project folder is not nested inside of the JavaScript project folder. I want to set up my project so that the two are side-by-side, like this:

```
android <-- Android project goes here
ios
shared/react <-- JavaScript project goes here
shared/rust
```

To accomplish this, I created a `reactNative` Gradle extension, so that the end user can configure the location of their JS project like this:

```gradle
apply from: file("../../shared/react/node_modules/@react-native-community/cli-platform-android/native_modules.gradle");

reactNative {
    root = file "../../shared/react"
}

applyNativeModulesAppBuildGradle(project)
```

Test Plan:
----------
In order to get this to work, I modified `native_modules.gradle` as seen in this PR, then I made a symlink from `shared/react/android` to the `android` directory so that the RN CLI would detect the configuration properly when queried. I'm not sure how I would write unit tests for something like this, but it works for me.
