### PR TITLE
Bump chalk to 4.x in cli-doctor

### DIFF
--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@react-native-community/cli-tools": "^7.0.1",
     "@react-native-community/cli-config": "^7.0.1",
-    "chalk": "^3.0.0",
+    "chalk": "^4.1.2",
     "envinfo": "^7.7.2",
     "hermes-profile-transformer": "^0.0.6",
     "ip": "^1.1.5",


### PR DESCRIPTION
To be consistent with the bump in all other existing packages from
1ac43cce3df75bff069558ac13e8314a17d892e4, and not need consumers to pull
down two versions when installing the cli.

Chalk 5 is ESM only, so that will have to wait until we're ready to use
ESM packages.