### PR TITLE
Better handle subdirectoried project on `upgrade`

### DIFF
--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -248,7 +248,8 @@ const applyPatch = async (
   tmpPatchFile: string,
   repoName: RepoNameType,
 ) => {
-  const defaultExcludes = ['package.json'];
+  const defaultExcludes = ['package.json', (process.env?.UPGRADE_PATCH_EXCLUDE || '').split(',')]
+    .map(e => `${relativePathFromRoot}${e}`);
   let filesThatDontExist: Array<string> = [];
   let filesThatFailedToApply: Array<string> = [];
 
@@ -273,6 +274,8 @@ const applyPatch = async (
         '-p2',
         '--3way',
         `--directory=${relativePathFromRoot}`,
+        '--whitespace',
+        'nowarn',
       ]);
       logger.info('Applying diff...');
     } catch (error) {
@@ -314,7 +317,7 @@ const applyPatch = async (
         ...defaultExcludes,
         ...filesThatDontExist,
         ...filesThatFailedToApply,
-      ].map((e) => `--exclude=${path.join(relativePathFromRoot, e)}`);
+      ].map((e) => `--exclude=${e}`);
       await execa('git', [
         'apply',
         tmpPatchFile,
@@ -322,6 +325,8 @@ const applyPatch = async (
         '-p2',
         '--3way',
         `--directory=${relativePathFromRoot}`,
+        '--whitespace',
+        'nowarn',
       ]);
     }
   } catch (error) {


### PR DESCRIPTION
Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/1622

Test Plan:
----------

Upgrade a RN project which is in a subdirectory of a repository, and has non-patchable files (e.g., they changed from the prior version's distributed copy.) Upgrade will fail to patch any files. This also adds an environment variable to further exclude files that might have been changed and will be in a dirty state (e.g., after `expo upgrade`.)
