### PR TITLE
fix: pass projectRoot path to doctors fixers

### DIFF
--- a/packages/cli-doctor/src/commands/doctor.ts
+++ b/packages/cli-doctor/src/commands/doctor.ts
@@ -1,5 +1,9 @@
 import chalk from 'chalk';
-import {logger, getLoader} from '@react-native-community/cli-tools';
+import {
+  logger,
+  getLoader,
+  findProjectRoot,
+} from '@react-native-community/cli-tools';
 import {getHealthchecks, HEALTHCHECK_TYPES} from '../tools/healthchecks';
 import printFixOptions, {KEYS} from '../tools/printFixOptions';
 import runAutomaticFix, {AUTOMATIC_FIX_LEVELS} from '../tools/runAutomaticFix';
@@ -116,6 +120,8 @@ const doctorCommand = (async (_, options) => {
 
   const environmentInfo = await getEnvironmentInfo();
 
+  const projectRoot = findProjectRoot();
+
   const iterateOverHealthChecks = async ({
     label,
     healthchecks,
@@ -133,7 +139,7 @@ const doctorCommand = (async (_, options) => {
             version,
             versions,
             versionRange,
-          } = await healthcheck.getDiagnostics(environmentInfo);
+          } = await healthcheck.getDiagnostics(environmentInfo, projectRoot);
 
           // Assume that it's required unless specified otherwise
           const isRequired = healthcheck.isRequired !== false;
@@ -213,6 +219,7 @@ const doctorCommand = (async (_, options) => {
       stats,
       loader,
       environmentInfo,
+      projectRoot,
     });
   }
 
@@ -248,6 +255,7 @@ const doctorCommand = (async (_, options) => {
           stats,
           loader,
           environmentInfo,
+          projectRoot,
         });
 
         process.exit(0);

--- a/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
@@ -2,7 +2,6 @@ import {HealthCheckInterface} from '../../types';
 import fs from 'fs';
 import path from 'path';
 import {promisify} from 'util';
-import {findProjectRoot} from '@react-native-community/cli-tools';
 import {findPodfilePaths} from '@react-native-community/cli-platform-ios';
 
 const xcodeEnvFile = '.xcode.env';
@@ -26,8 +25,8 @@ function pathDoesNotHaveXcodeEnvFile(pathString: string): boolean {
 export default {
   label: '.xcode.env',
   description: 'File to customize Xcode environment',
-  getDiagnostics: async () => {
-    const projectRoot = findProjectRoot();
+  getDiagnostics: async (_, projectRoot) => {
+    console.log('projectRoot @ getDiagnostics', projectRoot);
     const allPathsHasXcodeEnvFile = findPodfilePaths(projectRoot)
       .map((pathString) => {
         const basePath = removeLastPathComponent(pathString);
@@ -38,9 +37,8 @@ export default {
       needsToBeFixed: !allPathsHasXcodeEnvFile,
     };
   },
-  runAutomaticFix: async () => {
+  runAutomaticFix: async ({projectRoot}) => {
     const templateXcodeEnv = '_xcode.env';
-    const projectRoot = findProjectRoot();
 
     const templateIosPath = path.dirname(
       require.resolve('react-native/template/ios'),

--- a/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
@@ -26,7 +26,6 @@ export default {
   label: '.xcode.env',
   description: 'File to customize Xcode environment',
   getDiagnostics: async (_, projectRoot) => {
-    console.log('projectRoot @ getDiagnostics', projectRoot);
     const allPathsHasXcodeEnvFile = findPodfilePaths(projectRoot)
       .map((pathString) => {
         const basePath = removeLastPathComponent(pathString);

--- a/packages/cli-doctor/src/tools/runAutomaticFix.ts
+++ b/packages/cli-doctor/src/tools/runAutomaticFix.ts
@@ -20,6 +20,7 @@ interface RunAutomaticFixArgs {
   };
   loader: Loader;
   environmentInfo: EnvironmentInfo;
+  projectRoot: string;
 }
 
 export default async function ({
@@ -27,6 +28,7 @@ export default async function ({
   automaticFixLevel,
   stats,
   environmentInfo,
+  projectRoot,
 }: RunAutomaticFixArgs) {
   // Remove the fix options from screen
   if (process.stdout.isTTY) {
@@ -90,6 +92,7 @@ export default async function ({
           loader: spinner,
           logManualInstallation,
           environmentInfo,
+          projectRoot,
         });
       } catch (error) {
         // TODO: log the error in a meaningful way

--- a/packages/cli-doctor/src/types.ts
+++ b/packages/cli-doctor/src/types.ts
@@ -75,6 +75,7 @@ export type RunAutomaticFix = (args: {
     message?: string;
   }) => void;
   environmentInfo: EnvironmentInfo;
+  projectRoot: string;
 }) => Promise<void> | void;
 
 export type HealthCheckInterface = {
@@ -84,6 +85,7 @@ export type HealthCheckInterface = {
   description?: string;
   getDiagnostics: (
     environmentInfo: EnvironmentInfo,
+    projectRoot: string,
   ) => Promise<{
     version?: string;
     versions?: [string];


### PR DESCRIPTION
Summary:
---------

Pass `projectRoot` as an argument both to `doctor`'s `getDiagnostics` and `runAutomaticFix` methods. 

Fixes: #1588 

Test Plan:
----------

`doctor` should still work. 
