### PR TITLE
breaking: Upgrade metro dependencies to 0.72.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jest-circus": "^26.6.2",
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^4.0.0",
-    "metro-memory-fs": "^0.71.3",
+    "metro-memory-fs": "^0.72.0",
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "slash": "^3.0.0",

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -10,12 +10,12 @@
     "@react-native-community/cli-server-api": "^9.0.0-alpha.6",
     "@react-native-community/cli-tools": "^9.0.0-alpha.6",
     "chalk": "^4.1.2",
-    "metro": "^0.71.3",
-    "metro-config": "^0.71.3",
-    "metro-core": "^0.71.3",
-    "metro-react-native-babel-transformer": "^0.71.3",
-    "metro-resolver": "^0.71.3",
-    "metro-runtime": "^0.71.3",
+    "metro": "^0.72.0",
+    "metro-config": "^0.72.0",
+    "metro-core": "^0.72.0",
+    "metro-react-native-babel-transformer": "^0.72.0",
+    "metro-resolver": "^0.72.0",
+    "metro-runtime": "^0.72.0",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8096,53 +8096,53 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.71.3.tgz#ca55850cc904178b740be123b77b58e81f156e4f"
-  integrity sha512-zsbD8MurKherTtwKY3To/dVNKCkPojX//apetyeVrAkJ7M9dw4+hqoglP3SraOlrL3jm/ufFPRZwC2Pr8V9ZQQ==
+metro-babel-transformer@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.72.0.tgz#18a425865fcdc817363e0982f6d1e3f6a1f8ee74"
+  integrity sha512-bezw+WQo7S+XmOqlIQ699TVWhTrHAEVtOZdK1JQeBTlxE4dvFu5xl8G2xYOvcmlE3UFbFZVjxD1kwKxRuFk0vQ==
   dependencies:
     "@babel/core" "^7.14.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.71.3"
+    metro-source-map "0.72.0"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.71.3.tgz#1f9a22476ff9ba717b296e2bcf0920ab371fab71"
-  integrity sha512-V7ZJaQgzsgDBlr3AjEj10UE1rnIxkiLx5StZfwwoVZ2PBe2ZWgG0yGq2dvyRtpC/8FLc/cIFbUVteLrDs1V/mg==
+metro-cache-key@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.72.0.tgz#347eebbe5a7b806f675e52890722ab1b88c953d9"
+  integrity sha512-zoZ2SXzjJeXkwGikx2V97r7D/yo6rZOdM9iARKugj+Dk+9W+VdehiGNnmIwKmbIudCWulWOpWkJOeygeUkTfIw==
 
-metro-cache@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.71.3.tgz#992ce0c609306025e36a7d05ed7f8a04c1e517a9"
-  integrity sha512-B7rHnbRnwCFpNPp//zqCpDpbLeb7NSOdFlLYGyADFbU/Bu35GlAmdf4q/PNLeDdbcLkvZaWelKMDXYWeCAn6FQ==
+metro-cache@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.72.0.tgz#423e38d9c45b815ff1ef2800a60f5a3c1bc333b0"
+  integrity sha512-Ui7qilKLjDMdc+IlkyhQXQ0wVAz9ji6qAyUC6q6WUkEyo9fp3j1Bv2c7MogXeGoRLkfw0YGXa3DFqZG8vBNDbg==
   dependencies:
-    metro-core "0.71.3"
+    metro-core "0.72.0"
     rimraf "^2.5.4"
 
-metro-config@0.71.3, metro-config@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.71.3.tgz#f876f96398fb8063a04adf68890c01f393d8b7b2"
-  integrity sha512-RLedw7x5GLSsDSkG2WQ59LDcna69C51/f086Ksr+Ey6fRZEjcdjzHs3dtZeJyiCylKwZL9ofr1OYrFixb/mHsg==
+metro-config@0.72.0, metro-config@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.72.0.tgz#c027dc429d1750a6d44033fb2f5bf11c0cc4df4c"
+  integrity sha512-hdJUbASzO/zPo6Ip9s7FH+nnWhEqPc610xzQUBjP5PZlpfl4sOqTn+cpmy2fk1LdMV8x4Wr6y6lsEJI+pbVDKA==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.71.3"
-    metro-cache "0.71.3"
-    metro-core "0.71.3"
-    metro-runtime "0.71.3"
+    metro "0.72.0"
+    metro-cache "0.72.0"
+    metro-core "0.72.0"
+    metro-runtime "0.72.0"
 
-metro-core@0.71.3, metro-core@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.71.3.tgz#5ffe3c4ab20c6a40d12746a538ef34e6d7ba1046"
-  integrity sha512-/c1X4+jsr2uxqN1p87gcwyd073apsQAy76zeD5ihDTF05IHLN6z407JuFZWi+WKhReFmdipXTjAoqzd3GZ+PwA==
+metro-core@0.72.0, metro-core@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.72.0.tgz#1eb6cdde21293a7bd7a188c419780180004e9925"
+  integrity sha512-MeEdRBl1OQxUukI2VBAOFjUl4hU2Ll9+I72WGX1mz9qqCrslJ7++4tEmnTplbLaYBSPb0PSH3+zC073aL1yeRg==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.71.3"
+    metro-resolver "0.72.0"
 
-metro-file-map@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.71.3.tgz#6ea153574f259e84ee426240897c3764502e6acd"
-  integrity sha512-a4DlTkCoQsPtzMMVxsrEt0DC3/Ga+NaXueHqdGuCsY5rzjSoWDiyAdscuWjFKLSPaoPacBQpZgSo4MhjBSPYng==
+metro-file-map@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.72.0.tgz#943f068f0cefe70d37d9fda13dd21ec94fdecf2e"
+  integrity sha512-bKkwgrrGOlGtdhuYqqdaiiNH7dRKLDgNNgVps9uOBqpJMX/d8/f+4uurRAFSZeRcJGZ1bu7ljvFg9+8xYZlKig==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -8159,37 +8159,37 @@ metro-file-map@0.71.3:
   optionalDependencies:
     fsevents "^2.1.2"
 
-metro-hermes-compiler@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.71.3.tgz#1b4c6b84e46e346b0def829493468a7577e5ee01"
-  integrity sha512-gqZSdUfzwcftXNwCFf/HiZhMMM7pAWQ2jMnLzIEINAp5qPxnIONvqJd5/yTnVzDjAf3kG9k1Pzt6NEsKQzuYIA==
+metro-hermes-compiler@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.72.0.tgz#b754df502e48c02c9523b92ef1ed5e19b1d94921"
+  integrity sha512-QkY8rHFKhjVlrrxB2FEj8bGzYVHNTOx/IENSlKx3PxlchFMGCG8fxVgzB8u5VyIW610hKd5d+Ux2pXldtm/vSA==
 
-metro-inspector-proxy@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.71.3.tgz#616ba731719ac80400b9374c592b398a28af8e40"
-  integrity sha512-HbM2GBXcAWKtnysw8j+pK/hv20Gx6LT3lFkIr+hsIG+ejaGkOpUYAV3EBrfDuQ4bM4F8yvIT4ZWjD2Zvcm1f5Q==
+metro-inspector-proxy@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.72.0.tgz#a0cb144af9cce828731d2fccde143e0fd4e42286"
+  integrity sha512-GIToyQr9xkap/ayt1MVMCU7/ZecVsPrCqOjL58TgXfE/5L7wF87p+mPy8nqceHAqgajCukfQC4n5McwxFEp4KA==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
     ws "^7.5.1"
     yargs "^15.3.1"
 
-metro-memory-fs@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.71.3.tgz#3e2f5925828df7b4444329c643564bff3a4b824b"
-  integrity sha512-j+om4EqSDkXOGLuH9pnogPBeyJ6pJCZ7uedBIGw0v2YtanJc87ytkKIZDqOdU5SF12khaOvSwa13xRlmr+pZJQ==
+metro-memory-fs@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.72.0.tgz#ddf4d5c13d6eafb30bbfa2ae8282ad671adde351"
+  integrity sha512-jp5G/N3iozgA1tRIzBZVJbd5p9GGHMo+WKpHp75n439qaZ7OG4uakTFp/WMVVEm0EEkOmZyKt00NxZvB5bxz2g==
 
-metro-minify-uglify@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.71.3.tgz#cb5cc716e98dcf7fa1e261de2a7232de25e377e9"
-  integrity sha512-sV5IVePaqJQ1Nypf5fCJOtUtYLtZCcfcOTZvbcD1lkDTw8jZnNsTWd9s61lYg2ppXoUQu+QXfirGJI917c7bUw==
+metro-minify-uglify@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.72.0.tgz#1a4a0f1734c841771f60aa5664b27d922dc69ba8"
+  integrity sha512-3NtBGA1w9+9524bTCvsRajq+YqEw/p/MQTeZ1746Qs8QjtrvXgxGlCeRvH/6yhQpss+LnXmiPO60Ql9YvT8yYw==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.71.3.tgz#8e30b87c39342d9ffb4ccc619e7790ac60e16929"
-  integrity sha512-ym8xeoK/5fY/TsQPQXVnJN822NB9TZglxc2XVk+DM8kJO0XacWh2GtDRFeFHEehVsYWpIZeaDPF2XES+YU5mhA==
+metro-react-native-babel-preset@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.72.0.tgz#7cbb0fa9cc918aca372c40791291f159e7cd2d36"
+  integrity sha512-AcS5X/eacckVj6oX8G0/KT4Q9+PsZoUchTe5xnBimHAJ1ZjOhjnHSkdAM7+MHRQlp4L63pCSp0/bsJoDbF6X1g==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -8231,63 +8231,63 @@ metro-react-native-babel-preset@0.71.3:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.71.3.tgz#7725cecffedf542fdb379fe59c1e19cf1d0f97b8"
-  integrity sha512-DTRIldy5Dt4/+YN9DXg+9ltyk1VPZkT0d8XERQ6Ln4/uwmeEUpc1MeaA72Te9TkpznCQElAR0vhupdoaHkPcoQ==
+metro-react-native-babel-transformer@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.72.0.tgz#5f6ae8454646d735cda57ccd2dbb7b0d692d5234"
+  integrity sha512-DsZPRgS/QOQDhAVzchGLa/luAiE2UDaIzVRLFfwT1zRUdryWqaaJO8JK+oGVDpdxoqi3qV7sHu/4WzkL7wvwbA==
   dependencies:
     "@babel/core" "^7.14.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.71.3"
-    metro-react-native-babel-preset "0.71.3"
-    metro-source-map "0.71.3"
+    metro-babel-transformer "0.72.0"
+    metro-react-native-babel-preset "0.72.0"
+    metro-source-map "0.72.0"
     nullthrows "^1.1.1"
 
-metro-resolver@0.71.3, metro-resolver@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.71.3.tgz#af58030209ff6176816684124c18a9250116cdb1"
-  integrity sha512-VeNlDVUZAKejtpV9ruZ3ivydhC2UtL6ZffYxAn1G6sPsW+B/lTywYigx32pY0xBkfkDnzul6bKOiKNe9LKW1uQ==
+metro-resolver@0.72.0, metro-resolver@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.72.0.tgz#a0877267a16ab3fdd730a5bcabde08c8f437e108"
+  integrity sha512-aQ3ILLFs6e7lju60WVhU3lxROJ+fZluiOncqLq0o0QECCnrEbWQTRVMQmDTpq5cI/w7k6tSbNMhlUzPPLFI5Uw==
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.71.3, metro-runtime@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.71.3.tgz#e17a3100bb61e7ea66d38f1dcaa971357572b59d"
-  integrity sha512-1l7YYYY64wdphvPOUA3NDHVoYxuV6SEn8O6/WGGEqGj/M0focrue1ra3caoCPDUOJFWgHxh6FVaAXXTOltjNwg==
+metro-runtime@0.72.0, metro-runtime@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.72.0.tgz#f72b158fc5072a83b6274d6eae1db41fb065d77e"
+  integrity sha512-ZY372filZa8KApndcC2MuuObUufW8A4UEYHaKv6onIT0maCX2mzNGaDIiOXs6i5gHjb801qaR0a3UqCVxhGgeQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
 
-metro-source-map@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.71.3.tgz#ffbb21d3ab5a137234bcf225336283e7e669ee0b"
-  integrity sha512-rMwDrYWFSC/J71N0XT8c/hf0q1tfvwNi8Tqa7lCCxmF0HUoPZSocY2lp7IcdZaxckpm++Nrrdc+D/jsG1JD5oQ==
+metro-source-map@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.72.0.tgz#1f15e838a81060573a0d0011a726001a9a08ad29"
+  integrity sha512-uLeyQu2pyW9IlelWX1CJx4PfGYZTbKHKQ8NVFutv+j299UgUvcav+zUG7mvqrYZH4JX4YbnnD9ppqOxiFuq1IA==
   dependencies:
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.0.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.71.3"
+    metro-symbolicate "0.72.0"
     nullthrows "^1.1.1"
-    ob1 "0.71.3"
+    ob1 "0.72.0"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.71.3.tgz#ba02b87742d2bed8e9a5a4cc0146ca8f6645c20b"
-  integrity sha512-fvcI9/1aSRviWnEGSrEVFYDS26r38PwLwKWpSl1GqEtwE6fgwlMeZKQbj+BIGYRSHXU48pIA/kJZc88oB4pjJA==
+metro-symbolicate@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.72.0.tgz#ca46943d522cef8123735b71fb81b57cc867c48f"
+  integrity sha512-+sTL57kzRVnYdNfjaGbNCO0RLQowGN+U5bpkhOcB6Ax7Dn+9vLVwLaBMSNQIBfiua1a88Z4GFRvFiPNHR8hYKw==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.71.3"
+    metro-source-map "0.72.0"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.71.3.tgz#25798db10459533b497a66e3be0d01a0d6b731ff"
-  integrity sha512-Z4XeaGD0obC3dHIlLA4w7DW5enczLD1OfxUaCM92W+yYIhqn2SJDw6yzaj7CV0AWzeOxRF9itkvQHdy3X+/6Yg==
+metro-transform-plugins@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.72.0.tgz#d495c6a535da33d986430dc0ef6eee7549dbe47b"
+  integrity sha512-IV7znwPOKusmfRbZi/TLUrdJqQTZBaufNZJ+evW+yM7Vjy4mGHy1GDlgOkGiMjzjIqB8yFSNh1oVo3q7LJlxlA==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
@@ -8295,29 +8295,29 @@ metro-transform-plugins@0.71.3:
     "@babel/traverse" "^7.14.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.71.3.tgz#474fa6f544891366f991a28b70d4f72f1de1cbd4"
-  integrity sha512-riaDvCfWRgkl0Cy2VUqGZOwzONQ7oqVg6UmgG1vhnTpGC3xJFXVV6np1pDLTHjlMFu4xjnb7zZxHm8emX6C4JQ==
+metro-transform-worker@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.72.0.tgz#3b9dd519b6383b32ea82e3deeb2229de2aa25fe5"
+  integrity sha512-QUFXeU4R4xgLkxczZUmI63XHbu418YlEh2km1c2vUwuDpEYvKndBi15tlwBkXU5uaWWqUVA59FnJdccExWtD8Q==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
     "@babel/parser" "^7.14.0"
     "@babel/types" "^7.0.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.71.3"
-    metro-babel-transformer "0.71.3"
-    metro-cache "0.71.3"
-    metro-cache-key "0.71.3"
-    metro-hermes-compiler "0.71.3"
-    metro-source-map "0.71.3"
-    metro-transform-plugins "0.71.3"
+    metro "0.72.0"
+    metro-babel-transformer "0.72.0"
+    metro-cache "0.72.0"
+    metro-cache-key "0.72.0"
+    metro-hermes-compiler "0.72.0"
+    metro-source-map "0.72.0"
+    metro-transform-plugins "0.72.0"
     nullthrows "^1.1.1"
 
-metro@0.71.3, metro@^0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.71.3.tgz#3e3c90d4e7d5b3f957df5fb7784d79a3b5a56c66"
-  integrity sha512-1Rig6w7othfDHAQXsGTpUTYdKhYBJDgmCWmdD1WVLv1DaW6tqxTM1DPPi1L5x6w33LdPUjAANT3nwJp5Ki81tg==
+metro@0.72.0, metro@^0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.72.0.tgz#6b7d536b28a36422bffa4e815fd27224df0273c6"
+  integrity sha512-LyZfgtAHkxtXBU99SBeN06UfnZyE1pcmEw7fkslZvFS2DXe30WeRosPvy/5uVgeD9du2y62Q3T7H73qRepJggQ==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.14.0"
@@ -8342,22 +8342,22 @@ metro@0.71.3, metro@^0.71.3:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.71.3"
-    metro-cache "0.71.3"
-    metro-cache-key "0.71.3"
-    metro-config "0.71.3"
-    metro-core "0.71.3"
-    metro-file-map "0.71.3"
-    metro-hermes-compiler "0.71.3"
-    metro-inspector-proxy "0.71.3"
-    metro-minify-uglify "0.71.3"
-    metro-react-native-babel-preset "0.71.3"
-    metro-resolver "0.71.3"
-    metro-runtime "0.71.3"
-    metro-source-map "0.71.3"
-    metro-symbolicate "0.71.3"
-    metro-transform-plugins "0.71.3"
-    metro-transform-worker "0.71.3"
+    metro-babel-transformer "0.72.0"
+    metro-cache "0.72.0"
+    metro-cache-key "0.72.0"
+    metro-config "0.72.0"
+    metro-core "0.72.0"
+    metro-file-map "0.72.0"
+    metro-hermes-compiler "0.72.0"
+    metro-inspector-proxy "0.72.0"
+    metro-minify-uglify "0.72.0"
+    metro-react-native-babel-preset "0.72.0"
+    metro-resolver "0.72.0"
+    metro-runtime "0.72.0"
+    metro-source-map "0.72.0"
+    metro-symbolicate "0.72.0"
+    metro-transform-plugins "0.72.0"
+    metro-transform-worker "0.72.0"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -8969,10 +8969,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.71.3:
-  version "0.71.3"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.71.3.tgz#aa98b76e1038d016f4e0e42b5d1e7b009db3f0e0"
-  integrity sha512-SiCAg5YyrYyMvpgiri+B8DeUTTNdcvYNi+SR2ztH17Kv5X2moE+WPH7JI8UiLZrhlO5FQCUV5Dewzz0nXkF4Rg==
+ob1@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.72.0.tgz#13fa85d2fd1444d534156ac701c492fa6c17c956"
+  integrity sha512-QwCDyk1SvGg6KVEgpvAK9xG+7+0sEUZYuzNBT+aucFFVDkw0nHmsgfpzxNiiZwcSpWb04IxGp4CKAmFQBmLQPw==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Summary:
---------

Upgrades Metro dependencies to v0.72.0. The main user-impacting features this release includes are out-of-the-box support for `.cjs` and `.mjs` files and the new React 17 JSX transform, as well as strict CLI validation when `metro` is run directly.

Per the release notes we shared (linked below), I am suggesting that this is a breaking change for RN CLI.

Metro release notes:  https://github.com/facebook/metro/releases/tag/v0.72.0
Changelog between 0.71.3 and 0.72.0: [https://github.com/facebook/metro/compare/v0.71.3..v0.72.0](https://github.com/facebook/metro/compare/v0.71.3%E2%80%A6v0.72.0)

Test Plan:
----------

- Updated dependencies with `yarn`.
- ✅ Ran `yarn test`.
