### PR TITLE
Do not glob `node_modules` in findComponentDescriptors

### DIFF
--- a/packages/cli-platform-android/src/config/findComponentDescriptors.ts
+++ b/packages/cli-platform-android/src/config/findComponentDescriptors.ts
@@ -7,6 +7,7 @@ export function findComponentDescriptors(packageRoot: string) {
   const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {
     cwd: packageRoot,
     nodir: true,
+    ignore: '**/node_modules/**',
   });
   const codegenComponent = files
     .map((filePath) =>


### PR DESCRIPTION
Summary:
---------

See https://github.com/reactwg/react-native-releases/discussions/26#discussioncomment-3329589 for more context. We should not traverse other `node_modules when calling `findComponentDescriptors` as we might pick up too many files.

Test Plan:
----------

I've tested this manually against the linked project.