### PR TITLE
fix(platform-android): `findComponentDescriptors` picks up directories

### DIFF
--- a/packages/platform-android/src/config/findComponentDescriptors.ts
+++ b/packages/platform-android/src/config/findComponentDescriptors.ts
@@ -4,7 +4,7 @@ import glob from 'glob';
 import {extractComponentDescriptors} from './extractComponentDescriptors';
 
 export function findComponentDescriptors(packageRoot: string) {
-  const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {cwd: packageRoot});
+  const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {cwd: packageRoot, nodir: true});
   const codegenComponent = files
     .map((filePath) =>
       fs.readFileSync(path.join(packageRoot, filePath), 'utf8'),

--- a/packages/platform-android/src/config/findComponentDescriptors.ts
+++ b/packages/platform-android/src/config/findComponentDescriptors.ts
@@ -4,7 +4,10 @@ import glob from 'glob';
 import {extractComponentDescriptors} from './extractComponentDescriptors';
 
 export function findComponentDescriptors(packageRoot: string) {
-  const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {cwd: packageRoot, nodir: true});
+  const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {
+    cwd: packageRoot,
+    nodir: true,
+  });
   const codegenComponent = files
     .map((filePath) =>
       fs.readFileSync(path.join(packageRoot, filePath), 'utf8'),


### PR DESCRIPTION
Summary:
---------

`findComponentDescriptors` may pick up directories, e.g. [decimal.js](https://www.npmjs.com/package/decimal.js),  and throw when trying to read it.

Test Plan:
----------

Add `decimal.js` as a dependency and run `react-native config`