### PR TITLE
Add generate-static-view-configs command line argument for bundle command

### DIFF
--- a/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
@@ -28,6 +28,7 @@ interface RequestOptions {
   minify: boolean;
   platform: string | undefined;
   unstable_transformProfile: string | undefined;
+  generateStaticViewConfigs: boolean;
 }
 
 export interface AssetData {
@@ -101,6 +102,7 @@ export async function buildBundleWithConfig(
     minify: args.minify !== undefined ? args.minify : !args.dev,
     platform: args.platform,
     unstable_transformProfile: args.unstableTransformProfile,
+    generateStaticViewConfigs: args.generateStaticViewConfigs,
   };
   const server = new Server(config);
 

--- a/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
@@ -26,6 +26,7 @@ export interface CommandLineArgs {
   sourcemapUseAbsolutePath: boolean;
   verbose: boolean;
   unstableTransformProfile?: string;
+  generateStaticViewConfigs?: boolean;
 }
 
 export default [
@@ -116,5 +117,12 @@ export default [
     name: '--config <string>',
     description: 'Path to the CLI configuration file',
     parse: (val: string) => path.resolve(val),
+  },
+  {
+    name: '--generate-static-view-configs',
+    description:
+      'Generate static view configs for Fabric components. ' +
+      'If there are no Fabric components in the bundle or Fabric is disabled, this is just no-op.',
+    default: true,
   },
 ];

--- a/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
@@ -26,7 +26,7 @@ export interface CommandLineArgs {
   sourcemapUseAbsolutePath: boolean;
   verbose: boolean;
   unstableTransformProfile?: string;
-  generateStaticViewConfigs?: boolean;
+  generateStaticViewConfigs: boolean;
 }
 
 export default [


### PR DESCRIPTION
Summary:
---------

`@react-native/babel-plugin-codegen` is a Babel plugin that generates static view configs for Fabric components during bundling stage. Right now we have to add this plugin manually if we want to use Fabric: https://reactnative.dev/docs/next/new-architecture-app-renderer-ios#3-add-babel-plugins
In order to get rid of this manual step, we would like to ship this plugin as a part of Metro.
`--generate-static-view-configs` argument allows to turn it on or off. The idea is to have ON for Fabric projects and OFF for non-Fabric. Fabric users can also opt out, in case they don't need this feature for some reason.


Test Plan:
----------

Tested it locally by passing this argument to cli in _react-native/scripts/react-native-xcode.sh_