### PR TITLE
fix: `--verbose` option not working for `run-ios`

### DIFF
--- a/packages/cli/src/__tests__/index.test.ts
+++ b/packages/cli/src/__tests__/index.test.ts
@@ -1,0 +1,90 @@
+import commander from 'commander';
+import {attachCommand} from '../index';
+
+jest.mock('@react-native-community/cli-config', () => ({
+  commands: [],
+}));
+
+describe('attachCommand', () => {
+  it('should not pass verbose flag to sub-commands with their own verbose flag, given flag not set', () => {
+    const commandFunction = jest.fn();
+    const command = {
+      name: 'command-with-verbose-option',
+      func: commandFunction,
+      options: [
+        {name: '--verbose'},
+        {name: '--other-option-set'},
+        {name: '--other-option-not-set'},
+      ],
+    };
+    attachCommand(command);
+
+    const argv = [
+      'node',
+      'index.ts',
+      'command-with-verbose-option',
+      '--other-option-set',
+    ];
+    commander.parse(argv);
+
+    expect(commandFunction).toBeCalledWith(expect.any(Object), undefined, {
+      verbose: undefined,
+      otherOptionSet: true,
+      otherOptionNotSet: undefined,
+    });
+  });
+
+  it('should pass verbose flag to sub-commands with their own verbose flag, given flag set', () => {
+    const commandFunction = jest.fn();
+    const command = {
+      name: 'command-with-verbose-option',
+      func: commandFunction,
+      options: [
+        {name: '--verbose'},
+        {name: '--other-option-set'},
+        {name: '--other-option-not-set'},
+      ],
+    };
+    attachCommand(command);
+
+    const argv = [
+      'node',
+      'index.ts',
+      'command-with-verbose-option',
+      '--verbose',
+      '--other-option-set',
+    ];
+    commander.parse(argv);
+
+    expect(commandFunction).toBeCalledWith(expect.any(Object), undefined, {
+      verbose: true,
+      otherOptionSet: true,
+      otherOptionNotSet: undefined,
+    });
+  });
+
+  it('should not pass verbose flag to sub-commands without their own verbose flag, given flag set', () => {
+    const commandFunction = jest.fn();
+    const command = {
+      name: 'command-without-verbose-option',
+      func: commandFunction,
+      options: [{name: '--other-option-set'}, {name: '--other-option-not-set'}],
+    };
+    attachCommand(command);
+
+    const argv = [
+      'node',
+      'index.ts',
+      'command-without-verbose-option',
+      '--verbose',
+      '--other-option-set',
+    ];
+    commander.parse(argv);
+
+    expect(commandFunction).toBeCalledWith(expect.any(Object), undefined, {
+      otherOptionSet: true,
+      otherOptionNotSet: undefined,
+    });
+    expect(commandFunction.mock.calls[0][2]).not.toHaveProperty('verbose');
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -137,6 +137,13 @@ function attachCommand<IsDetached extends boolean>(
       const passedOptions = this.opts();
       const argv = Array.from(args).slice(0, -1);
 
+      // Copy parent commander verbose value to the sub-command if the sub-command also has a verbose option
+      // This is a workaround that can potentially be removed if commander is upgraded to v7+
+      // See https://github.com/react-native-community/cli/issues/1391#issuecomment-813078097 for more info
+      if (passedOptions.hasOwnProperty('verbose')) {
+        passedOptions.verbose = commander.verbose;
+      }
+
       try {
         if (isDetachedCommand(command)) {
           await command.func(argv, passedOptions);
@@ -254,4 +261,4 @@ async function setupAndRun() {
 
 const bin = require.resolve('./bin');
 
-export {run, bin, loadConfig};
+export {run, bin, loadConfig, attachCommand};


### PR DESCRIPTION
Fixes #1391

Summary:
---------

This commit implements a workaround to get the verbose option working again on run-ios. It not working is caused by the fact that the root command has a verbose option too. This 'steals' it from the the run-ios sub-command in commander 2.x. See https://github.com/react-native-community/cli/issues/1391#issuecomment-813078097 for more information.

Test Plan:
----------

Added unit tests for the new code. Testing `run` directly looked like it was going to be a hassle so I exported `attachCommand` so I could test it directly, I hope that's okay.