### PR TITLE
build(deps): bump minimum node to v12

### DIFF
--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -1,6 +1,6 @@
 export default {
   // Common
-  NODE_JS: '>= 8.3',
+  NODE_JS: '>= 12',
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
   WATCHMAN: '4.x',


### PR DESCRIPTION
Summary:
---------

react-native apparently still works with v12, the only changelog
note I found was that v12 is the current minimum:
https://github.com/facebook/react-native/blob/main/CHANGELOG.md#breaking-1
I do not believe this is a breaking change here because react-native already required it

Test Plan:
----------

CI should be testing this?
Also when I make this change locally via manual patch (and then patch-package) in node_modules it works for me (I have v16 installed currently...)