### PR TITLE
fix: properly create .xcode.env file with doctors auto fix

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
@@ -1,8 +1,10 @@
 import {HealthCheckInterface} from '../../types';
 import fs from 'fs';
-import path from 'path';
 import {promisify} from 'util';
-import {findProjectRoot} from '@react-native-community/cli-tools';
+import {
+  findProjectRoot,
+  resolveNodeModuleDir,
+} from '@react-native-community/cli-tools';
 import {findPodfilePaths} from '@react-native-community/cli-platform-ios';
 
 const xcodeEnvFile = '.xcode.env';
@@ -29,33 +31,37 @@ export default {
   getDiagnostics: async () => {
     const projectRoot = findProjectRoot();
     const allPathsHasXcodeEnvFile = findPodfilePaths(projectRoot)
-      .map((pathString) => {
+      .map((pathString: string) => {
         const basePath = removeLastPathComponent(pathString);
         return pathHasXcodeEnvFile(basePath);
       })
-      .reduce((previousValue, currentValue) => previousValue && currentValue);
+      .reduce(
+        (previousValue: boolean, currentValue: boolean) =>
+          previousValue && currentValue,
+      );
     return {
       needsToBeFixed: !allPathsHasXcodeEnvFile,
     };
   },
-  runAutomaticFix: async () => {
+  runAutomaticFix: async ({loader}) => {
+    loader.stop();
     const templateXcodeEnv = '_xcode.env';
     const projectRoot = findProjectRoot();
-
-    const templateIosPath = path.dirname(
-      require.resolve('react-native/template/ios'),
+    const templateIosPath = resolveNodeModuleDir(
+      projectRoot,
+      'react-native/template/ios',
     );
-
-    const src = templateIosPath + templateXcodeEnv;
+    const src = templateIosPath + pathSeparator + templateXcodeEnv;
     const copyFileAsync = promisify(fs.copyFile);
 
     findPodfilePaths(projectRoot)
       .map(removeLastPathComponent)
       // avoid overriding existing .xcode.env
       .filter(pathDoesNotHaveXcodeEnvFile)
-      .forEach(async (pathString) => {
+      .forEach(async (pathString: string) => {
         const destFilePath = pathString + pathSeparator + xcodeEnvFile;
         await copyFileAsync(src, destFilePath);
       });
+    loader.succeed();
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
@@ -44,24 +44,28 @@ export default {
     };
   },
   runAutomaticFix: async ({loader}) => {
-    loader.stop();
-    const templateXcodeEnv = '_xcode.env';
-    const projectRoot = findProjectRoot();
-    const templateIosPath = resolveNodeModuleDir(
-      projectRoot,
-      'react-native/template/ios',
-    );
-    const src = templateIosPath + pathSeparator + templateXcodeEnv;
-    const copyFileAsync = promisify(fs.copyFile);
+    try {
+      loader.stop();
+      const templateXcodeEnv = '_xcode.env';
+      const projectRoot = findProjectRoot();
+      const templateIosPath = resolveNodeModuleDir(
+        projectRoot,
+        'react-native/template/ios',
+      );
+      const src = templateIosPath + pathSeparator + templateXcodeEnv;
+      const copyFileAsync = promisify(fs.copyFile);
 
-    findPodfilePaths(projectRoot)
-      .map(removeLastPathComponent)
-      // avoid overriding existing .xcode.env
-      .filter(pathDoesNotHaveXcodeEnvFile)
-      .forEach(async (pathString: string) => {
-        const destFilePath = pathString + pathSeparator + xcodeEnvFile;
-        await copyFileAsync(src, destFilePath);
-      });
-    loader.succeed();
+      findPodfilePaths(projectRoot)
+        .map(removeLastPathComponent)
+        // avoid overriding existing .xcode.env
+        .filter(pathDoesNotHaveXcodeEnvFile)
+        .forEach(async (pathString: string) => {
+          const destFilePath = pathString + pathSeparator + xcodeEnvFile;
+          await copyFileAsync(src, destFilePath);
+        });
+      loader.succeed('.xcode.env file have been created!');
+    } catch (e) {
+      loader.fail(e);
+    }
   },
 } as HealthCheckInterface;


### PR DESCRIPTION
Summary:
---------

Noticed that doctor does not create `.xcode.env` file when it should. 
It was happening because this command was failing silently:
```ts
    const templateIosPath = path.dirname(
      require.resolve('react-native/template/ios'),
    );
```

Test Plan:
----------

Create fresh project and then delete `.xcode.env` file. Then run `doctor` command and try to autofix the error. 

```bash
❯ npx react-native doctor                         
Common
 ✓ Node.js
 ✓ yarn
 ✓ Watchman - Used for watching changes in the filesystem when in development mode

Android
 ✓ JDK
 ✓ Android Studio - Required for building and installing your app on Android
 ✓ Android SDK - Required for building and installing your app on Android
 ✓ ANDROID_HOME

iOS
 ✓ Xcode - Required for building and installing your app on iOS
 ✓ CocoaPods - Required for installing iOS dependencies
 ● ios-deploy - Required for installing your app on a physical device with the CLI
 ✖ .xcode.env - File to customize Xcode environment

Errors:   1
Warnings: 1

Attempting to fix 1 issue...

iOS
⠋ .xcode.env%         
```

Run doctor again and error is still present:
```bash                
❯ npx react-native doctor
Common
 ✓ Node.js
 ✓ yarn
 ✓ Watchman - Used for watching changes in the filesystem when in development mode

Android
 ✓ JDK
 ✓ Android Studio - Required for building and installing your app on Android
 ✓ Android SDK - Required for building and installing your app on Android
 ✓ ANDROID_HOME

iOS
 ✓ Xcode - Required for building and installing your app on iOS
 ✓ CocoaPods - Required for installing iOS dependencies
 ● ios-deploy - Required for installing your app on a physical device with the CLI
 ✖ .xcode.env - File to customize Xcode environment
                                                       
```

