### PR TITLE
fix(clean, cocoapods): clean spec cache + installed Pods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,11 +46,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
-          distribution: adopt
-          java-version: 8
-          cache: gradle
+          distribution: 'zulu'
+          java-version: 11
+          cache: 'gradle'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -107,12 +107,20 @@ export async function clean(
             description: 'CocoaPods cache',
             tasks: [
               {
-                label: 'Clean CocoaPods cache',
+                label: 'Clean CocoaPods pod cache',
                 action: async () => {
                   await execa('pod', ['cache', 'clean', '--all'], {
                     cwd: projectRoot,
                   });
                 },
+              },
+              {
+                label: 'Remove installed CocoaPods',
+                action: () => cleanDir('ios/Pods'),
+              },
+              {
+                label: 'Remove CocoaPods spec cache',
+                action: () => cleanDir('~/.cocoapods'),
               },
             ],
           },


### PR DESCRIPTION
Summary:
---------

I just saw that the CLI has a new clean command. That's fantastic!

Historically I steer people to https://github.com/pmadruga/react-native-clean-project but really it's basic functionality, glad to see it in the CLI.

I had a problem that I PRd to react-native-clean-project regarding cocoapods spec cache poisoning, and install / unpack failures, and they were solved by also cleaning `~/.cocoapods` and cleaning `ios/Pods` so I am PR'ing that here

I understand paths might be an issue but since we are inside an `os === darwin` conditional, the `~/` should be okay. I'm not sure about the `ios/` though and will happily take guidance


Test Plan:
----------

In practice for a long time, here: 

https://github.com/pmadruga/react-native-clean-project/blob/65c012ed0dcf4ea6786af867e8a7b1c1ee00be86/source/internals/tasks.js#L8-L22

```javascript
  wipeiOSPodsFolder: {
    name: 'wipe iOS Pods folder',
    command: 'rm',
    args: ['-rf', 'ios/Pods']
  },
  wipeSystemiOSPodsCache: {
    name: 'wipe system iOS Pods cache',
    command: 'cd ios & pod',
    args: ['cache', 'clean', '--all']
  },
  wipeUseriOSPodsCache: {
    name: 'wipe user iOS Pods cache',
    command: 'rm',
    args: ['-rf', '~/.cocoapods']
  },
```
