### PR TITLE
WIP: feat: List available apple devices

### DIFF
--- a/packages/cli-platform-ios/src/commands/index.ts
+++ b/packages/cli-platform-ios/src/commands/index.ts
@@ -1,4 +1,5 @@
+import listIOS from './listIOS';
 import logIOS from './logIOS';
 import runIOS from './runIOS';
 
-export default [logIOS, runIOS];
+export default [listIOS, logIOS, runIOS];

--- a/packages/cli-platform-ios/src/commands/listIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/listIOS/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {execFileSync} from 'child_process';
+import {logger} from '@react-native-community/cli-tools';
+import {Device} from '../../types';
+
+function findAvailableDevices(devices: {[index: string]: Array<Device>}) {
+  // TODO -- It would be cool to separate out the Apple Watch, iOS, iPad, TV, and others...
+  let availableDevices = [];
+  for (const key of Object.keys(devices)) {
+    for (const device of devices[key]) {
+      if (
+        device.availability === '(available)' ||
+        device.isAvailable === true
+      ) {
+        availableDevices.push(device.name);
+      }
+    }
+  }
+  return availableDevices;
+}
+
+async function listIOS() {
+  const rawDevices = execFileSync(
+    'xcrun',
+    ['simctl', 'list', 'devices', '--json'],
+    {encoding: 'utf8'},
+  );
+
+  const {devices} = JSON.parse(rawDevices) as {
+    devices: {[index: string]: Array<Device>};
+  };
+
+  const availableDevices = findAvailableDevices(devices);
+  if (availableDevices === null) {
+    logger.error('No available iOS devices found');
+    return;
+  }
+  logger.info(JSON.stringify(availableDevices));
+}
+
+export default {
+  name: 'list-ios',
+  description: 'lists available iOS devices',
+  func: listIOS,
+};

--- a/packages/cli-platform-ios/src/commands/listIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/listIOS/index.ts
@@ -7,6 +7,8 @@
  */
 
 import {execFileSync} from 'child_process';
+import prompts from 'prompts';
+import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 import {Device} from '../../types';
 
@@ -42,7 +44,23 @@ async function listIOS() {
     logger.error('No available iOS devices found');
     return;
   }
-  logger.info(JSON.stringify(availableDevices));
+
+  async function promptForDeviceSelection(): Promise<string[] | undefined> {
+    const {device} = await prompts({
+      type: 'select',
+      name: 'device',
+      message: 'Select the device you want to use',
+      choices: availableDevices.map((deviceName) => ({
+        title: `${chalk.dim(`(${deviceName})`)}`,
+        value: deviceName,
+        // selected: DEFAULT_GROUPS.includes(cmd),
+      })),
+      min: 1,
+    });
+    return device;
+  }
+
+  promptForDeviceSelection();
 }
 
 export default {

--- a/packages/cli-platform-ios/src/commands/listIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/listIOS/index.ts
@@ -51,9 +51,8 @@ async function listIOS() {
       name: 'device',
       message: 'Select the device you want to use',
       choices: availableDevices.map((deviceName) => ({
-        title: `${chalk.dim(`(${deviceName})`)}`,
+        title: `${chalk.bold(`(${deviceName})`)}`,
         value: deviceName,
-        // selected: DEFAULT_GROUPS.includes(cmd),
       })),
       min: 1,
     });


### PR DESCRIPTION
Summary:
---------

Hey, so this is a WIP for listing available apple devices in an interactive cli prompt. The intention of this is to be able to let the user select an available simulator vs. having to paste device name/udid strings in.

I wanted to put this up as a WIP first because **I don't know which path to take next**...

1. I could have this be its own helper function, that just lists out the sims (its current state) -- Do we want this as an optional helper for users?
2. I could merge it into the `run-ios` flow (initial thoughts: if user doesn't select a sim, one isn't booted or the one they supply isn't available/existing, instead of fallbacks we give this prompt and then carry-on the run-ios command)
3. Something else? Maybe a combination of 1 & 2 (it's available standalone, and also inside `run-ios`)? 🤔 

Some advice would be really helpful here as my only experience with the CLI has been my own (and teams') usage. I don't feel I have the context to make a judgement call here for a whole community. Maybe it's super obvious/simple, I just don't know 🤷 


Test Plan:
----------

WIP
