### PR TITLE
Ignore case in validatePackageName

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/getAndroidProject.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getAndroidProject.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {validatePackageName} from '../getAndroidProject';
+
+describe('android::getAndroidProject', () => {
+  const expectedResults = {
+    'com.app': true,
+    'com.example.app': true,
+    'com.my_app': true,
+    'org.my_app3': true,
+    'com.App': true,
+    'com.Example.APP1': true,
+    'COM.EXAMPLE.APP': true,
+    '': false,
+    com: false,
+    'com.3example.app': false,
+    'com.my_app*': false,
+    'org.my-app3': false,
+    'com.App ': false,
+    'com.Example.APP#1': false,
+  };
+
+  Object.keys(expectedResults).forEach((packageName) => {
+    it(`should validate package name "${packageName}" correctly`, () => {
+      expect(validatePackageName(packageName)).toBe(
+        expectedResults[packageName],
+      );
+    });
+  });
+});

--- a/packages/cli-platform-android/src/config/getAndroidProject.ts
+++ b/packages/cli-platform-android/src/config/getAndroidProject.ts
@@ -48,5 +48,5 @@ export function getPackageName(manifestPath: string) {
 
 // Validates that the package name is correct
 function validatePackageName(packageName: string) {
-  return /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/.test(packageName);
+  return /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/i.test(packageName);
 }

--- a/packages/cli-platform-android/src/config/getAndroidProject.ts
+++ b/packages/cli-platform-android/src/config/getAndroidProject.ts
@@ -47,6 +47,6 @@ export function getPackageName(manifestPath: string) {
 }
 
 // Validates that the package name is correct
-function validatePackageName(packageName: string) {
+export function validatePackageName(packageName: string) {
   return /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/i.test(packageName);
 }


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

Currently `validatePackageName` fails for package names containing uppercase letters. A message like this is shown during pod install:
```
warn Invalid application's package name "com.lugg.ReactNativeConfig" in 'AndroidManifest.xml'. Read guidelines for setting the package name here: https://developer.android.com/studio/build/application-id
warn Invalid application's package name "com.BV.LinearGradient" in 'AndroidManifest.xml'. Read guidelines for setting the package name here: https://developer.android.com/studio/build/application-id
warn Invalid application's package name "com.lugg.ReactNativeConfig" in 'AndroidManifest.xml'. Read guidelines for setting the package name here: https://developer.android.com/studio/build/application-id
warn Invalid application's package name "com.BV.LinearGradient" in 'AndroidManifest.xml'. Read guidelines for setting the package name here: https://developer.android.com/studio/build/application-id
```
 However both the package name (https://developer.android.com/guide/topics/manifest/manifest-element.html#package) and the application id (https://developer.android.com/studio/build/application-id) are allowed to contain upper case letters.

![Screenshot 2022-07-28 at 14 29 33](https://user-images.githubusercontent.com/4928274/181500894-3b9f0ff2-c19c-4838-87a1-48ea414a05c0.png)
![Screenshot 2022-07-28 at 14 29 58](https://user-images.githubusercontent.com/4928274/181500912-a9d38327-5da2-43a7-8d1a-fde934f5ad2b.png)

This change adds the "i" flag to the regex to ignore case when validating package name.

Related issue: https://github.com/facebook/react-native/issues/34247


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I verified in browser console that the updated regex works correctly:
![Screenshot 2022-07-28 at 15 05 24](https://user-images.githubusercontent.com/4928274/181500847-c6e7db61-5a8f-4c5a-bfd9-64f1276dad09.png)

