### PR TITLE
feat: add "clean" command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@react-native-community/eslint-config": "^2.0.0",
     "@types/glob": "^7.1.1",
     "@types/jest": "^26.0.15",
-    "@types/node": "^10.0.0",
+    "@types/node": "^12.0.0",
     "@types/node-fetch": "^2.3.7",
     "babel-jest": "^26.6.2",
     "babel-plugin-module-resolver": "^3.2.0",
@@ -55,6 +55,6 @@
     "typescript": "^3.8.0"
   },
   "resolutions": {
-    "@types/node": "^10.0.0"
+    "@types/node": "^12.0.0"
   }
 }

--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -9,6 +9,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@react-native-community/cli-tools": "^8.0.0-alpha.0",
+    "chalk": "^4.1.2",
     "execa": "^1.0.0",
     "prompts": "^2.4.0"
   },

--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -9,6 +9,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@react-native-community/cli-tools": "^8.0.0-alpha.0",
+    "execa": "^1.0.0",
     "prompts": "^2.4.0"
   },
   "files": [
@@ -18,6 +19,7 @@
   ],
   "devDependencies": {
     "@react-native-community/cli-types": "^8.0.0-alpha.0",
+    "@types/execa": "^0.9.0",
     "@types/prompts": "^2.0.9"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-clean",

--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -8,7 +8,8 @@
   },
   "types": "build/index.d.ts",
   "dependencies": {
-    "@react-native-community/cli-tools": "^8.0.0-alpha.0"
+    "@react-native-community/cli-tools": "^8.0.0-alpha.0",
+    "prompts": "^2.4.0"
   },
   "files": [
     "build",
@@ -16,7 +17,8 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "^8.0.0-alpha.0"
+    "@react-native-community/cli-types": "^8.0.0-alpha.0",
+    "@types/prompts": "^2.0.9"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-clean",
   "repository": {

--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@react-native-community/cli-clean",
+  "version": "8.0.0-alpha.0",
+  "license": "MIT",
+  "main": "build/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "types": "build/index.d.ts",
+  "dependencies": {
+    "@react-native-community/cli-tools": "^8.0.0-alpha.0"
+  },
+  "files": [
+    "build",
+    "!*.d.ts",
+    "!*.map"
+  ],
+  "devDependencies": {
+    "@react-native-community/cli-types": "^8.0.0-alpha.0"
+  },
+  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-clean",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/react-native-community/cli.git",
+    "directory": "packages/cli-clean"
+  }
+}

--- a/packages/cli-clean/src/__tests__/clean.test.ts
+++ b/packages/cli-clean/src/__tests__/clean.test.ts
@@ -1,0 +1,47 @@
+import execa from 'execa';
+import os from 'os';
+import prompts from 'prompts';
+import {clean} from '../clean';
+
+jest.mock('execa', () => jest.fn());
+jest.mock('prompts', () => jest.fn());
+
+describe('clean', () => {
+  const mockConfig: any = {};
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('throws if project root is not set', () => {
+    expect(clean([], mockConfig, mockConfig)).rejects.toThrow();
+  });
+
+  it('prompts if `--include` is omitted', async () => {
+    prompts.mockReturnValue({cache: []});
+
+    await clean([], mockConfig, {include: '', projectRoot: process.cwd()});
+
+    expect(execa).not.toBeCalled();
+    expect(prompts).toBeCalled();
+  });
+
+  it('stops Watchman and clears out caches', async () => {
+    await clean([], mockConfig, {
+      include: 'watchman',
+      projectRoot: process.cwd(),
+    });
+
+    expect(prompts).not.toBeCalled();
+    expect(execa).toBeCalledWith(
+      os.platform() === 'win32' ? 'tskill' : 'killall',
+      ['watchman'],
+      expect.anything(),
+    );
+    expect(execa).toBeCalledWith(
+      'watchman',
+      ['watch-del-all'],
+      expect.anything(),
+    );
+  });
+});

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -1,0 +1,213 @@
+import {getLoader} from '@react-native-community/cli-tools';
+import type {Config as CLIConfig} from '@react-native-community/cli-types';
+import {spawn} from 'child_process';
+import {existsSync as fileExists, rmdir} from 'fs';
+import os from 'os';
+import path from 'path';
+import {promisify} from 'util';
+
+type Args = {
+  include: string;
+  projectRoot: string;
+  verifyCache?: boolean;
+};
+
+type Task = {
+  label: string;
+  action: () => Promise<void>;
+};
+
+type CLICommand = {
+  [key: string]: Task[];
+};
+
+const DEFAULT_CATEGORIES = ['metro', 'npm', 'watchman', 'yarn'];
+
+const rmdirAsync = promisify(rmdir);
+
+function cleanDir(directory: string): Promise<void> {
+  if (!fileExists(directory)) {
+    return Promise.resolve();
+  }
+
+  return rmdirAsync(directory, {maxRetries: 3, recursive: true});
+}
+
+function execute(command: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const process = spawn(command, args, {
+      cwd,
+      stdio: ['inherit', null, null],
+    });
+
+    const stderr: Buffer[] = [];
+    process.stderr.on('data', (data) => {
+      stderr.push(data);
+    });
+
+    process.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+      } else if (stderr) {
+        reject(Buffer.concat(stderr).toString().trimEnd());
+      } else if (signal) {
+        reject(`Failed with signal ${signal}`);
+      } else {
+        reject(`Failed with exit code ${code}`);
+      }
+    });
+  });
+}
+
+function findPath(startPath: string, files: string[]): string | undefined {
+  // TODO: Find project files via `@react-native-community/cli`
+  for (const file of files) {
+    const filename = path.resolve(startPath, file);
+    if (fileExists(filename)) {
+      return filename;
+    }
+  }
+
+  return undefined;
+}
+
+export async function clean(
+  _argv: string[],
+  _config: CLIConfig,
+  cleanOptions: Args,
+): Promise<void> {
+  const {include, projectRoot, verifyCache} = cleanOptions;
+  if (!fileExists(projectRoot)) {
+    throw new Error(`Invalid path provided! ${projectRoot}`);
+  }
+
+  const npm = os.platform() === 'win32' ? 'npm.cmd' : 'npm';
+  const yarn = os.platform() === 'win32' ? 'yarn.cmd' : 'yarn';
+
+  const COMMANDS: CLICommand = {
+    android: [
+      {
+        label: 'Clean Gradle cache',
+        action: () => {
+          const candidates =
+            os.platform() === 'win32'
+              ? ['android/gradlew.bat', 'gradlew.bat']
+              : ['android/gradlew', 'gradlew'];
+          const gradlew = findPath(projectRoot, candidates);
+          if (gradlew) {
+            const script = path.basename(gradlew);
+            return execute(
+              os.platform() === 'win32' ? script : `./${script}`,
+              ['clean'],
+              path.dirname(gradlew),
+            );
+          } else {
+            return Promise.resolve();
+          }
+        },
+      },
+    ],
+    cocoapods: [
+      {
+        label: 'Clean CocoaPods cache',
+        action: () => execute('pod', ['cache', 'clean', '--all'], projectRoot),
+      },
+    ],
+    metro: [
+      {
+        label: 'Clean Metro cache',
+        action: () => cleanDir(`${os.tmpdir()}/metro-*`),
+      },
+      {
+        label: 'Clean Haste cache',
+        action: () => cleanDir(`${os.tmpdir()}/haste-map-*`),
+      },
+      {
+        label: 'Clean React Native cache',
+        action: () => cleanDir(`${os.tmpdir()}/react-*`),
+      },
+    ],
+    npm: [
+      {
+        label: 'Remove node_modules',
+        action: () => cleanDir(`${projectRoot}/node_modules`),
+      },
+      ...(verifyCache
+        ? [
+            {
+              label: 'Verify npm cache',
+              action: () => execute(npm, ['cache', 'verify'], projectRoot),
+            },
+          ]
+        : []),
+    ],
+    watchman: [
+      {
+        label: 'Stop Watchman',
+        action: () =>
+          execute(
+            os.platform() === 'win32' ? 'tskill' : 'killall',
+            ['watchman'],
+            projectRoot,
+          ),
+      },
+      {
+        label: 'Delete Watchman cache',
+        action: () => execute('watchman', ['watch-del-all'], projectRoot),
+      },
+    ],
+    yarn: [
+      {
+        label: 'Clean Yarn cache',
+        action: () => execute(yarn, ['cache', 'clean'], projectRoot),
+      },
+    ],
+  };
+
+  const spinner = getLoader();
+  for (const category of include.split(',')) {
+    const commands = COMMANDS[category];
+    if (!commands) {
+      spinner.warn(`Unknown category: ${category}`);
+      return;
+    }
+
+    for (const {action, label} of commands) {
+      spinner.start(label);
+      await action()
+        .then(() => {
+          spinner.succeed();
+        })
+        .catch((e) => {
+          spinner.fail(`${label} » ${e}`);
+        });
+    }
+  }
+}
+
+export default {
+  func: clean,
+  name: 'clean',
+  description:
+    'Cleans your project by removing React Native related caches and modules.',
+  options: [
+    {
+      name: '--include <string>',
+      description:
+        'Comma-separated flag of caches to clear e.g. `npm,yarn`. When not specified , only non-platform specific caches are cleared. Valid values are android, cocoapods, npm, metro, watchman, yarn.',
+      default: DEFAULT_CATEGORIES.join(','),
+    },
+    {
+      name: '--project-root <string>',
+      description:
+        'Root path to your React Native project. When not specified, defaults to current working directory.',
+      default: process.cwd(),
+    },
+    {
+      name: '--verify-cache',
+      description:
+        'Whether to verify the cache. Currently only applies to npm cache.',
+      default: false,
+    },
+  ],
+};

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -22,7 +22,7 @@ type CLICommand = {
   [key: string]: Task[];
 };
 
-const DEFAULT_CATEGORIES = ['metro', 'npm', 'watchman', 'yarn'];
+const DEFAULT_CATEGORIES = ['metro', 'watchman'];
 
 const rmdirAsync = promisify(rmdir);
 

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -198,7 +198,7 @@ export async function clean(
     const commands = COMMANDS[group];
     if (!commands) {
       spinner.warn(`Unknown group: ${group}`);
-      return;
+      continue;
     }
 
     for (const {action, label} of commands.tasks) {

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -1,5 +1,6 @@
 import {getLoader} from '@react-native-community/cli-tools';
 import type {Config as CLIConfig} from '@react-native-community/cli-types';
+import chalk from 'chalk';
 import execa from 'execa';
 import {existsSync as fileExists, rmdir} from 'fs';
 import os from 'os';
@@ -57,7 +58,7 @@ async function promptForCaches(
     name: 'caches',
     message: 'Select all caches to clean',
     choices: Object.entries(groups).map(([cmd, group]) => ({
-      title: `${cmd} (${group.description})`,
+      title: `${cmd} ${chalk.dim(`(${group.description})`)}`,
       value: cmd,
       selected: DEFAULT_GROUPS.includes(cmd),
     })),

--- a/packages/cli-clean/src/index.ts
+++ b/packages/cli-clean/src/index.ts
@@ -1,0 +1,3 @@
+import {default as clean} from './clean';
+
+export const commands = {clean};

--- a/packages/cli-clean/tsconfig.json
+++ b/packages/cli-clean/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "references": [
+    {"path": "../tools"},
+    {"path": "../cli-types"},
+    {"path": "../cli-config"}
+  ]
+}

--- a/packages/cli-doctor/src/commands/doctor.ts
+++ b/packages/cli-doctor/src/commands/doctor.ts
@@ -228,7 +228,6 @@ const doctorCommand = (async (_, options) => {
       removeKeyPressListener();
 
       process.exit(0);
-      return;
     }
 
     if (

--- a/packages/cli-doctor/src/tools/windows/androidWinHelpers.ts
+++ b/packages/cli-doctor/src/tools/windows/androidWinHelpers.ts
@@ -47,13 +47,13 @@ export const installComponent = (component: string, androidSdkRoot: string) => {
     const child = executeCommand(command);
     let stderr = '';
 
-    child.stdout.on('data', (data) => {
+    child.stdout?.on('data', (data) => {
       if (data.includes('(y/N)')) {
-        child.stdin.write('y\n');
+        child.stdin?.write('y\n');
       }
     });
 
-    child.stderr.on('data', (data) => {
+    child.stderr?.on('data', (data) => {
       stderr += data.toString('utf-8');
     });
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,6 +24,7 @@
     "testEnvironment": "node"
   },
   "dependencies": {
+    "@react-native-community/cli-clean": "^8.0.0-alpha.0",
     "@react-native-community/cli-config": "^8.0.0-alpha.0",
     "@react-native-community/cli-debugger-ui": "^8.0.0-alpha.0",
     "@react-native-community/cli-doctor": "^8.0.0-alpha.0",

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 import {Command, DetachedCommand} from '@react-native-community/cli-types';
+import {commands as cleanCommands} from '@react-native-community/cli-clean';
 import {commands as doctorCommands} from '@react-native-community/cli-doctor';
 import {commands as configCommands} from '@react-native-community/cli-config';
 import {commands as metroCommands} from '@react-native-community/cli-plugin-metro';
@@ -9,6 +10,7 @@ import init from './init';
 export const projectCommands = [
   ...metroCommands,
   ...configCommands,
+  cleanCommands.clean,
   doctorCommands.info,
   upgrade,
   profileHermes,

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,13 +5,14 @@
     "outDir": "build"
   },
   "references": [
-    {"path": "../tools"},
-    {"path": "../cli-types"},
-    {"path": "../debugger-ui"},
-    {"path": "../cli-server-api"},
+    {"path": "../cli-clean"},
+    {"path": "../cli-config"},
+    {"path": "../cli-doctor"},
     {"path": "../cli-hermes"},
     {"path": "../cli-plugin-metro"},
-    {"path": "../cli-doctor"},
-    {"path": "../cli-config"}
+    {"path": "../cli-server-api"},
+    {"path": "../cli-types"},
+    {"path": "../debugger-ui"},
+    {"path": "../tools"}
   ]
 }

--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -228,7 +228,10 @@ async function runOnSimulator(
   if (result.status === 0) {
     logger.success('Successfully launched the app on the simulator');
   } else {
-    logger.error('Failed to launch the app on simulator', result.stderr);
+    logger.error(
+      'Failed to launch the app on simulator',
+      result.stderr.toString(),
+    );
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2458,10 +2458,10 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^10.0.0":
-  version "10.17.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.35.tgz#58058f29b870e6ae57b20e4f6e928f02b7129f56"
-  integrity sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==
+"@types/node@*", "@types/node@^12.0.0":
+  version "12.20.47"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
+  integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Summary:
---------

This adds a `clean` command to the CLI for common cleaning operations.

Originally contributed by @dennismunene: https://github.com/microsoft/rnx-kit/pull/993


Test Plan:
----------

```
yarn link @react-native-community/cli @react-native-community/cli-clean
```

Test `--help`:

```
% npx react-native clean --help
react-native clean

Cleans your project by removing React Native related caches and modules.

Options:
  --include <string>       Comma-separated flag of caches to clear e.g. `npm,yarn`. If omitted, an interactive prompt will appear.
  --project-root <string>  Root path to your React Native project. When not specified, defaults to current working directory. (default: "/~/test-app")
  --verify-cache           Whether to verify the cache. Currently only applies to npm cache.
  -h, --help               output usage information
```

By default, prompts the user for caches to remove:

```
% yarn react-native clean
? Select all caches to clean ›
Instructions:
    ↑/↓: Highlight option
    ←/→/[space]: Toggle selection
    a: Toggle all
    enter/return: Complete answer
◯   android (Android build caches, e.g. Gradle)
◯   cocoapods (CocoaPods cache)
◉   metro (Metro, haste-map caches)
◯   npm (`node_modules` folder in the current package, and optionally verify npm cache)
◉   watchman (Stop Watchman and delete its cache)
◯   yarn (Yarn cache)
```

Remove `node_modules`:

```
% npx react-native clean --include npm
✔ Remove node_modules
```

Clean Gradle cache and `node_modules`:

```
% npx react-native clean --include android,npm
✔ Clean Gradle cache
✔ Remove node_modules
```