### PR TITLE
fix: allow `dependency.platforms.[platform]` to be `null` again

### DIFF
--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -145,3 +145,14 @@ Object {
   "root": "<<REPLACED>>/node_modules/react-native-test",
 }
 `;
+
+exports[`supports disabling dependency for ios platform 1`] = `
+Object {
+  "name": "react-native-test",
+  "platforms": Object {
+    "android": null,
+    "ios": null,
+  },
+  "root": "<<REPLACED>>/node_modules/react-native-test",
+}
+`;

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -339,3 +339,32 @@ test('supports dependencies from user configuration with custom build type', () 
     removeString(dependencies['react-native-test'], DIR),
   ).toMatchSnapshot();
 });
+
+test('supports disabling dependency for ios platform', () => {
+  DIR = getTempDirectory('config_test_disable_dependency_platform');
+  writeFiles(DIR, {
+    ...REACT_NATIVE_MOCK,
+    'node_modules/react-native-test/package.json': '{}',
+    'node_modules/react-native-test/ReactNativeTest.podspec': '',
+    'node_modules/react-native-test/react-native.config.js': `
+      module.exports = {
+        dependency: {
+          platforms: {
+            ios: null
+          }
+        }
+      }
+    `,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1",
+        "react-native-test": "0.0.1"
+      }
+    }`,
+  });
+
+  const {dependencies} = loadConfig(DIR);
+  expect(
+    removeString(dependencies['react-native-test'], DIR),
+  ).toMatchSnapshot();
+});

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -72,7 +72,7 @@ export const dependencyConfig = t
                 scriptPhases: t.array().items(t.object()),
                 configurations: t.array().items(t.string()).default([]),
               })
-              .default({}),
+              .allow(null),
             android: t
               // AndroidDependencyParams
               .object({
@@ -87,7 +87,7 @@ export const dependencyConfig = t
                 componentDescriptors: t.array().items(t.string()).allow(null),
                 androidMkPath: t.string().allow(null),
               })
-              .default({}),
+              .allow(null),
           })
           .default(),
       })

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -80,8 +80,12 @@ function getAppName(sourceDir: string, userConfigAppName: string | undefined) {
  */
 export function dependencyConfig(
   root: string,
-  userConfig: AndroidDependencyParams = {},
+  userConfig: AndroidDependencyParams | null = {},
 ): AndroidDependencyConfig | null {
+  if (userConfig === null) {
+    return null;
+  }
+
   const src = userConfig.sourceDir || findAndroidDir(root);
 
   if (!src) {

--- a/packages/platform-ios/src/config/index.ts
+++ b/packages/platform-ios/src/config/index.ts
@@ -52,8 +52,12 @@ export function projectConfig(
 
 export function dependencyConfig(
   folder: string,
-  userConfig: IOSDependencyParams,
+  userConfig: IOSDependencyParams | null = {},
 ): IOSDependencyConfig | null {
+  if (userConfig === null) {
+    return null;
+  }
+
   const podspecPath = findPodspec(folder);
 
   if (!podspecPath) {


### PR DESCRIPTION
Summary:
---------

Resolves #1612.


Test Plan:
----------

1. Clone and check out the branch with a repro:
   ```
   git clone https://github.com/microsoft/react-native-test-app.git
   cd react-native-test-app
   git checkout tido/enable-turbomodule
   ```
2. Apply below diff to make `@react-native-community/cli` think that `react-native-test-app` has native modules to link:
   ```diff
   diff --git a/android/app/src/turbomodule/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt b/android/app/src/turbomodule/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
   index 2b02ad7..5ef4977 100644
   --- a/android/app/src/turbomodule/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
   +++ b/android/app/src/turbomodule/java/com/microsoft/reacttestapp/turbomodule/TurboModuleManagerDelegate.kt
   @@ -20,7 +20,7 @@ typealias ReactTurboModuleManagerDelegate = ReactPackageTurboModuleManagerDelega
     */
    class TurboModuleManagerDelegate protected constructor(
        reactApplicationContext: ReactApplicationContext?,
   -    packages: PackagesList?
   +    packages: List<ReactPackage?>?
    ) : ReactTurboModuleManagerDelegate(reactApplicationContext, packages) {
   
        protected external fun initHybrid(): HybridData?
   ```
3. Run `react-native config` and note that the output contains both Android and iOS modules:
   ```
   cd example
   yarn react-native config
   ```
4. Disable autolinking for Android:
   ```diff
   diff --git a/react-native.config.js b/react-native.config.js
   index 833fe69..be3e6c5 100644
   --- a/react-native.config.js
   +++ b/react-native.config.js
   @@ -102,6 +102,7 @@ module.exports = {
      ],
      dependency: {
        platforms: {
   +      android: null,
          windows: null,
        },
      },
   ```
5. Run `react-native config` and verify that the output only contains iOS modules
6. Disable autolinking for iOS:
   ```diff
   diff --git a/react-native.config.js b/react-native.config.js
   index 833fe69..be3e6c5 100644
   --- a/react-native.config.js
   +++ b/react-native.config.js
   @@ -102,6 +102,7 @@ module.exports = {
      ],
      dependency: {
        platforms: {
   -      android: null,
   +      ios: null,
          windows: null,
        },
      },
   ```
7. Run `react-native config` and verify that the output only contains Android modules
8. Disable autolinking for both Android and iOS:
   ```diff
   diff --git a/react-native.config.js b/react-native.config.js
   index 833fe69..be3e6c5 100644
   --- a/react-native.config.js
   +++ b/react-native.config.js
   @@ -102,6 +102,7 @@ module.exports = {
      ],
      dependency: {
        platforms: {
   +      android: null,
          ios: null,
          windows: null,
        },
      },
   ```
9. Run `react-native config` and verify that the output contains no native modules