### PR TITLE
add flow-bin for template

### DIFF
--- a/packages/cli/src/commands/init/initCompat.ts
+++ b/packages/cli/src/commands/init/initCompat.ts
@@ -74,6 +74,7 @@ async function generateProject(
       '@babel/runtime',
       '@react-native-community/eslint-config',
       'eslint',
+      'flow-bin',
       'jest',
       'babel-jest',
       'metro-react-native-babel-preset',


### PR DESCRIPTION
Summary:
---------
Closes #1518. Add flow-bin as a template dependency when `init`ing project. When copying the react-native template by default it's built in flowtype but because of missing deps it's not a seamless experience
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Build and run init project locally, see that flow-bin is installed and `yarn flow` works out of the box
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
