### PR TITLE
feat: improve new release checker CTA and logic

### DIFF
--- a/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
@@ -24,6 +24,15 @@ export default async function getLatestRelease(
   try {
     logger.debug(`Current version: ${currentVersion}`);
 
+    // if the version is a 1000.0.0 version or 0.0.0, we want to bail
+    // since they are nightlies or unreleased versions
+    if (
+      currentVersion.includes('1000.0.0') ||
+      currentVersion.includes('0.0.0')
+    ) {
+      return;
+    }
+
     const cachedLatest = cacheManager.get(name, 'latestVersion');
 
     if (cachedLatest) {

--- a/packages/cli-tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/printNewRelease.ts
@@ -16,7 +16,7 @@ export default function printNewRelease(
   );
   logger.info(`Changelog: ${chalk.dim.underline(latestRelease.changelogUrl)}`);
   logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}`);
-  logger.info(`To upgrade, run "${chalk.bold('react-native upgrade')}".`);
+  logger.info(`For more info, check out "${chalk.dim.underline('https://reactnative.dev/docs/upgrading')}".`);
 
   cacheManager.set(name, 'lastChecked', new Date().toISOString());
 }

--- a/packages/cli-tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/printNewRelease.ts
@@ -16,7 +16,11 @@ export default function printNewRelease(
   );
   logger.info(`Changelog: ${chalk.dim.underline(latestRelease.changelogUrl)}`);
   logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}`);
-  logger.info(`For more info, check out "${chalk.dim.underline('https://reactnative.dev/docs/upgrading')}".`);
+  logger.info(
+    `For more info, check out "${chalk.dim.underline(
+      'https://reactnative.dev/docs/upgrading',
+    )}".`,
+  );
 
   cacheManager.set(name, 'lastChecked', new Date().toISOString());
 }


### PR DESCRIPTION
Summary:
---------

This is a small PR to address a minor inconvenience with the script that shows up when a newer version of react-native is available.

It modifies the last line to not directly mention `react-native upgrade` since that command doesn't lead the developer down a happy path.

On top of that, a small improvement to avoid the message popping up for nightlies and other non-stable releases of RN, which might happen with 1000.0.0 and 0.0.0 versions.

Test Plan:
----------

Tested locally, following the contribution guidelines:
<img width="752" alt="Screenshot 2022-10-14 at 13 05 34" src="https://user-images.githubusercontent.com/16104054/195843216-0bdee364-3749-42bd-8881-4324d4a58dc7.png">
