### PR TITLE
fix(doctor, watchman): accept new date-based watchman versions

### DIFF
--- a/packages/cli-doctor/src/tools/checkInstallation.ts
+++ b/packages/cli-doctor/src/tools/checkInstallation.ts
@@ -19,11 +19,13 @@ const isSoftwareNotInstalled = async (command: string): Promise<boolean> => {
 const doesSoftwareNeedToBeFixed = ({
   version,
   versionRange,
+  looseRange = false,
 }: {
   version: string;
   versionRange: string;
+  looseRange?: boolean;
 }): boolean => {
-  const coercedVersion = semver.coerce(version);
+  const coercedVersion = semver.coerce(version, {loose: looseRange});
 
   return (
     version === 'Not Found' ||

--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/watchman.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/watchman.test.ts
@@ -1,0 +1,100 @@
+import execa from 'execa';
+import watchman from '../watchman';
+import getEnvironmentInfo from '../../envinfo';
+import {EnvironmentInfo} from '../../../types';
+import {NoopLoader} from '@react-native-community/cli-tools';
+import * as common from '../common';
+import * as brewInstall from '../../brewInstall';
+
+jest.mock('execa', () => jest.fn());
+
+const logSpy = jest.spyOn(common, 'logManualInstallation');
+const {logManualInstallation} = common;
+
+describe('watchman', () => {
+  let environmentInfo: EnvironmentInfo;
+
+  beforeAll(async () => {
+    environmentInfo = await getEnvironmentInfo();
+    ((execa as unknown) as jest.Mock).mockResolvedValue({stdout: ''});
+  }, 60000);
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns a message if the watchman is not installed', async () => {
+    // @ts-ignore - 'Not Found' is a valid return from envinfo but not typed here
+    environmentInfo.Binaries.Watchman = 'Not Found';
+
+    const diagnostics = await watchman.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(true);
+  });
+
+  it('returns false if watchman is installed with v4 version', async () => {
+    environmentInfo.Binaries.Watchman = {
+      version: '4.9.0',
+      path: '/unimportant/path',
+    };
+
+    const diagnostics = await watchman.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
+  it('logs manual installation steps to the screen for the non-macOS fix', async () => {
+    // Pretend we are linux, all the time
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'linux',
+    });
+
+    const loader = new NoopLoader();
+
+    await watchman.runAutomaticFix({
+      loader,
+      logManualInstallation,
+      environmentInfo,
+    });
+
+    // Restore the platform before we assert anything that might fail
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('installs watchman on macOS when missing', async () => {
+    // Pretend we are darwin, all the time
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', {
+      value: 'darwin',
+    });
+
+    const loaderSpy = new NoopLoader();
+    const loaderSucceedSpy = jest.spyOn(loaderSpy, 'succeed');
+    const loaderFailSpy = jest.spyOn(loaderSpy, 'fail');
+    const brewInstallSpy = jest
+      .spyOn(brewInstall, 'brewInstall')
+      .mockImplementation(({loader}) => {
+        loader.succeed();
+        return Promise.resolve();
+      });
+
+    await watchman.runAutomaticFix({
+      loader: loaderSpy,
+      logManualInstallation,
+      environmentInfo,
+    });
+
+    // Restore the platform before we assert anything that might fail
+    Object.defineProperty(process, 'platform', {
+      value: originalPlatform,
+    });
+
+    expect(loaderFailSpy).toHaveBeenCalledTimes(0);
+    expect(logSpy).toHaveBeenCalledTimes(0);
+    expect(brewInstallSpy).toBeCalledTimes(1);
+    expect(loaderSucceedSpy).toBeCalledTimes(1);
+  });
+});

--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/watchman.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/watchman.test.ts
@@ -41,6 +41,16 @@ describe('watchman', () => {
     expect(diagnostics.needsToBeFixed).toBe(false);
   });
 
+  it('returns false if watchman is installed with new date-based versions', async () => {
+    environmentInfo.Binaries.Watchman = {
+      version: '2020.02.07.00',
+      path: '/unimportant/path',
+    };
+
+    const diagnostics = await watchman.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
   it('logs manual installation steps to the screen for the non-macOS fix', async () => {
     // Pretend we are linux, all the time
     const originalPlatform = process.platform;

--- a/packages/cli-doctor/src/tools/healthchecks/watchman.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/watchman.ts
@@ -13,6 +13,7 @@ export default {
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Watchman.version,
       versionRange: versionRanges.WATCHMAN,
+      looseRange: true,
     }),
     version: Binaries.Watchman.version,
     versionRange: versionRanges.WATCHMAN,

--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -3,7 +3,7 @@ export default {
   NODE_JS: '>= 8.3',
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
-  WATCHMAN: '4.x',
+  WATCHMAN: '>= 4.x',
   JAVA: '1.8.x || >= 9',
   // Android
   ANDROID_SDK: '>= 26.x',


### PR DESCRIPTION
Summary:
---------

fix(doctor, watchman): accept new date-based watchman versions

doctor was giving false-negatives with the new watchman versions

they use date-based versions now that violate semver with leading-zeros in numeric parts:
- https://github.com/npm/node-semver/issues/232
    
loose mode correctly pasrses them though, so add optional parameter to install check that
allows loose version range coercion

Should be compatible as watchman project is on record as being permanently backwards-compatible:
https://facebook.github.io/watchman/docs/compatibility.html


Test Plan:
----------

I wrote a test that covers watchman completely before modifying it, then modified it and added a chunk of test to check the modification - so, best reviewed one commit at a time