### PR TITLE
Fix metro crash when Flipper connects

### DIFF
--- a/packages/cli-server-api/src/websocket/eventsSocketServer.ts
+++ b/packages/cli-server-api/src/websocket/eventsSocketServer.ts
@@ -125,9 +125,10 @@ function attachToServer(
     verifyClient({origin}: {origin: string}) {
       // This exposes the full JS logs and enables issuing commands like reload
       // so let's make sure only locally running stuff can connect to it
-      return (
-        origin.startsWith('http://localhost:') || origin.startsWith('file:')
-      );
+      // origin is only checked if it is set, e.g. when the request is made from a (CORS) browser
+      // any 'back-end' connection isn't CORS at all, and has full control over the origin header,
+      // so there is no point in checking it security wise
+      return !origin || origin.startsWith('http://localhost:') || origin.startsWith('file:');
     },
   });
 

--- a/packages/cli-server-api/src/websocket/eventsSocketServer.ts
+++ b/packages/cli-server-api/src/websocket/eventsSocketServer.ts
@@ -128,7 +128,11 @@ function attachToServer(
       // origin is only checked if it is set, e.g. when the request is made from a (CORS) browser
       // any 'back-end' connection isn't CORS at all, and has full control over the origin header,
       // so there is no point in checking it security wise
-      return !origin || origin.startsWith('http://localhost:') || origin.startsWith('file:');
+      return (
+        !origin ||
+        origin.startsWith('http://localhost:') ||
+        origin.startsWith('file:')
+      );
     },
   });
 


### PR DESCRIPTION
Summary:
---------

Fixes per work around: https://github.com/facebook/flipper/issues/3189#issuecomment-997191720. The same fix has been applied to FB infra, and the next release will temporarily set an `origin` header as work around for existing RN versions. 

Fixes:
* https://github.com/facebook/flipper/issues/2870
* https://github.com/facebook/flipper/issues/3189

The essence of the fix is that we shouldn't check the `origin` header if it is not present. That might sound unsafe, but it actually is just a check to protect from malicious websites, and browsers ensure the origin header is set for cross site requests. For websocket connections created outside a browser context, the creator has full control over the origin header anyway, so checking it would not add any safety.

Test Plan:
----------

Before, metro quits as soon as Flipper 0.125 / 0.126 connects:

<img width="1463" alt="Screenshot 2021-12-22 at 11 40 28" src="https://user-images.githubusercontent.com/1820292/147081227-31aa829a-36c2-4695-a38d-a10542931197.png">

After, with manually applying the patch per linked comment above, no crash:
<img width="1127" alt="Screenshot 2021-12-22 at 11 42 25" src="https://user-images.githubusercontent.com/1820292/147081326-0c6f41cf-677d-4986-94c7-521e65b1537d.png">

N.B.: code formatter will probably fail, will push another commit once CI fails

