### PR TITLE
feat: add --hermes flag for enable hermes while init project

### DIFF
--- a/packages/cli/src/commands/init/enableHermes.ts
+++ b/packages/cli/src/commands/init/enableHermes.ts
@@ -1,0 +1,35 @@
+import path from 'path';
+import {logger} from '@react-native-community/cli-tools';
+import fs from 'fs-extra';
+
+function enableHermesAndroid() {
+  const podFilePath = path.resolve(
+    process.cwd(),
+    'android',
+    'app',
+    'build.gradle',
+  );
+  const gradleAppFile = fs.readFileSync(podFilePath, 'utf8');
+  const enabledHermesGradleAppFile = gradleAppFile.replace(
+    /enableHermes:\s+(false|true)/,
+    'enableHermes: true',
+  );
+  fs.writeFileSync(podFilePath, enabledHermesGradleAppFile);
+  logger.debug(`Enabing hermes for Android in ${podFilePath}`);
+}
+
+function enableHermesIOS() {
+  const podFilePath = path.resolve(process.cwd(), 'ios', 'Podfile');
+  const podFile = fs.readFileSync(podFilePath, 'utf8');
+  const enabledHermesPodFile = podFile.replace(
+    /hermes_enabled\s+=>\s+(false|true)/,
+    'hermes_enabled => true',
+  );
+  fs.writeFileSync(podFilePath, enabledHermesPodFile);
+  logger.debug(`Enabing hermes for Ios in ${podFilePath}`);
+}
+
+export async function enableHermes() {
+  enableHermesIOS();
+  enableHermesAndroid();
+}

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -32,5 +32,9 @@ export default {
       name: '--skip-install',
       description: 'Skips dependencies installation step',
     },
+    {
+      name: '--hermes',
+      description: 'enable hermes engine',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -18,6 +18,7 @@ import {
   executePostInitScript,
 } from './template';
 import {changePlaceholderInTemplate} from './editTemplate';
+import {enableHermes} from './enableHermes';
 import * as PackageManager from '../../tools/packageManager';
 import {installPods} from '@react-native-community/cli-doctor';
 import banner from './banner';
@@ -31,6 +32,7 @@ type Options = {
   displayName?: string;
   title?: string;
   skipInstall?: boolean;
+  hermes?: boolean;
 };
 
 interface TemplateOptions {
@@ -40,6 +42,7 @@ interface TemplateOptions {
   directory: string;
   projectTitle?: string;
   skipInstall?: boolean;
+  hermes?: boolean;
 }
 
 function doesDirectoryExist(dir: string) {
@@ -82,6 +85,7 @@ async function createFromTemplate({
   directory,
   projectTitle,
   skipInstall,
+  hermes,
 }: TemplateOptions) {
   logger.debug('Initializing new project');
   logger.log(banner);
@@ -120,6 +124,15 @@ async function createFromTemplate({
     });
 
     loader.succeed();
+
+    if (hermes) {
+      loader.start('Enabling hermes engine');
+
+      await enableHermes();
+
+      loader.succeed();
+    }
+
     const {postInitScript} = templateConfig;
     if (postInitScript) {
       // Leaving trailing space because there may be stdout from the script
@@ -191,6 +204,7 @@ async function createProject(
     directory,
     projectTitle: options.title,
     skipInstall: options.skipInstall,
+    hermes: options.hermes,
   });
 }
 


### PR DESCRIPTION
Summary:
---------
#1470 
we need to add the Hermes flag for enabling Hermes while the init project therefore I added this `--hermes` flag in init command
```
react-native init RnReleaseTest --hermes
```


<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
`react-native init RnReleaseTest --hermes`

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
