### PR TITLE
refactor: url validation (http/https) before opening

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -21,6 +21,7 @@
     "@react-native-community/cli-types": "^9.0.0-alpha.0",
     "@types/lodash": "^4.14.149",
     "@types/mime": "^2.0.1",
+    "@types/node": "^17.0.35",
     "@types/node-fetch": "^2.5.5"
   },
   "files": [

--- a/packages/tools/src/isValidUrl.ts
+++ b/packages/tools/src/isValidUrl.ts
@@ -1,0 +1,23 @@
+/**
+ * Check if a string is an http/https url
+ */
+export default function isValidBrowserUrl(
+    url: string,
+): boolean {
+    try {
+        const _url = new URL(url);
+
+        const urlProtocol = _url.protocol;
+
+        const expectedProtocol = {
+            [urlProtocol]: false,
+            "http:": true,
+            "https:": true,
+        }
+
+        const isFromExpectedProtocol = expectedProtocol[urlProtocol];
+        return isFromExpectedProtocol;
+    } catch (error) {
+        return false
+    }
+}

--- a/packages/tools/src/isValidUrl.ts
+++ b/packages/tools/src/isValidUrl.ts
@@ -4,22 +4,18 @@
 export default function isValidBrowserUrl(
     url: string,
 ) {
-    try {
-        const _url = new URL(url);
+    const _url = new URL(url);
 
-        const urlProtocol = _url.protocol;
+    const urlProtocol = _url.protocol;
 
-        const expectedProtocol = {
-            [urlProtocol]: false,
-            "http:": true,
-            "https:": true,
-        }
-
-        const isFromExpectedProtocol = expectedProtocol[urlProtocol];
-
-        if (!isFromExpectedProtocol) throw new Error("invalid url, missing http/https protocol");
-
-    } catch (error) {
-        throw error;
+    const expectedProtocol = {
+        [urlProtocol]: false,
+        "http:": true,
+        "https:": true,
     }
+
+    const isFromExpectedProtocol = expectedProtocol[urlProtocol];
+
+    if (!isFromExpectedProtocol) throw new Error("invalid url, missing http/https protocol");
+
 }

--- a/packages/tools/src/isValidUrl.ts
+++ b/packages/tools/src/isValidUrl.ts
@@ -3,7 +3,7 @@
  */
 export default function isValidBrowserUrl(
     url: string,
-): boolean {
+) {
     try {
         const _url = new URL(url);
 
@@ -16,8 +16,10 @@ export default function isValidBrowserUrl(
         }
 
         const isFromExpectedProtocol = expectedProtocol[urlProtocol];
-        return isFromExpectedProtocol;
+
+        if (!isFromExpectedProtocol) throw new Error("invalid url, missing http/https protocol");
+
     } catch (error) {
-        return false
+        throw error;
     }
 }

--- a/packages/tools/src/launchDefaultBrowser.ts
+++ b/packages/tools/src/launchDefaultBrowser.ts
@@ -8,12 +8,12 @@
  */
 
 import open from 'open';
-import isValidBrowserUrl from './isValidUrl';
+import throwIfNonHttpProtocol from './throwIfNonHttpProtocol';
 import logger from './logger';
 
 async function launchDefaultBrowser(url: string) {
   try {
-    isValidBrowserUrl(url);
+    throwIfNonHttpProtocol(url);
 
     await open(url);
   } catch (err) {

--- a/packages/tools/src/launchDefaultBrowser.ts
+++ b/packages/tools/src/launchDefaultBrowser.ts
@@ -13,8 +13,7 @@ import logger from './logger';
 
 async function launchDefaultBrowser(url: string) {
   try {
-    const isSafeToOpenUrlInBrowser = isValidBrowserUrl(url);
-    if (!isSafeToOpenUrlInBrowser) throw new Error("invalid url, missing http/https protocol");
+    isValidBrowserUrl(url);
 
     await open(url);
   } catch (err) {

--- a/packages/tools/src/launchDefaultBrowser.ts
+++ b/packages/tools/src/launchDefaultBrowser.ts
@@ -8,10 +8,14 @@
  */
 
 import open from 'open';
+import isValidBrowserUrl from './isValidUrl';
 import logger from './logger';
 
 async function launchDefaultBrowser(url: string) {
   try {
+    const isSafeToOpenUrlInBrowser = isValidBrowserUrl(url);
+    if (!isSafeToOpenUrlInBrowser) throw new Error("invalid url, missing http/https protocol");
+
     await open(url);
   } catch (err) {
     if (err) {

--- a/packages/tools/src/throwIfNonHttpProtocol.ts
+++ b/packages/tools/src/throwIfNonHttpProtocol.ts
@@ -1,7 +1,7 @@
 /**
  * Check if a string is an http/https url
  */
-export default function isValidBrowserUrl(
+export default function throwIfNonHttpProtocol(
     url: string,
 ) {
     const _url = new URL(url);

--- a/packages/tools/src/throwIfNonHttpProtocol.ts
+++ b/packages/tools/src/throwIfNonHttpProtocol.ts
@@ -1,21 +1,20 @@
 /**
  * Check if a string is an http/https url
  */
-export default function throwIfNonHttpProtocol(
-    url: string,
-) {
-    const _url = new URL(url);
+export default function throwIfNonHttpProtocol(url: string) {
+  const _url = new URL(url);
 
-    const urlProtocol = _url.protocol;
+  const urlProtocol = _url.protocol;
 
-    const expectedProtocol = {
-        [urlProtocol]: false,
-        "http:": true,
-        "https:": true,
-    }
+  const expectedProtocol = {
+    [urlProtocol]: false,
+    'http:': true,
+    'https:': true,
+  };
 
-    const isFromExpectedProtocol = expectedProtocol[urlProtocol];
+  const isFromExpectedProtocol = expectedProtocol[urlProtocol];
 
-    if (!isFromExpectedProtocol) throw new Error("invalid url, missing http/https protocol");
-
+  if (!isFromExpectedProtocol) {
+    throw new Error('invalid url, missing http/https protocol');
+  }
 }


### PR DESCRIPTION
## Summary:
I've been curious about how rn cli handle app in debug mode interactions with IDE, 
I know that when you get some error in your app (e.g crash) when you are coding, you get an error message saying what line broke.. And that got me thinking.. how can the app open my IDE? and I came across this endpoint from cli package `cli-server-api`:
```
POST /open-url
```
#### In first sight i assumed it was HTTP and HTTPS only, but its not, turns out you can open any uri scheme.

To put this in perspective, if you have the cli-server-api running and someone inside your network wants your pc to open any uri scheme, they can though this endpoint. Especial thanks to @R3tr074 for investigating it further (poc)

#### POC:
```bash

curl --request POST \
  --url http://localhost:8081/open-url \
  --header 'Content-Type: application/json' \
  --data '{"url": "file:///etc/hosts"}'

```
Other uri schemes:
![image](https://user-images.githubusercontent.com/50163396/169915326-3365a45d-c6ba-4918-a383-58a8f666be29.png)
I've tested on linux and macOs, linux depends on how you set up your `xdg-open` config, and macOs uses the default `open` command;

<details><summary>You can see what uri schemes are available on MacOs using this command</summary>

```bash
lsregister -dump URLSchemeBinding;

# lsregister is available at: /System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister
```
</details>


## Test Plan:
I tested it with react-native change locally, and linking with my projects as previously recommended in contributing guide

Result:
![image](https://user-images.githubusercontent.com/50163396/169916290-30c6c0c2-5c46-4a88-9eda-d004e90e543e.png)
