### PR TITLE
chore: Automated CLI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Setup git user"
         run: |
           git config user.name "${{ github.actor }}"
-          git config user.email "bot@callstack.com"
+          git config user.email "bot@callstack.io"
 
       - name: "Prelease"
         if: "github.event.release.prerelease"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v2
+        with:
+          ref: "master"
+
+      - name: "Setup Node v16"
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: "Setup git user"
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "bot@callstack.com"
+
+      - name: "Prelease"
+        if: "github.event.release.prerelease"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          npx lerna version --conventional-commits --conventional-prerelease --preid alpha --yes
+          
+          npx lerna publish from-git --no-verify-access --no-changelog --yes
+
+      - name: "Release"
+        if: "!github.event.release.prerelease"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          npx lerna version --conventional-commits --yes
+          
+          npx lerna publish from-git --no-verify-access --no-changelog --yes


### PR DESCRIPTION
Summary:
---------

Added release workflow to github actions. Releases marked as `pre-release` will add `--conventional-prerelease` flag with `alpha` as `preid`.

**In order to this workflow work properly** new `Automation` npm token named `NPM_TOKEN` must be added to project secrets.
As requested, lerna changelog generation is disabled for now.