### PR TITLE
fix: broken link to changelog

### DIFF
--- a/packages/tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/tools/src/releaseChecker/printNewRelease.ts
@@ -14,8 +14,8 @@ export default function printNewRelease(
   logger.info(
     `React Native v${latestRelease.version} is now available (your project is running on v${currentVersion}).`,
   );
-  logger.info(`Changelog: ${chalk.dim.underline(latestRelease.changelogUrl)}.`);
-  logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}.`);
+  logger.info(`Changelog: ${chalk.dim.underline(latestRelease.changelogUrl)}`);
+  logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}`);
   logger.info(`To upgrade, run "${chalk.bold('react-native upgrade')}".`);
 
   cacheManager.set(name, 'lastChecked', new Date().toISOString());


### PR DESCRIPTION
Summary:
---------

When a new version available, the link to the Changelog is broken. But the reason is simple: the period at the end of the sentence is getting in the way.

Removing that dot ('.') works great!

fixes: #1632 

Test Plan:
----------

Being with react-native in an earlier version 0.69.0 the cli will display information that there is a new version. We will be able to click on the link to view the Changelog, without breaking! o/

Evidence:
----------

![image](https://user-images.githubusercontent.com/2224625/175788413-1247ee1e-b79f-4114-991a-c92006c0b33a.png)
