### PR TITLE
fix: use xctrace instead of instruments

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -97,7 +97,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
       'Support for Xcode 11 and older is deprecated. Please upgrade to Xcode 12.',
     );
     devices = parseIOSDevicesList(
-      execa.sync('xcrun', ['instruments', '-s']).stdout,
+      execa.sync('xcrun', ['xctrace', 'list', 'devices']).stdout,
     );
   }
 
@@ -584,8 +584,7 @@ export default {
     },
     {
       desc: 'Run on the AppleTV simulator',
-      cmd:
-        'react-native run-ios --simulator "Apple TV"  --scheme "helloworld-tvOS"',
+      cmd: 'react-native run-ios --simulator "Apple TV"  --scheme "helloworld-tvOS"',
     },
   ],
   options: [

--- a/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
+++ b/packages/platform-ios/src/commands/runIOS/parseIOSDevicesList.ts
@@ -23,21 +23,28 @@ import {Device} from '../../types';
  */
 function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];
+  let isSimulator = false;
 
   text.split('\n').forEach((line) => {
-    const device = line.match(
-      /(.*?) (\(([0-9.]+)\) )?\[([0-9A-F-]+)\]( \(Simulator\))?/i,
-    );
-    if (device) {
-      const [, name, , version, udid, isSimulator] = device;
-      const metadata: Device = {name, udid};
-      if (version) {
-        metadata.version = version;
-        metadata.type = isSimulator ? 'simulator' : 'device';
-      } else {
-        metadata.type = 'catalyst';
+    if (line.indexOf('== Simulators ==') !== -1) {
+      isSimulator = true;
+    }
+
+    if (!isSimulator) {
+      const device = line.match(
+        /(.*?) (\(([0-9.]+)\) )?\[([0-9A-F-]+)\]( \(Simulator\))?/i,
+      );
+      if (device) {
+        const [, name, , version, udid, isSimulator] = device;
+        const metadata: Device = {name, udid};
+        if (version) {
+          metadata.version = version;
+          metadata.type = isSimulator ? 'simulator' : 'device';
+        } else {
+          metadata.type = 'catalyst';
+        }
+        devices.push(metadata);
       }
-      devices.push(metadata);
     }
   });
 


### PR DESCRIPTION
Summary:
---------

This PR is replacing deprecated `instruments` with recommended `xctrace` to support run on device in Xcode 13.
