### PR TITLE
Upgrade Metro dependencies to v0.73.0 in `cli-plugin-metro`

### DIFF
--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -10,12 +10,12 @@
     "@react-native-community/cli-server-api": "^9.1.0",
     "@react-native-community/cli-tools": "^9.1.0",
     "chalk": "^4.1.2",
-    "metro": "0.72.3",
-    "metro-config": "0.72.3",
-    "metro-core": "0.72.3",
-    "metro-react-native-babel-transformer": "0.72.3",
-    "metro-resolver": "0.72.3",
-    "metro-runtime": "0.72.3",
+    "metro": "0.73.0",
+    "metro-config": "0.73.0",
+    "metro-core": "0.73.0",
+    "metro-react-native-babel-transformer": "0.73.0",
+    "metro-resolver": "0.73.0",
+    "metro-runtime": "0.73.0",
     "readline": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Summary:
---------

Updating the versions of Metro in the `cli-plugin-metro` to incorporate the new Metro Release v0.73.0. This release switches the default minifier to `terser`, raises the minimum Node version to ^14.17, and drops support for old Watchman versions. It also improves support for Apple Silicon and will enable the use of BigInt out of the box in React Native 0.71.

Per the release notes we shared (link below), I am suggesting that this is a breaking change for RN CLI.

**Metro Release Notes:** https://github.com/facebook/metro/releases/tag/v0.73.0
**Full Changelog between v0.72.3 and v0.73.0:** https://github.com/facebook/metro/compare/v0.72.3...v0.73.0

Reminder : When React Native updates the CLI to a version that depends on metro 0.73.0, it must also update metro-runtime etc to 0.73.0 in the same commit

Test Plan:
----------

- Updated dependencies with `yarn`.
- ✅ Ran `yarn test`.



