### PR TITLE
fix: update logic to check for available ios devices for `log-ios` to work

### DIFF
--- a/packages/cli-platform-ios/src/commands/logIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/logIOS/index.ts
@@ -15,7 +15,11 @@ import {Device} from '../../types';
 function findAvailableDevice(devices: {[index: string]: Array<Device>}) {
   for (const key of Object.keys(devices)) {
     for (const device of devices[key]) {
-      if (device.availability === '(available)' && device.state === 'Booted') {
+      if (
+        (device.availability === '(available)' ||
+          device.isAvailable === true) &&
+        device.state === 'Booted'
+      ) {
         return device;
       }
     }


### PR DESCRIPTION
Summary:
---------

Hey, just ran into this while working on a new feature.

When pulling the devices via `xcrun simctl list devices --json` now, I don't actually get the `availability` key, I just get the `isAvailable` key. They are both already listed as optional keys in the `Device` type in the repo. My guess is that the `availability` key was on an older version of `simctl`.

Anyway, if I run the `log-ios` as-is, without this change, it always fails to find an available iOS device because `device.availability` simply never exists. Changing it to also check for `device.isAvailable` works.

Test Plan:
----------
environment: 
macOS 12.5 (latest stable)
xcrun version 61 / xcode 13.4.1 (latest stable)

1. Have an iOS simulator open and running
2. Run the `log-ios` command as is in the current `main` cli branch. (Result: FAILS with `error: No active iOS device found`)
3. Run the `log-ios` command with this PR's code. (Result: Successfully finds the active simulator and starts a log session)