### PR TITLE
Fix link to blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Command line tools that ship with [`react-native`](https://github.com/facebook/r
 
 [![Build Status][build-badge]][build] [![Version][version-badge]][package] [![MIT License][license-badge]][license] [![PRs Welcome][prs-welcome-badge]][prs-welcome] [![Lean Core Extracted][lean-core-badge]][lean-core]
 
-_Note: CLI has been extracted from core `react-native` as a part of "[Lean Core](https://github.com/facebook/react-native/issues/23313)" effort. Please read [this blog post](https://blog.callstack.io/the-react-native-cli-has-a-new-home-79b63838f0e6) for more details._
+_Note: CLI has been extracted from core `react-native` as a part of "[Lean Core](https://github.com/facebook/react-native/issues/23313)" effort. Please read [this blog post](https://www.callstack.com/blog/the-react-native-cli-has-a-new-home) for more details._
 
 ## Contents
 


### PR DESCRIPTION
First of all, thanks for all your effort on the `@react-native-community` packages, including the CLI packages! 🙌

Summary:
---------

Fix the broken link to the blog post where the motivation for the Lean Core effort is described

Test Plan:
----------

- [x] New link works
