### PR TITLE
fix: no minimum version of Watchman

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/watchman.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/watchman.ts
@@ -9,7 +9,7 @@ export default {
   description:
     'Used for watching changes in the filesystem when in development mode',
   getDiagnostics: async ({Binaries}) => ({
-    needsToBeFixed: !Binaries.Watchman.version,
+    needsToBeFixed: Boolean(Binaries.Watchman.version),
   }),
   runAutomaticFix: async ({loader}) =>
     await install({

--- a/packages/cli-doctor/src/tools/healthchecks/watchman.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/watchman.ts
@@ -1,5 +1,3 @@
-import versionRanges from '../versionRanges';
-import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import {install} from '../install';
 import {HealthCheckInterface} from '../../types';
 
@@ -7,16 +5,11 @@ const label = 'Watchman';
 
 export default {
   label,
+  isRequired: false,
   description:
     'Used for watching changes in the filesystem when in development mode',
   getDiagnostics: async ({Binaries}) => ({
-    needsToBeFixed: doesSoftwareNeedToBeFixed({
-      version: Binaries.Watchman.version,
-      versionRange: versionRanges.WATCHMAN,
-      looseRange: true,
-    }),
-    version: Binaries.Watchman.version,
-    versionRange: versionRanges.WATCHMAN,
+    needsToBeFixed: !Binaries.Watchman.version,
   }),
   runAutomaticFix: async ({loader}) =>
     await install({

--- a/packages/cli-doctor/src/tools/healthchecks/watchman.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/watchman.ts
@@ -9,7 +9,7 @@ export default {
   description:
     'Used for watching changes in the filesystem when in development mode',
   getDiagnostics: async ({Binaries}) => ({
-    needsToBeFixed: Boolean(Binaries.Watchman.version),
+    needsToBeFixed: Boolean(Binaries.Watchman.version) === false,
   }),
   runAutomaticFix: async ({loader}) =>
     await install({

--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -3,7 +3,6 @@ export default {
   NODE_JS: '>= 14',
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
-  WATCHMAN: '>= 4.x',
   JAVA: '>= 11',
   // Android
   ANDROID_SDK: '>= 31.x',


### PR DESCRIPTION
Summary:
---------

Closes #1694 

Watchman is using CalVer for versioning and is appears that in some cases `semver` have difficulties to correctly check if it `satisfies` our minimum version required, even when `looseRange` is on. 
We could do a special CalVer check for watchman but then question arises what is oldest version CLI supports. Oldest release found on GitHub is [v2020.07.13.00](https://github.com/facebook/watchman/releases/tag/v2020.07.13.00) while latest semver release ([4.9.0](https://facebook.github.io/watchman/docs/release-notes.html#watchman-490-2017-08-24)) was done in 2017 so quite some time ago...

So actually it appears that we support **all versions**, it only needs to be installed.
 

Test Plan:
----------

Clone the repo, checkout to branch with the fix and run doctor command from any react native project.
```bash
node ../cli/packages/cli/build/bin.js doctor
```