### PR TITLE
test(doctor, jdk): fix windows jdk doctor install test

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts
@@ -4,7 +4,7 @@ import getEnvironmentInfo from '../../envinfo';
 import {EnvironmentInfo} from '../../../types';
 import * as tools from '@react-native-community/cli-tools';
 import * as common from '../common';
-import * as unzip from '../../unzip';
+import * as downloadAndUnzip from '../../downloadAndUnzip';
 import * as deleteFile from '../../deleteFile';
 
 jest.mock('execa', () => jest.fn());
@@ -75,8 +75,8 @@ describe('jdk', () => {
     const loader = new tools.NoopLoader();
     const loaderSucceedSpy = jest.spyOn(loader, 'succeed');
     const loaderFailSpy = jest.spyOn(loader, 'fail');
-    const unzipSpy = jest
-      .spyOn(unzip, 'unzip')
+    const downloadAndUnzipSpy = jest
+      .spyOn(downloadAndUnzip, 'downloadAndUnzip')
       .mockImplementation(() => Promise.resolve());
 
     await jdk.win32AutomaticFix({
@@ -87,7 +87,7 @@ describe('jdk', () => {
 
     expect(loaderFailSpy).toHaveBeenCalledTimes(0);
     expect(logSpy).toHaveBeenCalledTimes(0);
-    expect(unzipSpy).toBeCalledTimes(1);
+    expect(downloadAndUnzipSpy).toBeCalledTimes(1);
     expect(loaderSucceedSpy).toBeCalledWith(
       'JDK installed successfully. Please restart your shell to see the changes',
     );


### PR DESCRIPTION
Summary:
---------

the jdk doctor fix command is using "[downloadAndUnzip](https://github.com/react-native-community/cli/blob/d2ac438528c282f69b71a7a39b1689f6bb276670/packages/cli-doctor/src/tools/healthchecks/jdk.ts#L35)", but the test
was mocking / spying on "unzip", this fixes the test to mock/spy on
the method actually used, patterned after the android studio test

This is the failure I see:

```
 FAIL  packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts (34.812 s)
  ● jdk › downloads and unzips JDK on Windows when missing

    thrown: "Exceeded timeout of 20000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      72 |   });
      73 |
    > 74 |   it('downloads and unzips JDK on Windows when missing', async () => {
         |   ^
      75 |     const loader = new tools.NoopLoader();
      76 |     const loaderSucceedSpy = jest.spyOn(loader, 'succeed');
      77 |     const loaderFailSpy = jest.spyOn(loader, 'fail');

      at packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts:74:3
      at Object.<anonymous> (packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts:20:1)
```


Test Plan:
----------

It's literally made of test ;-) - I always start working in a repository by checking it out, and running all it's tests. I needed this PR in order to successfully run `yarn test` against tip of master branch in my macos environment.

Technically this also means there is a false-positive in CI, as [`yarn tests:ci:unit`](https://github.com/react-native-community/cli/blob/d2ac438528c282f69b71a7a39b1689f6bb276670/.github/workflows/test.yml#L37) is [passing](https://github.com/react-native-community/cli/actions?query=branch%3Amaster), I think that's because `unzip` [is called (after the download) ](https://github.com/react-native-community/cli/blob/d2ac438528c282f69b71a7a39b1689f6bb276670/packages/cli-doctor/src/tools/downloadAndUnzip.ts#L29)so the test assertion that the spy is called passes, and in the CI environment it downloads quickly enough not to hit the timeout I get locally, so it passes the test.