### PR TITLE
fix: remove peerDependencies on react-native

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/files/package.json
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/package.json
@@ -46,9 +46,6 @@
     "url": "git://github.com/oblador/react-native-vector-icons.git"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "react-native": ">=0.4.0 || 0.5.0-rc1 || 0.6.0-rc || 0.7.0-rc || 0.7.0-rc.2 || 0.8.0-rc || 0.8.0-rc.2 || 0.9.0-rc || 0.10.0-rc || 0.11.0-rc || 0.12.0-rc || 0.13.0-rc || 0.14.0-rc || 0.15.0-rc || 0.16.0-rc"
-  },
   "dependencies": {
     "yargs": "^3.30.0",
     "rnpm-plugin-test": "*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -42,9 +42,6 @@
     "prompts": "^2.4.0",
     "semver": "^6.3.0"
   },
-  "peerDependencies": {
-    "react-native": "*"
-  },
   "devDependencies": {
     "@types/fs-extra": "^8.1.0",
     "@types/graceful-fs": "^4.1.3",


### PR DESCRIPTION
Summary:
---------

Peer dep on "react-native" makes npm 7+ automatically install the "latest" version, which is currently 0.69.x, and when someone is installing RN 0.70 RC, it's erroring out. This PR essentially removes the peer dep from one and only package that defines it. Making it an implicit peer dependency.


Test Plan:
----------

None
