### PR TITLE
Update reactNativePlatformResolver for new metro

### DIFF
--- a/packages/cli-plugin-metro/src/tools/metroPlatformResolver.ts
+++ b/packages/cli-plugin-metro/src/tools/metroPlatformResolver.ts
@@ -12,38 +12,21 @@
  *    macos: 'react-native-macos'
  * }
  */
-// @ts-ignore - no typed definition for the package
-import {resolve} from 'metro-resolver';
 
 export function reactNativePlatformResolver(platformImplementations: {
   [platform: string]: string;
 }) {
-  return (
-    context: any,
-    _realModuleName: string,
-    platform: string,
-    moduleName: string,
-  ) => {
-    let backupResolveRequest = context.resolveRequest;
-    delete context.resolveRequest;
-
-    try {
-      let modifiedModuleName = moduleName;
-      if (platformImplementations[platform]) {
-        if (moduleName === 'react-native') {
-          modifiedModuleName = platformImplementations[platform];
-        } else if (moduleName.startsWith('react-native/')) {
-          modifiedModuleName = `${
-            platformImplementations[platform]
-          }/${modifiedModuleName.slice('react-native/'.length)}`;
-        }
+  return (context: any, moduleName: string, platform: string) => {
+    let modifiedModuleName = moduleName;
+    if (platformImplementations[platform]) {
+      if (moduleName === 'react-native') {
+        modifiedModuleName = platformImplementations[platform];
+      } else if (moduleName.startsWith('react-native/')) {
+        modifiedModuleName = `${
+          platformImplementations[platform]
+        }/${modifiedModuleName.slice('react-native/'.length)}`;
       }
-      let result = resolve(context, modifiedModuleName, platform);
-      return result;
-    } catch (e) {
-      throw e;
-    } finally {
-      context.resolveRequest = backupResolveRequest;
     }
+    return context.resolveRequest(context, modifiedModuleName, platform);
   };
 }


### PR DESCRIPTION
Summary:
---------

Metro changed how to hook into the resolver with this commit:
https://github.com/facebook/metro/commit/d81d8877c05637eac2b4ea946a9fa1e8ae869b06

The reactNativePlatformResolver is still using the old format, which causes bundle commands to fail if the project has any out of tree platforms (Ex: react-native-windows-macOS)


Test Plan:
----------

The following bundle command fails currently.  But works after making this change locally.
npx --yes react-native@0.0.0-20220415-2010-3c1a81446 init testcli --template react-native@0.0.0-20220415-2010-3c1a81446
cd testcli
npx --yes react-native-windows-init@latest --verbose --version 0.0.0-canary.495 --overwrite --language cs --projectType app --namespace MyCompany.MyApplication.MyComponent
npx react-native bundle --entry-file index.js --platform windows --bundle-output test.bundle

