### PR TITLE
fix: add PROJECT_ROOT variable to pass launchPackager

### DIFF
--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -78,7 +78,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
           args.port,
           args.terminal,
           config.reactNativePath,
-          androidProject.folder,
+          path.join(androidProject.sourceDir, '..'),
         );
       } catch (error) {
         logger.warn(

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -228,9 +228,9 @@ function startServerInNewWindow(
   const portExportContent = isWindows
     ? `set RCT_METRO_PORT=${port}`
     : `export RCT_METRO_PORT=${port}`;
-    const projectRootExportContent = isWindows
-      ? `set PROJECT_ROOT=${projectRoot}`
-      : `export PROJECT_ROOT=${projectRoot}`;
+  const projectRootExportContent = isWindows
+    ? `set PROJECT_ROOT=${projectRoot}`
+    : `export PROJECT_ROOT=${projectRoot}`;
 
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
@@ -251,10 +251,14 @@ function startServerInNewWindow(
   /**
    * Ensure we overwrite file by passing the `w` flag
    */
-  fs.writeFileSync(packagerEnvFile, portExportContent + "\n" + projectRootExportContent, {
-    encoding: 'utf8',
-    flag: 'w',
-  });
+  fs.writeFileSync(
+    packagerEnvFile,
+    portExportContent + '\n' + projectRootExportContent,
+    {
+      encoding: 'utf8',
+      flag: 'w',
+    },
+  );
 
   if (process.platform === 'darwin') {
     try {

--- a/packages/platform-android/src/commands/runAndroid/index.ts
+++ b/packages/platform-android/src/commands/runAndroid/index.ts
@@ -78,6 +78,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
           args.port,
           args.terminal,
           config.reactNativePath,
+          androidProject.folder,
         );
       } catch (error) {
         logger.warn(
@@ -214,6 +215,7 @@ function startServerInNewWindow(
   port: number,
   terminal: string,
   reactNativePath: string,
+  projectRoot: string,
 ) {
   /**
    * Set up OS-specific filenames and commands
@@ -226,6 +228,9 @@ function startServerInNewWindow(
   const portExportContent = isWindows
     ? `set RCT_METRO_PORT=${port}`
     : `export RCT_METRO_PORT=${port}`;
+    const projectRootExportContent = isWindows
+      ? `set PROJECT_ROOT=${projectRoot}`
+      : `export PROJECT_ROOT=${projectRoot}`;
 
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
@@ -246,7 +251,7 @@ function startServerInNewWindow(
   /**
    * Ensure we overwrite file by passing the `w` flag
    */
-  fs.writeFileSync(packagerEnvFile, portExportContent, {
+  fs.writeFileSync(packagerEnvFile, portExportContent + "\n" + projectRootExportContent, {
     encoding: 'utf8',
     flag: 'w',
   });


### PR DESCRIPTION
Summary:
---------

These days I working on a monorepo project, I try to prevent using "nohoise" option
There is a problem in react-native when it trying to run cli.js in [```launchPackager.bat```](https://github.com/facebook/react-native/blob/main/scripts/launchPackager.bat) file, react-native go two folders up then run cli.js
If you have a monorepo project folder tree is like this:
```
- project
    - packages
       - appA
       - appB
       - libA
    - node_modules
        - react-native
        - metro
        - ...
```
In this case, it should move to PROJECT_ROOT and then run cli.js

I fix the [```launchPackager.bat```](https://github.com/AliRezaBeigy/react-native/blob/main/scripts/launchPackager.bat) too, If this pull request is accepted, I will create a pull request for react-native too.


Test Plan:
----------

I tested it with react-native change locally, this change has no effect on any project because I add a variable for further use.
