### PR TITLE
feat: add --binary-path to run-ios and run-android to enable installing pre-build binaries

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -385,6 +385,7 @@ Build native libraries only for the current device architecture for debug builds
 > default: false
 
 List all available Android devices and simulators and let you choose one to run the app.
+
 ### `build-android`
 
 Usage:
@@ -401,17 +402,20 @@ Builds Android app.
 
 > default: debug
 
-Mode to build the app. Either 'debug' (default) or 'release'. 
-
+Mode to build the app. Either 'debug' (default) or 'release'.
 
 #### `--extra-params <string>`
 
-Custom properties that will be passed to gradle build command. 
-Example: 
+Custom properties that will be passed to gradle build command.
+Example:
+
 ```sh
 react-native build-android --extra-params "-x lint -x test"
 ```
 
+#### `--binary-path <path>`
+
+Installs passed binary instead of building a fresh one. This command is not compatible with `--tasks`.
 
 ### `run-ios`
 
@@ -483,6 +487,10 @@ Explicitly pass `xcconfig` options from the command line.
 #### `--buildFolder <string>`
 
 Location for iOS build artifacts. Corresponds to Xcode's `-derivedDataPath`.
+
+#### `--binary-path <path>`
+
+Installs passed binary instead of building a fresh one.
 
 ### `start`
 

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -30,7 +30,7 @@ export interface Flags extends BuildFlags {
   binaryPath?: string;
 }
 
-type AndroidProject = NonNullable<Config['project']['android']>;
+export type AndroidProject = NonNullable<Config['project']['android']>;
 
 /**
  * Starts the app on a connected Android emulator or device.

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import execa from 'execa';
 import fs from 'fs';
 import {Config} from '@react-native-community/cli-types';
 import adb from './adb';
@@ -19,6 +18,7 @@ import {getAndroidProject} from '../../config/getAndroidProject';
 import listAndroidDevices from './listAndroidDevices';
 import tryLaunchEmulator from './tryLaunchEmulator';
 import chalk from 'chalk';
+import path from 'path';
 import {build, runPackager, BuildFlags, options} from '../buildAndroid';
 
 export interface Flags extends BuildFlags {
@@ -47,7 +47,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
       ? args.binaryPath
       : path.join(config.root, args.binaryPath);
 
-    if (!fs.existsSync(args.binaryPath)) {
+    if (args.binaryPath && !fs.existsSync(args.binaryPath)) {
       throw new CLIError(
         'binary-path was specified, but the file was not found.',
       );

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -12,6 +12,7 @@ import adb from './adb';
 import runOnAllDevices from './runOnAllDevices';
 import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
+import tryInstallAppOnDevice from './tryInstallAppOnDevice';
 import getAdbPath from './getAdbPath';
 import {logger, CLIError} from '@react-native-community/cli-tools';
 import {getAndroidProject} from '../../config/getAndroidProject';
@@ -134,63 +135,6 @@ function runOnSpecificDevice(
   } else {
     logger.error('No Android device or emulator connected.');
   }
-}
-
-function tryInstallAppOnDevice(
-  args: Flags,
-  adbPath: string,
-  device: string,
-  androidProject: AndroidProject,
-) {
-  try {
-    // "app" is usually the default value for Android apps with only 1 app
-    const {appName, sourceDir} = androidProject;
-    const variant = (args.mode || 'debug').toLowerCase();
-    const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
-    const apkFile = getInstallApkName(
-      appName,
-      adbPath,
-      variant,
-      device,
-      buildDirectory,
-    );
-
-    const pathToApk = `${buildDirectory}/${apkFile}`;
-    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
-    logger.info(`Installing the app on the device "${device}"...`);
-    logger.debug(
-      `Running command "cd android && adb -s ${device} install -r -d ${pathToApk}"`,
-    );
-    execa.sync(adbPath, adbArgs, {stdio: 'inherit'});
-  } catch (error) {
-    throw new CLIError('Failed to install the app on the device.', error);
-  }
-}
-
-function getInstallApkName(
-  appName: string,
-  adbPath: string,
-  variant: string,
-  device: string,
-  buildDirectory: string,
-) {
-  const availableCPUs = adb.getAvailableCPUs(adbPath, device);
-
-  // check if there is an apk file like app-armeabi-v7a-debug.apk
-  for (const availableCPU of availableCPUs.concat('universal')) {
-    const apkName = `${appName}-${availableCPU}-${variant}.apk`;
-    if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
-      return apkName;
-    }
-  }
-
-  // check if there is a default file like app-debug.apk
-  const apkName = `${appName}-${variant}.apk`;
-  if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
-    return apkName;
-  }
-
-  throw new CLIError('Could not find the correct install APK file.');
 }
 
 function installAndLaunchOnDevice(

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -43,7 +43,10 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
       );
     }
 
-    args.binaryPath = path.join(config.root, args.binaryPath);
+    args.binaryPath = path.isAbsolute(args.binaryPath)
+      ? args.binaryPath
+      : path.join(config.root, args.binaryPath);
+
     if (!fs.existsSync(args.binaryPath)) {
       throw new CLIError(
         'binary-path was specified, but the file was not found.',

--- a/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -1,0 +1,64 @@
+import execa from 'execa';
+import fs from 'fs';
+import {logger, CLIError} from '@react-native-community/cli-tools';
+
+import adb from './adb';
+
+function tryInstallAppOnDevice(
+  args: Flags,
+  adbPath: string,
+  device: string,
+  androidProject: AndroidProject,
+) {
+  try {
+    // "app" is usually the default value for Android apps with only 1 app
+    const {appName, sourceDir} = androidProject;
+    const variant = (args.mode || 'debug').toLowerCase();
+    const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
+    const apkFile = getInstallApkName(
+      appName,
+      adbPath,
+      variant,
+      device,
+      buildDirectory,
+    );
+
+    const pathToApk = `${buildDirectory}/${apkFile}`;
+    const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
+    logger.info(`Installing the app on the device "${device}"...`);
+    logger.debug(
+      `Running command "cd android && adb -s ${device} install -r -d ${pathToApk}"`,
+    );
+    execa.sync(adbPath, adbArgs, {stdio: 'inherit'});
+  } catch (error) {
+    throw new CLIError('Failed to install the app on the device.', error);
+  }
+}
+
+function getInstallApkName(
+  appName: string,
+  adbPath: string,
+  variant: string,
+  device: string,
+  buildDirectory: string,
+) {
+  const availableCPUs = adb.getAvailableCPUs(adbPath, device);
+
+  // check if there is an apk file like app-armeabi-v7a-debug.apk
+  for (const availableCPU of availableCPUs.concat('universal')) {
+    const apkName = `${appName}-${availableCPU}-${variant}.apk`;
+    if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
+      return apkName;
+    }
+  }
+
+  // check if there is a default file like app-debug.apk
+  const apkName = `${appName}-${variant}.apk`;
+  if (fs.existsSync(`${buildDirectory}/${apkName}`)) {
+    return apkName;
+  }
+
+  throw new CLIError('Could not find the correct install APK file.');
+}
+
+export default tryInstallAppOnDevice;

--- a/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import {logger, CLIError} from '@react-native-community/cli-tools';
 
 import adb from './adb';
+import type {AndroidProject, Flags} from './';
 
 function tryInstallAppOnDevice(
   args: Flags,

--- a/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -14,16 +14,22 @@ function tryInstallAppOnDevice(
     // "app" is usually the default value for Android apps with only 1 app
     const {appName, sourceDir} = androidProject;
     const variant = (args.mode || 'debug').toLowerCase();
-    const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
-    const apkFile = getInstallApkName(
-      appName,
-      adbPath,
-      variant,
-      device,
-      buildDirectory,
-    );
 
-    const pathToApk = `${buildDirectory}/${apkFile}`;
+    let pathToApk;
+    if (!args.binaryPath) {
+      const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
+      const apkFile = getInstallApkName(
+        appName,
+        adbPath,
+        variant,
+        device,
+        buildDirectory,
+      );
+      pathToApk = `${buildDirectory}/${apkFile}`;
+    } else {
+      pathToApk = args.binaryPath;
+    }
+
     const adbArgs = ['-s', device, 'install', '-r', '-d', pathToApk];
     logger.info(`Installing the app on the device "${device}"...`);
     logger.debug(

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -51,7 +51,10 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 
   if (args.binaryPath) {
-    args.binaryPath = path.join(ctx.root, args.binaryPath);
+    args.binaryPath = path.isAbsolute(args.binaryPath)
+      ? args.binaryPath
+      : path.join(ctx.root, args.binaryPath);
+
     if (!fs.existsSync(args.binaryPath)) {
       throw new CLIError(
         'binary-path was specified, but the file was not found.',

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -264,6 +264,12 @@ async function runOnDevice(
   xcodeProject: IOSProjectInfo,
   args: FlagsT,
 ) {
+  if (args.binaryPath && selectedDevice.type === 'catalyst') {
+    throw new CLIError(
+      'binary-path was specified for catalyst device, which is not supported.',
+    );
+  }
+
   const isIOSDeployInstalled = child_process.spawnSync(
     'ios-deploy',
     ['--version'],

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -12,6 +12,7 @@ import child_process, {
   SpawnOptionsWithoutStdio,
 } from 'child_process';
 import path from 'path';
+import fs from 'fs';
 import chalk from 'chalk';
 import {Config, IOSProjectInfo} from '@react-native-community/cli-types';
 import parseIOSDevicesList from './parseIOSDevicesList';


### PR DESCRIPTION
Summary:
---------

Add support for `--binary-path` option to `run-ios` and `run-android`. This allows a caller to specify their own (pre-built) binary that they want to install on devices, while still keeping all the great os/emulator/device support that react-native-community-cli brings.

Test Plan:
----------

- [x] `react-native run-ios` works & builds from scratch
- [x] `react-native run-ios --device` works & builds from scratch
- [x] `react-native run-ios --binary-path [PATH]` works & installs pre-built `.app` on simulator
- [x] `react-native run-ios --device --binary-path [PATH]` works & installs pre-built `.app` on device
- [x] `react-native run-android` works & builds from scratch
- [x] `react-native run-android --deviceId [ID]` works & builds from scratch
- [x] `react-native run-android --binary-path [PATH]` works & installs pre-built `.apk` on emulator/device
- [x] `react-native run-android --deviceId [ID] --binary-path [PATH]` works & installs pre-built `.apk` on emulator/device
- [x] `react-native run-android --binary-path [PATH] --tasks 'test'` throws; `tasks` and `binary-path` are not compatible
- [ ] catalyst build works as expected
- [ ] catalyst build throws if `--binary-path` specified