### PR TITLE
chore: add tests for `getProjectConfig` on iOS

### DIFF
--- a/packages/platform-ios/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/platform-ios/src/config/__tests__/getProjectConfig.test.ts
@@ -33,14 +33,14 @@ describe('ios::getProjectConfig', () => {
   it('returns correct configuration when multiple Podfile are present', () => {
     fs.__setMockFilesystem({
       sample: {
-        Podfile: ''
+        Podfile: '',
       },
       ios: {
         Podfile: '',
       },
       example: {
         Podfile: '',
-      }
+      },
     });
     expect(projectConfig('/', {})).toMatchInlineSnapshot(`
       Object {

--- a/packages/platform-ios/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/platform-ios/src/config/__tests__/getProjectConfig.test.ts
@@ -5,12 +5,48 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+import {projectConfig} from '../index';
 
 jest.mock('path');
 jest.mock('fs');
 
+const fs = require('fs');
+
 describe('ios::getProjectConfig', () => {
-  it.skip('returns `null` if Podfile was not found', () => {});
-  it.skip('returns an object with ios project configuration', () => {});
-  it.skip('returns correct configuration when multiple Podfile are present', () => {});
+  it('returns `null` if Podfile was not found', () => {
+    fs.__setMockFilesystem({});
+    expect(projectConfig('/', {})).toBe(null);
+  });
+  it('returns an object with ios project configuration', () => {
+    fs.__setMockFilesystem({
+      ios: {
+        Podfile: '',
+      },
+    });
+    expect(projectConfig('/', {})).toMatchInlineSnapshot(`
+      Object {
+        "sourceDir": "/ios",
+        "xcodeProject": null,
+      }
+    `);
+  });
+  it('returns correct configuration when multiple Podfile are present', () => {
+    fs.__setMockFilesystem({
+      sample: {
+        Podfile: ''
+      },
+      ios: {
+        Podfile: '',
+      },
+      example: {
+        Podfile: '',
+      }
+    });
+    expect(projectConfig('/', {})).toMatchInlineSnapshot(`
+      Object {
+        "sourceDir": "/ios",
+        "xcodeProject": null,
+      }
+    `);
+  });
 });


### PR DESCRIPTION
Summary:
---------

As per TODO in https://github.com/react-native-community/cli/pull/1537, adding missing tests.

Test Plan:
----------

CI is green.