### PR TITLE
fix: schema validation errors disguised as warnings

### DIFF
--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -53,7 +53,7 @@ export async function runUntil(
     ...options,
   });
 
-  spawnPromise.stderr.pipe(
+  spawnPromise.stderr?.pipe(
     new Writable({
       write(chunk: any, _encoding: string, callback: () => void) {
         const output = chunk.toString('utf8');

--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -62,6 +62,18 @@ Object {
 }
 `;
 
+exports[`should not skip packages that have invalid configuration (to avoid breaking users): dependencies config 1`] = `
+Object {
+  "react-native": Object {
+    "name": "react-native",
+    "platforms": Object {},
+    "root": "<<REPLACED>>/node_modules/react-native",
+  },
+}
+`;
+
+exports[`should not skip packages that have invalid configuration (to avoid breaking users): logged warning 1`] = `"warn Package react-native contains invalid configuration: \\"dependency.invalidProperty\\" is not allowed. Please verify it's properly linked using \\"react-native config\\" command and contact the package maintainers about this."`;
+
 exports[`should read a config of a dependency and use it to load other settings 1`] = `
 Object {
   "name": "react-native-test",
@@ -124,10 +136,6 @@ Object {
   },
 }
 `;
-
-exports[`should skip packages that have invalid configuration: dependencies config 1`] = `Object {}`;
-
-exports[`should skip packages that have invalid configuration: logged warning 1`] = `"warn Package react-native has been ignored because it contains invalid configuration. Reason: \\"dependency.invalidProperty\\" is not allowed"`;
 
 exports[`supports dependencies from user configuration with custom build type 1`] = `
 Object {

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -191,7 +191,7 @@ test('should load commands from "react-native-foo" and "react-native-bar" packag
   expect(commands).toMatchSnapshot();
 });
 
-test('should skip packages that have invalid configuration', () => {
+test('should not skip packages that have invalid configuration (to avoid breaking users)', () => {
   process.env.FORCE_COLOR = '0'; // To disable chalk
   DIR = getTempDirectory('config_test_skip');
   writeFiles(DIR, {
@@ -208,7 +208,9 @@ test('should skip packages that have invalid configuration', () => {
     }`,
   });
   const {dependencies} = loadConfig(DIR);
-  expect(dependencies).toMatchSnapshot('dependencies config');
+  expect(removeString(dependencies, DIR)).toMatchSnapshot(
+    'dependencies config',
+  );
   expect(spy.mock.calls[0][0]).toMatchSnapshot('logged warning');
 });
 

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import chalk from 'chalk';
 import {
   UserDependencyConfig,
   ProjectConfig,
@@ -8,8 +7,6 @@ import {
   Config,
 } from '@react-native-community/cli-types';
 import {
-  logger,
-  inlineString,
   findProjectRoot,
   resolveNodeModuleDir,
 } from '@react-native-community/cli-tools';
@@ -101,24 +98,9 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
     const localDependencyRoot =
       userConfig.dependencies[dependencyName] &&
       userConfig.dependencies[dependencyName].root;
-    let root: string;
-    let config: UserDependencyConfig;
-    try {
-      root =
-        localDependencyRoot ||
-        resolveNodeModuleDir(projectRoot, dependencyName);
-      config = readDependencyConfigFromDisk(root);
-    } catch (error) {
-      logger.warn(
-        inlineString(`
-          Package ${chalk.bold(
-            dependencyName,
-          )} has been ignored because it contains invalid configuration.
-
-          Reason: ${chalk.dim(error.message)}`),
-      );
-      return acc;
-    }
+    let root =
+      localDependencyRoot || resolveNodeModuleDir(projectRoot, dependencyName);
+    let config = readDependencyConfigFromDisk(root, dependencyName);
 
     const isPlatform = Object.keys(config.platforms).length > 0;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2616,7 +2616,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@^12.0.0":
+"@types/node@*", "@types/node@^12.0.0", "@types/node@^17.0.35":
   version "12.20.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.47.tgz#ca9237d51f2a2557419688511dab1c8daf475188"
   integrity sha512-BzcaRsnFuznzOItW1WpQrDHM7plAa7GIDMZ6b5pnMbkqEtM/6WCOhvZar39oeMQP79gwvFUWjjptE7/KGcNqFg==


### PR DESCRIPTION
Summary:
---------

When Joi validates the schema, it will abort early and thus prevent us from constructing the rest of the configuration, which might be correct. In such case the CLI would emit a warning that configuration for a certain package was invalid. However what this warning wouldn't tell is that the library failed to autolink completely. 

This PR changes the Joi validation to not abort early and make warnings what they really are, without preventing the schema object to be created. 

This caused issues like this one: https://github.com/reactwg/react-native-releases/discussions/23 

Test Plan:
----------

Adjusted the wording of the warning:

<img width="752" alt="image" src="https://user-images.githubusercontent.com/5106466/177827935-c751e2c1-798c-44a6-8944-249953537f88.png">