### PR TITLE
build(deps)!: JDK11 and SDK 31+ are required

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
-          distribution: adopt
-          java-version: 8
-          cache: gradle
+          distribution: 'zulu'
+          java-version: 11
+          cache: 'gradle'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/androidSDK.test.ts
@@ -141,12 +141,12 @@ describe('androidSDK', () => {
     // 2. Install all required components
     const requiredComponents = [
       'platform-tools',
-      'build-tools;29.0.3',
-      'platforms;android-29',
+      'build-tools;31.0.0',
+      'platforms;android-31',
       'build-tools;28.0.3',
       'platforms;android-28',
       'emulator',
-      'system-images;android-28;google_apis;x86_64',
+      'system-images;android-31;google_apis;x86_64',
       '--licenses',
     ];
     // Make sure we are installing the right number

--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts
@@ -38,27 +38,27 @@ describe('jdk', () => {
   it('returns false if JDK version is in range (JDK 9+ version number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
-      version: '9.0.4',
+      version: '14.0.4',
     };
 
     const diagnostics = await jdk.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(false);
   });
 
-  it('returns false if JDK version is in range (JDK 8 version number format)', async () => {
+  it('returns true if JDK version is not in range (JDK <= 8 version number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
       version: '1.8.0_282',
     };
 
     const diagnostics = await jdk.getDiagnostics(environmentInfo);
-    expect(diagnostics.needsToBeFixed).toBe(false);
+    expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
-  it('returns true if JDK version is not in range', async () => {
+  it('returns true if JDK version is not in range (JDK 9+ verison number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
-      version: '7',
+      version: '10.0.15+10',
     };
 
     const diagnostics = await jdk.getDiagnostics(environmentInfo);

--- a/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
@@ -90,14 +90,14 @@ export default {
   win32AutomaticFix: async ({loader}) => {
     // Need a GitHub action to update automatically. See #1180
     const cliToolsUrl =
-      'https://dl.google.com/android/repository/commandlinetools-win-6200805_latest.zip';
+      'https://dl.google.com/android/repository/commandlinetools-win-8512546_latest.zip';
 
-    const systemImage = 'system-images;android-28;google_apis;x86_64';
+    const systemImage = 'system-images;android-31;google_apis;x86_64';
     // Installing 29 as well so Android Studio does not complain on first boot
     const componentsToInstall = [
       'platform-tools',
-      'build-tools;29.0.3',
-      'platforms;android-29',
+      'build-tools;31.0.0',
+      'platforms;android-31',
       // Is 28 still needed?
       'build-tools;28.0.3',
       'platforms;android-28',
@@ -182,7 +182,7 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android SDK',
-      url: 'https://reactnative.dev/docs/getting-started',
+      url: 'https://reactnative.dev/docs/environment-setup',
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/healthchecks/jdk.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/jdk.ts
@@ -57,7 +57,7 @@ export default {
     loader.fail();
     logManualInstallation({
       healthcheck: 'JDK',
-      url: 'https://openjdk.java.net/',
+      url: 'https://reactnative.dev/docs/environment-setup',
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -4,9 +4,9 @@ export default {
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
   WATCHMAN: '>= 4.x',
-  JAVA: '1.8.x || >= 9',
+  JAVA: '>= 11',
   // Android
-  ANDROID_SDK: '>= 26.x',
+  ANDROID_SDK: '>= 31.x',
   ANDROID_NDK: '>= 19.x',
   // iOS
   XCODE: '>= 12.x',


### PR DESCRIPTION
Summary:
---------

The template now inits a compileSdk/targetSdk 31 project,
JDK8 cannot compile reliably against SDK31, so bump JDK as well

~~I will mark this as draft, it should get a few more commits:~~

- [x]  https://github.com/react-native-community/cli/blob/master/packages/cli-doctor/src/tools/healthchecks/jdk.ts updated to latest v11 URL for windows and ideally to adoptium
- [x] manual JDK fix instructions point to environment setup on reactnative.dev now
- [x] updated versions / URLs to all this stuff https://github.com/react-native-community/cli/blob/master/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts here


Test Plan:
----------

seems to work for me locally?

Each commit is separate and useful, they should be removed commit by commit to make it all crystal clear

:skull_and_crossbones: : :warning: the `!` in the commit message is a good idea or not, to drive a breaking change semver? :warning: :skull_and_crossbones: : 