### PR TITLE
Fix broken 'release' Github Action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 # Temporarily disable until issues resolved
-# on:
+on:
 #   release:
 #     types: [published]
+  workflow_dispatch:
 
 jobs:
   release:


### PR DESCRIPTION
Summary:
---------

Currently the `release` workflow is failing on forks as it's missing a `on` clause. I'm adding a manual trigger to it so it won't complain on every commit any contributor would push on their fork.


Test Plan:
----------
Tested on my fork. This was the failure: https://github.com/cortinico/cli/actions/runs/2559141563 

Now it's not happening anymore.