### PR TITLE
breaking(run-android): remove deprecated run-android properties

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -17,8 +17,6 @@ jest.mock('../tryLaunchEmulator');
 
 describe('--appFolder', () => {
   const args: Flags = {
-    root: '/root',
-    appFolder: undefined,
     appId: '',
     tasks: undefined,
     variant: 'debug',
@@ -74,31 +72,6 @@ describe('--appFolder', () => {
     );
   });
 
-  it('uses appFolder and default variant', async () => {
-    await runOnAllDevices(
-      {...args, appFolder: 'someApp', variant: 'debug'},
-      './gradlew',
-      'adb',
-      androidProject,
-    );
-
-    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
-      'someApp:installDebug',
-    );
-  });
-
-  it('uses appFolder and custom variant', async () => {
-    await runOnAllDevices(
-      {...args, appFolder: 'anotherApp', variant: 'staging'},
-      './gradlew',
-      'adb',
-      androidProject,
-    );
-
-    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
-      'anotherApp:installStaging',
-    );
-  });
 
   it('uses only task argument', async () => {
     await runOnAllDevices(
@@ -118,19 +91,6 @@ describe('--appFolder', () => {
       ...androidProject,
       appName: 'anotherApp',
     });
-
-    expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
-      'anotherApp:someTask',
-    );
-  });
-
-  it('uses appFolder and custom task argument', async () => {
-    await runOnAllDevices(
-      {...args, appFolder: 'anotherApp', tasks: ['someTask'], variant: 'debug'},
-      './gradlew',
-      'adb',
-      {...androidProject, appName: 'anotherApp'},
-    );
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
       'anotherApp:someTask',

--- a/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -72,7 +72,6 @@ describe('--appFolder', () => {
     );
   });
 
-
   it('uses only task argument', async () => {
     await runOnAllDevices(
       {...args, tasks: ['someTask']},

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -293,7 +293,7 @@ export default {
     'builds your app and starts it on a connected Android emulator or device',
   func: runAndroid,
   options: [
-     {
+    {
       name: '--variant <string>',
       description: "Specify your app's build variant",
       default: 'debug',

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -23,24 +23,9 @@ import {
 } from '@react-native-community/cli-tools';
 import {getAndroidProject} from '../../config/getAndroidProject';
 
-function displayWarnings(args: Flags) {
-  if (args.appFolder) {
-    logger.warn(
-      'Using deprecated "--appFolder" flag. Use "project.android.appName" in react-native.config.js instead.',
-    );
-  }
-  if (args.root) {
-    logger.warn(
-      'Using deprecated "--root" flag. App root is discovered automatically. Alternatively, set "project.android.sourceDir" in react-native.config.js.',
-    );
-  }
-}
-
 export interface Flags {
   tasks?: Array<string>;
-  root: string;
   variant: string;
-  appFolder: string;
   appId: string;
   appIdSuffix: string;
   mainActivity: string;
@@ -58,7 +43,6 @@ type AndroidProject = NonNullable<Config['project']['android']>;
  * Starts the app on a connected Android emulator or device.
  */
 async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
-  displayWarnings(args);
   const androidProject = getAndroidProject(config);
 
   if (args.jetifier) {
@@ -162,11 +146,10 @@ function tryInstallAppOnDevice(
   try {
     // "app" is usually the default value for Android apps with only 1 app
     const {appName, sourceDir} = androidProject;
-    const {appFolder} = args;
     const variant = args.variant.toLowerCase();
     const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
     const apkFile = getInstallApkName(
-      appFolder || appName, // TODO: remove appFolder
+      appName,
       adbPath,
       variant,
       device,
@@ -310,21 +293,10 @@ export default {
     'builds your app and starts it on a connected Android emulator or device',
   func: runAndroid,
   options: [
-    {
-      name: '--root <string>',
-      description:
-        '[DEPRECATED - root is discovered automatically] Override the root directory for the android build (which contains the android directory)',
-      default: '',
-    },
-    {
+     {
       name: '--variant <string>',
       description: "Specify your app's build variant",
       default: 'debug',
-    },
-    {
-      name: '--appFolder <string>',
-      description:
-        '[DEPRECATED – use "project.android.appName" in react-native.config.js] Specify a different application folder name for the android source. If not, we assume is "app"',
     },
     {
       name: '--appId <string>',

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -53,10 +53,7 @@ async function runOnAllDevices(
 
   try {
     const tasks = args.tasks || ['install' + toPascalCase(args.variant)];
-    const gradleArgs = getTaskNames(
-      androidProject.appName,
-      tasks,
-    );
+    const gradleArgs = getTaskNames(androidProject.appName, tasks);
 
     if (args.port != null) {
       gradleArgs.push('-PreactNativeDevServerPort=' + args.port);

--- a/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -54,7 +54,7 @@ async function runOnAllDevices(
   try {
     const tasks = args.tasks || ['install' + toPascalCase(args.variant)];
     const gradleArgs = getTaskNames(
-      args.appFolder || androidProject.appName,
+      androidProject.appName,
       tasks,
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9409,17 +9409,7 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-pkginfo@0.3.x:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.3.1.tgz#5b29f6a81f70717142e09e765bbeab97b4f81e21"
-  integrity sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=
-
-pkginfo@0.x.x:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
-  integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
-
-plist@^3.0.1, plist@^3.0.2:
+plist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/plist/-/plist-3.0.2.tgz#74bbf011124b90421c22d15779cee60060ba95bc"
   integrity sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==


### PR DESCRIPTION
Summary:
---------

`root` was never used, `appFolder` was marked deprecated. It's a good timing to get rid of that.

This is a follow-up to https://github.com/react-native-community/cli/pull/1537
