### PR TITLE
build(deps): align Xcode with current App Store submission requirements

### DIFF
--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -9,5 +9,5 @@ export default {
   ANDROID_SDK: '>= 26.x',
   ANDROID_NDK: '>= 19.x',
   // iOS
-  XCODE: '>= 10.x',
+  XCODE: '>= 12.x',
 };


### PR DESCRIPTION
Summary:
---------

Apple defines the minimum version of Xcode that is truly usable.
They will enforce iOS15 SDK (thus transitively requiring Xcode 13) in April 2022:
'Starting April 2022, all iOS and iPadOS apps submitted to the App Store must be built with Xcode 13 and the iOS 15 SDK.'

Until then, Xcode 12 is still a viable compiler.

Test Plan:
----------

I have side-by-side installations of Xcode.app installed in one of my test environments.
I switched to Xcode-12.4, the oldest one I still have, and then did `npx react-native init TestApp124 --version=0.68.0-rc.1` and ran it, it seemed to run fine. So Xcode 12 still seems to compile fine.

Note the converse is not true in reverse, not sure how to enforce it, but if you use react-native 0.63 with Xcode 12.5+ it will not work, but you don't want to limit the upper version range really. Not sure if it makes sense to release a patch on an old version of react-native-cli doctor for react-native <= 0.63 that clamps the version of Xcode to <= 12.4 - but the idea that an forward-incompatibility is discovered retroactively is something that will be needed in the future again, so it's interesting to think about