### PR TITLE
[android] Refine and test the findLibraryName function

### DIFF
--- a/packages/platform-android/src/config/__fixtures__/android.ts
+++ b/packages/platform-android/src/config/__fixtures__/android.ts
@@ -15,9 +15,13 @@ const manifest = fs.readFileSync(
 const mainJavaClass = fs.readFileSync(
   path.join(__dirname, './files/Main.java'),
 );
+const buildGradle = fs.readFileSync(
+  path.join(__dirname, './files/build.gradle'),
+);
 
 function generateValidFileStructure(classFileName: string) {
   return {
+    'build.gradle': buildGradle,
     src: {
       'AndroidManifest.xml': manifest,
       main: {

--- a/packages/platform-android/src/config/__fixtures__/files/build.gradle
+++ b/packages/platform-android/src/config/__fixtures__/files/build.gradle
@@ -1,0 +1,6 @@
+apply package: "com.android.application"
+apply package: "com.facebook.react"
+
+react {
+    libraryName = "justalibrary"
+}

--- a/packages/platform-android/src/config/__tests__/findLibraryName.test.ts
+++ b/packages/platform-android/src/config/__tests__/findLibraryName.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {findLibraryName} from '../findLibraryName';
+import * as mocks from '../__fixtures__/android';
+
+jest.mock('path');
+jest.mock('fs');
+
+const fs = require('fs');
+
+const buildGradleWithSingleQuotes = `
+  apply plugin: "com.android.application"
+  apply plugin: "com.facebook.react"
+
+  react {
+    libraryName = 'justalibrary'
+  }
+  `;
+
+const buildGradleKts = `
+  apply(id = "com.android.application")
+  apply(id = "com.facebook.react")
+
+  react {
+    libraryName.set("justalibrary")
+  }
+  `;
+
+const packageJsonWithCodegenConfig = `
+  {
+    "name": "my-awesome-library",
+    "version": "0.0.1",
+    "codegenConfig": {
+      "name": "my-awesome-library"
+    }
+  }
+  `;
+
+describe('android::findLibraryName', () => {
+  beforeAll(() => {
+    fs.__setMockFilesystem({
+      empty: {},
+      valid: {
+        android: mocks.valid,
+        singlequotes: {
+          'build.gradle': buildGradleWithSingleQuotes,
+        },
+        gradlekts: {
+          'build.gradle.kts': buildGradleKts,
+        },
+        withcodegenconfig: {
+          'package.json': packageJsonWithCodegenConfig,
+          android: {
+            'build.gradle': buildGradleWithSingleQuotes,
+          },
+        },
+      },
+    });
+  });
+
+  it('returns the library name if declared in the build.gradle file', () => {
+    expect(findLibraryName('/', '/valid/android')).toBe('justalibrary');
+  });
+
+  it('returns the library name if declared with single quotes in the build.gradle file', () => {
+    expect(findLibraryName('/', '/valid/singlequotes')).toBe('justalibrary');
+  });
+
+  it('returns the library name if declared with inside a build.gradle.kts file', () => {
+    expect(findLibraryName('/', '/valid/singlequotes')).toBe('justalibrary');
+  });
+
+  it('returns the library name if defined inside codegenConfig', () => {
+    expect(
+      findLibraryName(
+        '/valid/withcodegenconfig',
+        '/valid/withcodegenconfig/android',
+      ),
+    ).toBe('my-awesome-library');
+  });
+
+  it('returns null if there is no build.gradle file', () => {
+    expect(findLibraryName('/', '/empty')).toBeUndefined();
+  });
+});

--- a/packages/platform-android/src/config/findLibraryName.ts
+++ b/packages/platform-android/src/config/findLibraryName.ts
@@ -1,14 +1,34 @@
 import fs from 'fs';
 import path from 'path';
 
-export function findLibraryName(sourceDir: string) {
+export function findLibraryName(root: string, sourceDir: string) {
+  const packageJsonPath = path.join(root, 'package.json');
   const buildGradlePath = path.join(sourceDir, 'build.gradle');
-  if (fs.existsSync(buildGradlePath)) {
-    const buildGradleContents = fs.readFileSync(buildGradlePath, 'utf-8');
-    const match = buildGradleContents.match(/libraryName = "(.+)"/);
-    if (match) {
-      return match[1];
+  const buildGradleKtsPath = path.join(sourceDir, 'build.gradle.kts');
+
+  // We first check if there is a codegenConfig.name inside the package.json file.
+  if (fs.existsSync(packageJsonPath)) {
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    if (packageJson.codegenConfig.name) {
+      return packageJson.codegenConfig.name;
     }
   }
-  return undefined;
+
+  // If not, we check if the library specified it in the build.gradle file.
+  let buildGradleContents = '';
+  if (fs.existsSync(buildGradlePath)) {
+    buildGradleContents = fs.readFileSync(buildGradlePath, 'utf-8');
+  } else if (fs.existsSync(buildGradleKtsPath)) {
+    buildGradleContents = fs.readFileSync(buildGradleKtsPath, 'utf-8');
+  } else {
+    return undefined;
+  }
+
+  const match = buildGradleContents.match(/libraryName = ["'](.+)["']/);
+
+  if (match) {
+    return match[1];
+  } else {
+    return undefined;
+  }
 }

--- a/packages/platform-android/src/config/index.ts
+++ b/packages/platform-android/src/config/index.ts
@@ -120,7 +120,8 @@ export function dependencyConfig(
 
   const buildTypes = userConfig.buildTypes || [];
   const dependencyConfiguration = userConfig.dependencyConfiguration;
-  const libraryName = userConfig.libraryName || findLibraryName(sourceDir);
+  const libraryName =
+    userConfig.libraryName || findLibraryName(root, sourceDir);
   const componentDescriptors =
     userConfig.componentDescriptors || findComponentDescriptors(root);
   const androidMkPath = userConfig.androidMkPath


### PR DESCRIPTION
Summary:
---------

Here I'm extending the `findLibraryName` function to do the following:
1. Account for `codegenConfig.name` in the package.json in the root (if available)
2. Handle both single and double quotes in build.gradle files
3. Handle libraries using build.gradle.kts files.

This implements the remaining points listed here https://github.com/facebook/react-native/pull/33777#issuecomment-1165104204

Test Plan:
----------

I've wrote a small test suite for `findLibraryName` as it was empty.