### PR TITLE
[android] Do not separate autolinked libraries with \ on CMake

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -310,7 +310,7 @@ class ReactNativeModules {
       }.minus(null).join('\n')
       libraryModules = packages.collect {
         it.libraryName ? "${codegenLibPrefix}${it.libraryName}" : null
-      }.minus(null).join(" \\\n  ")
+      }.minus(null).join('\n  ')
     }
 
     String generatedFileContents = generatedFileContentsTemplate


### PR DESCRIPTION
Summary:
---------

Autolinking for New Architecture, on Android, with CMake, with more than 1 library is currently broken. The reason is that the library list is separated by `\` (as it was supposed to be for Android.mk) that are not a valid char for CMake (see https://cmake.org/cmake/help/latest/manual/cmake-language.7.html#cmake-language-lists for reference).

Test Plan:
----------

I've tested this against https://github.com/react-native-community/RNNewArchitectureApp.

Before:

```cmake
# This code was generated by [React Native CLI](https://www.npmjs.com/package/@react-native-community/cli)

cmake_minimum_required(VERSION 3.13)
set(CMAKE_VERBOSE_MAKEFILE on)

add_subdirectory(/Users/ncor/pg/RNNewArchitectureApp/AwesomeApp/node_modules/calculator/android/build/generated/source/codegen/jni/ calculator_autolinked_build)
add_subdirectory(/Users/ncor/pg/RNNewArchitectureApp/AwesomeApp/node_modules/centered-text/android/build/generated/source/codegen/jni/ centeredtext_autolinked_build)

set(AUTOLINKED_LIBRARIES
  react_codegen_calculator \
  react_codegen_centeredtext
)
```

After:

```cmake
# This code was generated by [React Native CLI](https://www.npmjs.com/package/@react-native-community/cli)

cmake_minimum_required(VERSION 3.13)
set(CMAKE_VERBOSE_MAKEFILE on)

add_subdirectory(/Users/ncor/pg/RNNewArchitectureApp/AwesomeApp/node_modules/calculator/android/build/generated/source/codegen/jni/ calculator_autolinked_build)
add_subdirectory(/Users/ncor/pg/RNNewArchitectureApp/AwesomeApp/node_modules/centered-text/android/build/generated/source/codegen/jni/ centeredtext_autolinked_build)

set(AUTOLINKED_LIBRARIES
  react_codegen_calculator
  react_codegen_centeredtext
)
```