### PR TITLE
fix(ios): allow detailed scriptPhases object in config

### DIFF
--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -51,7 +51,10 @@ Object {
       "configurations": Array [],
       "podspecPath": "<<REPLACED>>/node_modules/react-native-test/ReactNativeTest.podspec",
       "scriptPhases": Array [
-        "./abc",
+        Object {
+          "name": "abc",
+          "path": "./phase.sh",
+        },
       ],
     },
   },
@@ -68,7 +71,28 @@ Object {
       "configurations": Array [],
       "podspecPath": "<<REPLACED>>/node_modules/react-native-test/ReactNativeTest.podspec",
       "scriptPhases": Array [
-        "./customLocation/custom.sh",
+        Object {
+          "dependency_file": "/path/to/dependency/file",
+          "execution_position": "after_compile",
+          "input_file_lists": Array [
+            "input_file_1",
+            "input_file_2",
+          ],
+          "input_files": Array [
+            "input_file",
+          ],
+          "name": "[TEST] Some Configuration",
+          "output_file_lists": Array [
+            "output_file_1",
+            "output_file_2",
+          ],
+          "output_files": Array [
+            "output_file",
+          ],
+          "path": "./customLocation/custom.sh",
+          "shell_path": "some/shell/path/bash",
+          "show_env_vars_in_log": false,
+        },
       ],
     },
   },

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -146,7 +146,7 @@ test('should merge project configuration with default values', () => {
         "react-native-test": {
           platforms: {
             ios: {
-              scriptPhases: ["./abc"]
+              scriptPhases: [{name: "abc", path: "./phase.sh"}]
             }
           },
         }

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -97,7 +97,20 @@ test('should read a config of a dependency and use it to load other settings', (
       dependency: {
         platforms: {
           ios: {
-            scriptPhases: ["./customLocation/custom.sh"]
+            scriptPhases: [
+              {
+                name: "[TEST] Some Configuration",
+                path: "./customLocation/custom.sh",
+                execution_position: "after_compile",
+                input_files: ["input_file"],
+                shell_path: "some/shell/path/bash",
+                output_files: ["output_file"],
+                input_file_lists: ["input_file_1", "input_file_2"],
+                output_file_lists: ["output_file_1", "output_file_2"],
+                show_env_vars_in_log: false,
+                dependency_file: "/path/to/dependency/file"
+              }
+            ]
           }
         }
       }

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -123,7 +123,7 @@ export const projectConfig = t
               .object({
                 podspecPath: t.string(),
                 configurations: t.array().items(t.string()).default([]),
-                scriptPhases: t.array().items(t.object()),
+                scriptPhases: t.array().items(t.object()).default([]),
               })
               .allow(null),
             android: t

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -123,7 +123,35 @@ export const projectConfig = t
               .object({
                 podspecPath: t.string(),
                 configurations: t.array().items(t.string()).default([]),
-                scriptPhases: t.array().items(t.string()).default([]),
+                scriptPhases: t
+                  .array()
+                  .items(
+                    t.alternatives().try(
+                      t.string(),
+                      map(t.string(), t.any()).keys({
+                        name: t.string(),
+                        path: t.string(),
+                        execution_position: t
+                          .string()
+                          .valid('before_compile', 'after_compile', 'any')
+                          .allow(null),
+                        input_files: t.array().items(t.string()).allow(null),
+                        shell_path: t.string().allow(null),
+                        output_files: t.array().items(t.string()).allow(null),
+                        input_file_lists: t
+                          .array()
+                          .items(t.string())
+                          .allow(null),
+                        output_file_lists: t
+                          .array()
+                          .items(t.string())
+                          .allow(null),
+                        show_env_vars_in_log: t.bool().allow(null),
+                        dependency_file: t.string().allow(null),
+                      }),
+                    ),
+                  )
+                  .default([]),
               })
               .allow(null),
             android: t

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -69,7 +69,7 @@ export const dependencyConfig = t
             ios: t
               // IOSDependencyParams
               .object({
-                scriptPhases: t.array().items(t.string()),
+                scriptPhases: t.array().items(t.object()),
                 configurations: t.array().items(t.string()).default([]),
               })
               .default({}),
@@ -123,35 +123,7 @@ export const projectConfig = t
               .object({
                 podspecPath: t.string(),
                 configurations: t.array().items(t.string()).default([]),
-                scriptPhases: t
-                  .array()
-                  .items(
-                    t.alternatives().try(
-                      t.string(),
-                      map(t.string(), t.any()).keys({
-                        name: t.string(),
-                        path: t.string(),
-                        execution_position: t
-                          .string()
-                          .valid('before_compile', 'after_compile', 'any')
-                          .allow(null),
-                        input_files: t.array().items(t.string()).allow(null),
-                        shell_path: t.string().allow(null),
-                        output_files: t.array().items(t.string()).allow(null),
-                        input_file_lists: t
-                          .array()
-                          .items(t.string())
-                          .allow(null),
-                        output_file_lists: t
-                          .array()
-                          .items(t.string())
-                          .allow(null),
-                        show_env_vars_in_log: t.bool().allow(null),
-                        dependency_file: t.string().allow(null),
-                      }),
-                    ),
-                  )
-                  .default([]),
+                scriptPhases: t.array().items(t.object()),
               })
               .allow(null),
             android: t


### PR DESCRIPTION
align the joi schema for scriptPhases with the actually allowed values

Summary:
---------

react-native-firebase (and react-native-google-mobile-ads) use script phrases that are more than just strings, because we need to depend on the Info.plist file being generated from compilation to run the script

This worked in react-native <= 0.68 but is failing in 0.69.0-rc series

It appears that the validation has changed in the area from t.object to t.string, when it is t.object - our modules react-native-config.js files successfully validate and the modules are auto-linked, when it is t.string they are ignored.

However, if I alter it to t.object in schema.ts, then strings fail, so that's not right.

I attempted to do a joi alternatives with a full definition but I simply could **not** get the tests to work

So I need help to complete this, please, anyone :pray: as I'm out of time to work on it, but I'm certain I'm in the right area here and I *think* I've got the start of a real / fully specified solution

Test Plan:
----------

`yarn watch` and `yarn test --watch` was how I was developing

Here is an example of a module that used to work, and should work (and does work with t.object()):

https://github.com/invertase/react-native-firebase/blob/e861bea96b5b54cf56044cb390db539d07ad8f30/packages/app/react-native.config.js#L8-L14