### PR TITLE
feat(ios): use Bundler for pods installation

### DIFF
--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -5,6 +5,7 @@ import prompts from 'prompts';
 import {logger, NoopLoader} from '@react-native-community/cli-tools';
 // @ts-ignore untyped
 import sudo from 'sudo-prompt';
+import runBundleInstall from './runBundleInstall';
 import {brewInstall} from './brewInstall';
 import {Loader} from '../types';
 
@@ -24,7 +25,8 @@ async function runPodInstall(
         '(this may take a few minutes)',
       )}`,
     );
-    await execa('pod', ['install']);
+
+    await execa('bundle', ['exec', 'pod', 'install']);
   } catch (error) {
     // "pod" command outputs errors to stdout (at least some of them)
     const stderr = error.stderr || error.stdout;
@@ -41,10 +43,10 @@ async function runPodInstall(
       await runPodInstall(loader, directory, false);
     } else {
       loader.fail();
+      logger.error(stderr);
+
       throw new Error(
-        `Failed to install CocoaPods dependencies for iOS project, which is required by this template.\nPlease try again manually: "cd ./${directory}/ios && pod install".\nCocoaPods documentation: ${chalk.dim.underline(
-          'https://cocoapods.org/',
-        )}`,
+        'Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.',
       );
     }
   }
@@ -191,6 +193,7 @@ async function installPods({
       await installCocoaPods(loader);
     }
 
+    await runBundleInstall(loader);
     await runPodInstall(loader, directory);
   } catch (error) {
     throw error;

--- a/packages/cli-doctor/src/tools/runBundleInstall.ts
+++ b/packages/cli-doctor/src/tools/runBundleInstall.ts
@@ -1,0 +1,23 @@
+import execa from 'execa';
+import {logger} from '@react-native-community/cli-tools';
+
+import {Loader} from '../types';
+
+async function runBundleInstall(loader: Loader) {
+  try {
+    loader.start('Installing Bundler');
+
+    await execa('bundle', ['install']);
+  } catch (error) {
+    loader.fail();
+    logger.error(error.stderr || error.stdout);
+
+    throw new Error(
+      'Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.',
+    );
+  }
+
+  loader.succeed();
+}
+
+export default runBundleInstall;


### PR DESCRIPTION
Summary:
---------
- Using Bundler as a default way to handle dependencies on iOS

Test Plan:
----------
- `yarn test`
- Possible error output, when other ruby version is used:
<img width="682" alt="Screenshot 2022-10-04 at 11 42 28" src="https://user-images.githubusercontent.com/28902667/193802309-af267f35-28b3-4b29-8cc8-c17cb840527a.png">

- Successful run:
<img width="841" alt="Screenshot 2022-10-04 at 12 45 10" src="https://user-images.githubusercontent.com/28902667/193811817-cff2e5b9-cd34-4ec4-96e6-ba271cec4122.png">


