### PR TITLE
Android native_modules.gradle cliResolveScript should resolve to @react-native-community/cli

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -236,7 +236,7 @@ class ReactNativeModules {
      *
      * @todo: `fastlane` has been reported to not work too.
      */
-    def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
+    def cliResolveScript = "try {console.log(require('@react-native-community/cli').bin);} catch (e) {console.log(require('react-native/cli').bin);}"
     String[] nodeCommand = ["node", "-e", cliResolveScript]
     def cliPath = this.getCommandOutput(nodeCommand, this.root)
 

--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -236,7 +236,7 @@ class ReactNativeModules {
      *
      * @todo: `fastlane` has been reported to not work too.
      */
-    def cliResolveScript = "console.log(require('react-native/cli').bin);"
+    def cliResolveScript = "console.log(require('@react-native-community/cli').bin);"
     String[] nodeCommand = ["node", "-e", cliResolveScript]
     def cliPath = this.getCommandOutput(nodeCommand, this.root)
 


### PR DESCRIPTION
Summary:
---------

Android native_modules.gradle does not correctly get the app configuration. The cliResolveScript does not match the iOS version, and it only resolves to react-native/cli instead of @react-native-community/cli if avaiable

Test Plan:
----------
Green CI.
