### PR TITLE
Update ios readme to pass xcconfig from command line

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -440,6 +440,10 @@ Runs packager on specified port
 
 Default: `process.env.RCT_METRO_PORT || 8081`
 
+#### `--xcconfig <string>`
+
+Explicitly pass `xcconfig` options from the command line 
+
 ### `start`
 
 Usage:


### PR DESCRIPTION
Updates commands doc with the new xcconfig option