### PR TITLE
Add bundle and ruby-version to the underscored files

### DIFF
--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -76,6 +76,8 @@ const UNDERSCORED_DOTFILES = [
   'prettierrc.js',
   'watchmanconfig',
   'editorconfig',
+  'bundle',
+  'ruby-version',
 ];
 
 async function processDotfiles(filePath: string) {

--- a/packages/cli/src/tools/generator/copyProjectTemplateAndReplace.ts
+++ b/packages/cli/src/tools/generator/copyProjectTemplateAndReplace.ts
@@ -146,6 +146,8 @@ function translateFilePath(filePath: string) {
     .replace('_flowconfig', '.flowconfig')
     .replace('_buckconfig', '.buckconfig')
     .replace('_prettierrc.js', '.prettierrc.js')
+    .replace('_bundle', '.bundle')
+    .replace('_ruby-version', '.ruby-version')
     .replace('_watchmanconfig', '.watchmanconfig');
 }
 


### PR DESCRIPTION
Summary:
---------

While working with RN 0.67, I've just noticed that we have two `_` prefixed files in a newly generate project from the template with the `yarn react-native init ...` command.

That's how a `ls -la` on a new template looks like:

```
-rw-r--r--    1 ncor  staff     114 Jan 20 12:20 .buckconfig
-rw-r--r--    1 ncor  staff      74 Jan 20 12:20 .eslintrc.js
-rw-r--r--    1 ncor  staff    1410 Jan 20 12:20 .flowconfig
-rw-r--r--    1 ncor  staff     821 Jan 20 12:20 .gitignore
-rw-r--r--    1 ncor  staff     144 Jan 20 12:20 .prettierrc.js
-rw-r--r--    1 ncor  staff       2 Jan 20 12:20 .watchmanconfig
-rw-r--r--    1 ncor  staff    2465 Jan 20 12:20 App.js
-rw-r--r--    1 ncor  staff     168 Jan 20 12:20 Gemfile
-rw-r--r--    1 ncor  staff    2413 Jan 20 12:20 Gemfile.lock
drwxr-xr-x    3 ncor  staff      96 Jan 20 12:20 __tests__
drwxr-xr-x    3 ncor  staff      96 Jan 20 12:26 _bundle
-rw-r--r--    1 ncor  staff       6 Jan 20 12:20 _ruby-version
drwxr-xr-x    9 ncor  staff     288 Jan 20 12:20 android
-rw-r--r--    1 ncor  staff      53 Jan 20 12:20 app.json
-rw-r--r--    1 ncor  staff      77 Jan 20 12:20 babel.config.js
-rw-r--r--    1 ncor  staff     183 Jan 20 12:20 index.js
drwxr-xr-x    9 ncor  staff     288 Jan 20 12:22 ios
-rw-r--r--    1 ncor  staff     299 Jan 20 12:20 metro.config.js
drwxr-xr-x  620 ncor  staff   19840 Jan 20 12:21 node_modules
-rw-r--r--    1 ncor  staff     673 Jan 20 12:20 package.json
-rw-r--r--    1 ncor  staff  294134 Jan 20 12:21 yarn.lock
```

The `_bundle` folder and the `_ruby-version` file should be dot files instead. This PR attemptes to fix this.

cc @kelset 

Test Plan:
----------

I'm unsure how am I supposed to test this. Is the CI result sufficient or should I create a local version of the CLI and testing on my machine?