### PR TITLE
Postinit script loader

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -91,4 +91,21 @@ module.exports = {
 };
 ```
 
+## Breaking change >6.3.1
+Now the responsibility of showing the user progress of the "Executing post init script" goes to the implementor. In the cli, the `ora` package is used to display progress. 
+For a simple usage in a custom template, `ora` can be used like this in a postInitScript :
+
+```javascript
+#!/usr/bin/env node
+const ora = require('ora');
+
+new Promise((resolve) => {
+  const spinner = ora('Executing post init script ').start();
+  // do something
+  resolve();
+}).then(() => {
+  spinner.succeed();
+});
+```
+
 You can find example custom template [here](https://github.com/Esemesek/react-native-new-template).

--- a/docs/init.md
+++ b/docs/init.md
@@ -99,12 +99,17 @@ For a simple usage in a custom template, `ora` can be used like this in a postIn
 #!/usr/bin/env node
 const ora = require('ora');
 
+const spinner = ora('Executing post init script ');
+
 new Promise((resolve) => {
-  const spinner = ora('Executing post init script ').start();
+  spinner.start();
   // do something
   resolve();
 }).then(() => {
   spinner.succeed();
+}).catch(() => {
+  spinner.fail();
+  throw new Error('Something went wrong during the post init script execution');
 });
 ```
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -91,7 +91,7 @@ module.exports = {
 };
 ```
 
-## 6.3.1
+## Post init script loading
 The responsibility of showing the user progress of the "Executing post init script" goes to the implementor. In the cli, the `ora` package is used to display progress. 
 For a simple usage in a custom template, `ora` can be used like this in a postInitScript :
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -91,8 +91,8 @@ module.exports = {
 };
 ```
 
-## Breaking change >6.3.1
-Now the responsibility of showing the user progress of the "Executing post init script" goes to the implementor. In the cli, the `ora` package is used to display progress. 
+## 6.3.1
+The responsibility of showing the user progress of the "Executing post init script" goes to the implementor. In the cli, the `ora` package is used to display progress. 
 For a simple usage in a custom template, `ora` can be used like this in a postInitScript :
 
 ```javascript

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -120,6 +120,7 @@ async function createFromTemplate({
     loader.succeed();
     const {postInitScript} = templateConfig;
     if (postInitScript) {
+      loader.info('Executing post init script ');
       await executePostInitScript(
         templateName,
         postInitScript,

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -121,13 +121,11 @@ async function createFromTemplate({
     const {postInitScript} = templateConfig;
     if (postInitScript) {
       // Leaving trailing space because there may be stdout from the script
-      loader.start('Executing post init script ');
       await executePostInitScript(
         templateName,
         postInitScript,
         templateSourceDir,
       );
-      loader.succeed();
     }
 
     if (!skipInstall) {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -120,7 +120,6 @@ async function createFromTemplate({
     loader.succeed();
     const {postInitScript} = templateConfig;
     if (postInitScript) {
-      // Leaving trailing space because there may be stdout from the script
       await executePostInitScript(
         templateName,
         postInitScript,


### PR DESCRIPTION
Summary:
---------

Related to #1492.
The idea is to remove the `ora` loader from the core of the cli to give this responsibility to the implementor. 
That way, template creator can be more creative like prompting questions to user for better experience. 
Before this, it was difficult because `ora` keeps refreshing the last line of terminal and so the prompted question.

Test Plan:
----------

I don't find any resources on how to test the init command locally. I tried to install globally the forked cli but it fails. 
Btw, I just remove the `ora` loader only for the post init script and do not add code to the base code so it's really simple and seems to work without extra testing.
But, if you tell me how to do that I'll be happy to test it !

