### PR TITLE
fix: "no such file or directory" error when using Gradle Kotlin DSL

### DIFF
--- a/packages/platform-android/src/link/isInstalled.ts
+++ b/packages/platform-android/src/link/isInstalled.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {CLIError} from '@react-native-community/cli-tools';
 import fs from 'fs';
 import makeBuildPatch from './patches/makeBuildPatch';
 
@@ -13,6 +14,20 @@ export default function isInstalled(
   config: {buildGradlePath: string},
   name: string,
 ) {
-  const buildGradle = fs.readFileSync(config.buildGradlePath, 'utf8');
+  let buildGradle: string;
+
+  if (!fs.existsSync(config.buildGradlePath)) {
+    // Handle default build.gradle path for Gradle Kotlin DSL
+    if (!fs.existsSync(config.buildGradlePath + '.kts')) {
+      throw new CLIError(
+        'Cannot resolve build.gradle file at: ' + config.buildGradlePath,
+      );
+    } else {
+      buildGradle = fs.readFileSync(config.buildGradlePath + '.kts', 'utf8');
+    }
+  } else {
+    buildGradle = fs.readFileSync(config.buildGradlePath, 'utf8');
+  }
+
   return makeBuildPatch(name).installPattern.test(buildGradle);
 }


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

According to https://github.com/react-native-community/cli/discussions/1567#discussioncomment-2446121, older CLI versions do not handle `build.gradle.kts` as valid Gradle scripts, during autolinking.

This PR adds an additional check for default path to `build.gradle.kts` and throws an error, if there is no file at path.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

- Create project with cli v6 and build.gradle rewritten from Groovy DSL to Kotlin DSL (you can use https://github.com/mateusz1913/RNKotlinPOC)
- Add library which requires autolinking on Android
- Run Android app
