### PR TITLE
[android] Do not import a linked Android.mk file if the library is not specifying a libraryName

### DIFF
--- a/packages/platform-android/native_modules.gradle
+++ b/packages/platform-android/native_modules.gradle
@@ -257,7 +257,11 @@ class ReactNativeModules {
 
     if (packages.size() > 0) {
       libraryIncludes = packages.collect {
-        it.androidMkPath ? "include ${it.androidMkPath}" : null
+        if (it.androidMkPath != null && it.libraryName != null) {
+          "include ${it.androidMkPath}"
+        } else {
+          null
+        }
       }.minus(null).join('\n')
       libraryModules = packages.collect {
         it.libraryName ? "${codegenLibPrefix}${it.libraryName}" : null


### PR DESCRIPTION
Summary:
---------

Given a `react-native config` that has the following setup:

```
{
  "dependencies": {
    "react-native-awesome-module": {
      "root": "/Users/ncor/git/react-native/template/node_modules/react-native-awesome-module",
      "name": "react-native-awesome-module",
      "platforms": {
        "android": {
          "sourceDir": "/Users/ncor/git/react-native/template/node_modules/react-native-awesome-module/android",
          "packageImportPath": "import com.reactnativeawesomemodule.AwesomeModulePackage;",
          "packageInstance": "new AwesomeModulePackage()",
          "buildTypes": [],
          "componentDescriptors": [],
          "androidMkPath": "/Users/ncor/git/react-native/template/node_modules/react-native-awesome-module/android/build/generated/source/codegen/jni/Android.mk"
        }
      }
    }
  },
```

(note that `libraryName` is missing), you should not import the `androidMkPath` as the file is not going to be present. It will cause a build failure at compile time.

Test Plan:
----------

I've tested this locally on my fork. Seems like there are no tests for this `.gradle` file so I'm unsure how to test this further.