### PR TITLE
Add support for explicit cmakeListsPath in react-native.config.js

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -116,7 +116,7 @@ module.exports = {
           libraryName: null,
           componentDescriptors: null,
           androidMkPath: null,
-          cmakePath: null,
+          cmakeListsPath: null,
         },
       },
     },

--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -116,6 +116,7 @@ module.exports = {
           libraryName: null,
           componentDescriptors: null,
           androidMkPath: null,
+          cmakePath: null,
         },
       },
     },

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -58,7 +58,7 @@ type AndroidDependencyParams = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
-  cmakePath?: string | null;
+  cmakeListsPath?: string | null;
 };
 ```
 
@@ -142,7 +142,7 @@ An array of custom component descriptor strings. By default they're generated ba
 
 A relative path to a custom _Android.mk_ file not registered by codegen. Relative to `sourceDir`.
 
-#### platforms.android.cmakePath
+#### platforms.android.cmakeListsPath
 
 > Note: Only applicable when new architecture is turned on.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -58,6 +58,7 @@ type AndroidDependencyParams = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
+  cmakePath?: string | null;
 };
 ```
 
@@ -140,3 +141,9 @@ An array of custom component descriptor strings. By default they're generated ba
 > Note: Only applicable when new architecture is turned on.
 
 A relative path to a custom _Android.mk_ file not registered by codegen. Relative to `sourceDir`.
+
+#### platforms.android.cmakePath
+
+> Note: Only applicable when new architecture is turned on.
+
+A relative path to a custom _CMakeLists.txt_ file not registered by codegen. Relative to `sourceDir`.

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -121,5 +121,6 @@ type AndroidDependencyConfig = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
+  cmakePath?: string | null;
 };
 ```

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -121,6 +121,6 @@ type AndroidDependencyConfig = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
-  cmakePath?: string | null;
+  cmakeListsPath?: string | null;
 };
 ```

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -86,6 +86,7 @@ export const dependencyConfig = t
                 libraryName: t.string().allow(null),
                 componentDescriptors: t.array().items(t.string()).allow(null),
                 androidMkPath: t.string().allow(null),
+                cmakePath: t.string().allow(null),
               })
               .allow(null),
           })
@@ -137,6 +138,7 @@ export const projectConfig = t
                 libraryName: t.string().allow(null),
                 componentDescriptors: t.array().items(t.string()).allow(null),
                 androidMkPath: t.string().allow(null),
+                cmakePath: t.string().allow(null),
               })
               .allow(null),
           }),

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -86,7 +86,7 @@ export const dependencyConfig = t
                 libraryName: t.string().allow(null),
                 componentDescriptors: t.array().items(t.string()).allow(null),
                 androidMkPath: t.string().allow(null),
-                cmakePath: t.string().allow(null),
+                cmakeListsPath: t.string().allow(null),
               })
               .allow(null),
           })
@@ -138,7 +138,7 @@ export const projectConfig = t
                 libraryName: t.string().allow(null),
                 componentDescriptors: t.array().items(t.string()).allow(null),
                 androidMkPath: t.string().allow(null),
-                cmakePath: t.string().allow(null),
+                cmakeListsPath: t.string().allow(null),
               })
               .allow(null),
           }),

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -300,8 +300,13 @@ class ReactNativeModules {
 
     if (packages.size() > 0) {
       libraryIncludes = packages.collect {
-        if (it.libraryName != null && it.androidMkPath != null) {
-          // The CMakeLists.txt file is in the same folder as the Android.mk
+        if (it.libraryName != null && it.cmakePath != null) {
+          // If user provided a custom CMakePath, let's honor it.
+          String nativeFolderPath = it.cmakePath.replace("CMakeLists.txt", "")
+          "add_subdirectory($nativeFolderPath ${it.libraryName}_autolinked_build)"
+        } else if (it.libraryName != null && it.androidMkPath != null) {
+          // Fallback to previous behavior: reusing androidMkPath.
+          // We assume CMakeLists.txt file is in the same folder as the Android.mk
           String nativeFolderPath = it.androidMkPath.replace("Android.mk", "")
           "add_subdirectory($nativeFolderPath ${it.libraryName}_autolinked_build)"
         } else {
@@ -470,6 +475,7 @@ class ReactNativeModules {
         reactNativeModuleConfig.put("libraryName", androidConfig["libraryName"])
         reactNativeModuleConfig.put("componentDescriptors", androidConfig["componentDescriptors"])
         reactNativeModuleConfig.put("androidMkPath", androidConfig["androidMkPath"])
+        reactNativeModuleConfig.put("cmakePath", androidConfig["cmakePath"])
 
         if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -300,9 +300,9 @@ class ReactNativeModules {
 
     if (packages.size() > 0) {
       libraryIncludes = packages.collect {
-        if (it.libraryName != null && it.cmakePath != null) {
-          // If user provided a custom CMakePath, let's honor it.
-          String nativeFolderPath = it.cmakePath.replace("CMakeLists.txt", "")
+        if (it.libraryName != null && it.cmakeListsPath != null) {
+          // If user provided a custom cmakeListsPath, let's honor it.
+          String nativeFolderPath = it.cmakeListsPath.replace("CMakeLists.txt", "")
           "add_subdirectory($nativeFolderPath ${it.libraryName}_autolinked_build)"
         } else if (it.libraryName != null && it.androidMkPath != null) {
           // Fallback to previous behavior: reusing androidMkPath.
@@ -475,7 +475,7 @@ class ReactNativeModules {
         reactNativeModuleConfig.put("libraryName", androidConfig["libraryName"])
         reactNativeModuleConfig.put("componentDescriptors", androidConfig["componentDescriptors"])
         reactNativeModuleConfig.put("androidMkPath", androidConfig["androidMkPath"])
-        reactNativeModuleConfig.put("cmakePath", androidConfig["cmakePath"])
+        reactNativeModuleConfig.put("cmakeListsPath", androidConfig["cmakeListsPath"])
 
         if (androidConfig["buildTypes"] && !androidConfig["buildTypes"].isEmpty()) {
           reactNativeModulesBuildVariants.put(nameCleansed, androidConfig["buildTypes"])

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -127,6 +127,9 @@ export function dependencyConfig(
   const androidMkPath = userConfig.androidMkPath
     ? path.join(sourceDir, userConfig.androidMkPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/Android.mk');
+  const cmakePath = userConfig.cmakePath
+    ? path.join(sourceDir, userConfig.cmakePath)
+    : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
 
   return {
     sourceDir,
@@ -137,5 +140,6 @@ export function dependencyConfig(
     libraryName,
     componentDescriptors,
     androidMkPath,
+    cmakePath
   };
 }

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -127,8 +127,8 @@ export function dependencyConfig(
   const androidMkPath = userConfig.androidMkPath
     ? path.join(sourceDir, userConfig.androidMkPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/Android.mk');
-  const cmakePath = userConfig.cmakePath
-    ? path.join(sourceDir, userConfig.cmakePath)
+  const cmakeListsPath = userConfig.cmakeListsPath
+    ? path.join(sourceDir, userConfig.cmakeListsPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
 
   return {
@@ -140,6 +140,6 @@ export function dependencyConfig(
     libraryName,
     componentDescriptors,
     androidMkPath,
-    cmakePath
+    cmakeListsPath,
   };
 }

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -22,6 +22,7 @@ export type AndroidDependencyConfig = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
+  cmakePath?: string | null;
 };
 
 export type AndroidDependencyParams = {
@@ -35,4 +36,5 @@ export type AndroidDependencyParams = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
+  cmakePath?: string | null;
 };

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -22,7 +22,7 @@ export type AndroidDependencyConfig = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
-  cmakePath?: string | null;
+  cmakeListsPath?: string | null;
 };
 
 export type AndroidDependencyParams = {
@@ -36,5 +36,5 @@ export type AndroidDependencyParams = {
   libraryName?: string | null;
   componentDescriptors?: string[] | null;
   androidMkPath?: string | null;
-  cmakePath?: string | null;
+  cmakeListsPath?: string | null;
 };


### PR DESCRIPTION
Summary:
---------

Power library authors might want to specify a custom CMake path. Currently we've been reusing the `androidMkPath` config key assuming that the CMake file would be in the same folder (which is a sound assumption). However we should be more precise here and allow users to specify a custom `cmakeListsPath` if they want.

Test Plan:
----------

@thymikee not sure how can we test this as the change is touching several files.