### PR TITLE
build(deps): align android ndk version w/current template

### DIFF
--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -7,7 +7,7 @@ export default {
   JAVA: '1.8.x || >= 9',
   // Android
   ANDROID_SDK: '>= 26.x',
-  ANDROID_NDK: '>= 19.x',
+  ANDROID_NDK: '>= 21.4',
   // iOS
   XCODE: '>= 10.x',
 };


### PR DESCRIPTION
Summary:
---------

Currently template requires 21.4.xx
https://github.com/facebook/react-native/blob/1b3581e245d1ae5f965f80c59dc57aece0a854e7/template/android/build.gradle#L9

This NDK check may need to be moved out of `--contributor` if NDK is required for TurboModules?

Test Plan:
----------

CI should test this? It does not pass for me locally when I try it via `npx react-native doctor --contributor` because I have NDK installed side-by-side, and upstream envinfo needs to detect this:

https://github.com/tabrindle/envinfo/issues/218
