### PR TITLE
Upgrade metro dependencies to 0.73.3

### DIFF
--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -10,12 +10,12 @@
     "@react-native-community/cli-server-api": "^10.0.0-alpha.0",
     "@react-native-community/cli-tools": "^10.0.0-alpha.0",
     "chalk": "^4.1.2",
-    "metro": "0.73.0",
-    "metro-config": "0.73.0",
-    "metro-core": "0.73.0",
-    "metro-react-native-babel-transformer": "0.73.0",
-    "metro-resolver": "0.73.0",
-    "metro-runtime": "0.73.0",
+    "metro": "0.73.3",
+    "metro-config": "0.73.3",
+    "metro-core": "0.73.3",
+    "metro-react-native-babel-transformer": "0.73.3",
+    "metro-resolver": "0.73.3",
+    "metro-runtime": "0.73.3",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8149,53 +8149,53 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.73.0.tgz#1faf9db29c1a112b28ddba1912f236b8a376911a"
-  integrity sha512-GXb09baEAhCgTRVY8Y/mVup4nN4Q9NkG54LH7N+3QvxOb5rVrqBaExPBkt/B0HCtc+1iIUwbiPXxjbpEEpuLsQ==
+metro-babel-transformer@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.73.3.tgz#13e2e5d7981049f9b4babd6a97e40c8decdf19a8"
+  integrity sha512-vNNFMxsZn1JasZEk9RlC84KQiei1ecZ3BmRsNCipWN7YMC/SbV8QLMdqhgF8XIfKnZnS6Z2RCFGPYPxu7/9sJA==
   dependencies:
     "@babel/core" "^7.14.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.73.0"
+    metro-source-map "0.73.3"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.73.0.tgz#15f4235f2199cb3fe2820c482e1299d44499791f"
-  integrity sha512-w57wMW1gkPCkdJUUKzlBznPkX9cg9gTU++6ngSHSPTZal5onI/lbDxoLJ5+AQprBrWTWY+cplB8Xg95yY+3+9g==
+metro-cache-key@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.73.3.tgz#eabd107ba6274aa9c629a807c9801c914fc1091a"
+  integrity sha512-LsP8aZr/LJuw428hNAQHKJkL7N3RvYcHcG6kbUXUfRqwOsoE4q6C8kXebtm+5+fbNduNVzHjEBIQM2uFUctMow==
 
-metro-cache@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.73.0.tgz#6fdf60feaedfb45981b91381c171d13750ad9dd6"
-  integrity sha512-LLFs8y5v23sOdGBuXsZoM1lP0KcyuRApz2SMheqcRxwU5S/QDtKT55qYwF4cLw0Cjp9uzSjgfvZ14ghiKD5Q6g==
+metro-cache@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.73.3.tgz#172f4a5c88738643f1b11b7593c2edec6882bef6"
+  integrity sha512-nRLxn1B8J4LxFZo02OCFryalqaJKW1ddAteS5zdSmsJLdaDwvKH+J73Rp/XOR5Puu1A05A7BF4/aYKzwY/HU4A==
   dependencies:
-    metro-core "0.73.0"
-    rimraf "^2.5.4"
+    metro-core "0.73.3"
+    rimraf "^3.0.2"
 
-metro-config@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.73.0.tgz#e3fa52f1eeaae775b98524c5d2027fd5be0f27a6"
-  integrity sha512-Pd/y/2ervIsND3SWRn+MVVpZm/Qz8HrvzljQBCF5RVc0pBgemauAn5GviicckEsuC3gmHb6bpiVFfzpCxqc/LQ==
+metro-config@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.73.3.tgz#52fbb1b4ecf638fe16d2227535795609e4faf396"
+  integrity sha512-k1OSBNVe/i+Vm1IPA35qt1eD/3yjtEA0qfzvLeTmuvarE+twBpXupJViKqtfqvo6rldk0VoYX/UlnqzkaJ1hIg==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.73.0"
-    metro-cache "0.73.0"
-    metro-core "0.73.0"
-    metro-runtime "0.73.0"
+    metro "0.73.3"
+    metro-cache "0.73.3"
+    metro-core "0.73.3"
+    metro-runtime "0.73.3"
 
-metro-core@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.73.0.tgz#710eb7d04b9d89c59f197aecf47fd95dfd44410d"
-  integrity sha512-bir7JKYCQ4W9MQf0bqzuORGpkKrYaslpljQ1cEcKm3/aoYYDqOZFQwClo1TEHMShtwHev/mc8oT/g/FBbAKmlg==
+metro-core@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.73.3.tgz#dc79fa4abe6a266a4d3b4a2352864f4cb6440298"
+  integrity sha512-wsW2XyWU9QtWnNMrUIDnoTIKDHBvKa/uupY+91gYV9l6glKboP1F8AD0mpzNwFqOXtx48jm7iDa7xzEY25bgcA==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.73.0"
+    metro-resolver "0.73.3"
 
-metro-file-map@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.73.0.tgz#7b5a4a87999785a70faa5e5bbc452f1e27478088"
-  integrity sha512-egGbGp0jfTV4+pbFQRD6XzOveFRH/a82+rxnefMZQoWkPx24Yix+SAm1an1dY57Z7YsGoI8V0klR3T69ixlTJw==
+metro-file-map@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.73.3.tgz#e23b2e4d0cab5271372707ef80c91ad1f3512714"
+  integrity sha512-t6JrJH4YO8a1Qf+THZ4FCW1NRZ2qSUQb7p42T1Ea1w3C18OnfOg19xZUAiGQ/46FN7ROeZDdE8LLJDPT0s4fzQ==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -8208,19 +8208,20 @@ metro-file-map@0.73.0:
     jest-util "^27.2.0"
     jest-worker "^27.2.0"
     micromatch "^4.0.4"
+    nullthrows "^1.1.1"
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.73.0.tgz#b65dfbc052c7c47c52499110b76c1a7db28a9b15"
-  integrity sha512-S/KBAA3OKxYmLz/+HzFaPjjg0D+ua101hNicpWPNOsH3ofdZIZctbyFwBp8QJrHVpQOUdEj5jorBtV/9FI/rlA==
+metro-hermes-compiler@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.73.3.tgz#017c200ec0d2585eed19314612fa7a599a935f06"
+  integrity sha512-9r+dXiIt2k2uYmaNgeJoLJNZ2FnO6ok7pLppnMZIwFUEvOiFpvOBlBIpqOCEzzRh3gLinEtZ0SmRPhDstI+Iog==
 
-metro-inspector-proxy@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.73.0.tgz#5eb5eb800dcc37dbbc5c4cade3df8a8905895ba6"
-  integrity sha512-ZVZnhyqj5iFO4dLpEjpYsbGbqWbITfauhnKmCOK7G1vuJpsnIj+lIOsGIsIGBWs6MyzP8nXlPBxR9rP0SbCVWA==
+metro-inspector-proxy@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.73.3.tgz#6ac40f1217fb2ef7fa1331cffe730036dee70b36"
+  integrity sha512-I3Eixd28uamjbKtO6LB7jlGgdwt8zxBrRznp3qMWL8WZU6gu9TU/SAJa1TnABOK0VwdPmz161fWL/eHBEKZCrg==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
@@ -8232,24 +8233,24 @@ metro-memory-fs@0.72.3:
   resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.72.3.tgz#ed5919d2873b044a8cdea4fe97a76105e9a264ab"
   integrity sha512-GNNb6ZHPsV4t6s0senwcdn3W8LF2jniiDBdltghY/xSXSzoDj34hpQyiKYohUBW4y3nrYIXg63ce8198Ep7xOQ==
 
-metro-minify-terser@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.73.0.tgz#42771608a04751f67e0ed4df2e2fc94301dfa469"
-  integrity sha512-gDLAxK1adJAs/bFZMtYv5GQHs2i2+QymfS7d9dm5PVYGHp4m3QyqHHhCELfPE0iztpqcRWycv+0ce1/RqlVv5Q==
+metro-minify-terser@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.73.3.tgz#e0d8164a42067bcf8dfe8a066545d080af213bf5"
+  integrity sha512-EDA+G7WM9ACtlvIc735u002UNedTIKBXx4RaIFFnLbp8Z+0csrTnFY0hsasxwkFR1KcL42TppLiY0L+iO5TuJw==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.73.0.tgz#4f436fd25336c4780952b1d4866f74c41e354ad7"
-  integrity sha512-o0hsOruGMiMS41U/t3qIwqrIoI+vsiM+PCSMtxiR50CFYGbUuhtAYT1bYFwQ4dJsLjH+JKi3GgZ5IGppqnQ3aA==
+metro-minify-uglify@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.73.3.tgz#9e3438e73208a21e085891d5cdf60c80dd97bbb7"
+  integrity sha512-ksI9tiXYwFaNPMyuArzD1x5Fz3CNzlI7dL0uqEriDMdVXk5/7FDwi6hV+pAefTxJlTVt9NStDfKyQyj3x8CxJQ==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.0.tgz#7e5112867ab9d71b87f8dd15991d8da4fd8fc2a5"
-  integrity sha512-ZUMeDAxyRcHL+g4F60Vvky6hE5UgR+jiCEgIVlVWhpKWVqghx3DVvUBD6m5H1czqwBldff9BPnWjobtuH6pDGw==
+metro-react-native-babel-preset@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.3.tgz#c4a0fcae395894ec85e235ec75de88d56f64e291"
+  integrity sha512-JJ22lR4CVaw3OKTz9YAY/ckymr3DbO+qy/x5kLaF4g0LcvZmhhKfDK+fml577AZU6sKb/CTd0SBwt+VAz+Hu7Q==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -8290,64 +8291,64 @@ metro-react-native-babel-preset@0.73.0:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.0.tgz#99539e93c6ff50d183066d31599392891a41f4b3"
-  integrity sha512-cJM/xqi9hloYsDvVVlQZ3PrqDLey1p5au1Go+6uwbC9b0xPYCrzPsLMRCOA6RCye7UwRsnv/CTg3unkQAX+yfw==
+metro-react-native-babel-transformer@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.3.tgz#a521e5f559cec4ec9b878087e606afbb8e92db2b"
+  integrity sha512-9cCdN2S+skTx1IT/A+UHteN80eOmgU0ir3E/wWybUbV/zhWtHQjbxBnB+bEbFNRe9Jmk73Ga9pWkCFqO8txwYw==
   dependencies:
     "@babel/core" "^7.14.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.73.0"
-    metro-react-native-babel-preset "0.73.0"
-    metro-source-map "0.73.0"
+    metro-babel-transformer "0.73.3"
+    metro-react-native-babel-preset "0.73.3"
+    metro-source-map "0.73.3"
     nullthrows "^1.1.1"
 
-metro-resolver@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.73.0.tgz#55524b7bc6d1e816f52c354b405e5ca6f5b7b9c7"
-  integrity sha512-UNznhINzIp3zuCMdgyGjESezJDvliDG0QphQ471/qVQD6xK3mlYkCSKuqv9gQvbkTBXdR3/Me0wkcrsflKJO4A==
+metro-resolver@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.73.3.tgz#dc21ca03c8aeb0bc05fe4e8c318791e213bde9d7"
+  integrity sha512-XbiZ22MaFFchaErNfqeW9ZPPRpiQEIylhtlja9/5QzNgAcAWbfIGY0Ok39XyVyWjX4Ab8YAwQUeCqyO48ojzZQ==
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.73.0.tgz#745cd792a87fd2594747466177785d1eec7d5cd7"
-  integrity sha512-7Ls3ODvZ/x0NLBSB8lT4iMOCH6ElxUz0GyIpEO+qsSrIEdKMtOLPJASwLIvmth9Eid0nEQRg2kvGz4kAdMKTdw==
+metro-runtime@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.73.3.tgz#39fde3484342bf4eb8a3ec9bce8bc519e128e1ea"
+  integrity sha512-ywNq9exXtCiBA/vcmiyuI+sBR3tVMQIkvrmcHJ+cOWf5kl/vBS2FbYimESlMwZKjzH7l07LrQcvAvTn215N9bw==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-source-map@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.73.0.tgz#43a6ff319d53a123f0b96bfe4d59bab9ff127e05"
-  integrity sha512-VrfShEIAyTbCry0MkG4e9a+5v9w3L2/E5xHU/tsWlg5NVfXICrslghb2RIsslwo42Ga7KUtftu+xhSvYktQgtw==
+metro-source-map@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.73.3.tgz#6eaf99ccd98b46f8afd8cb5cbb5e360dcce3836a"
+  integrity sha512-zOm8Ha0hWiJhI52IcMibdNIS6O3YK6qUnQ7dgZOGvnEWRTfzYlX08yFXwMg91GIdXzxHJE43opcPwSE1RDvoGQ==
   dependencies:
     "@babel/traverse" "^7.14.0"
     "@babel/types" "^7.0.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.73.0"
+    metro-symbolicate "0.73.3"
     nullthrows "^1.1.1"
-    ob1 "0.73.0"
+    ob1 "0.73.3"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.73.0.tgz#4593fa86bbfe5d20eb728e82a15ae140f367dbff"
-  integrity sha512-EGwXsQwAoHRG1/ehLuH3ZUKwOhN4aG0hTPmGBiQTrf4AU6HuLhNYg+cxkWu+Ny4rUdmzueqPkPJmHZijJ7Mugw==
+metro-symbolicate@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.73.3.tgz#2641dd63fc8ef348a3c2bb0fa2f82f1a75d8b96a"
+  integrity sha512-gOjoQcUFuDl3YKO0D7rcLEDIw331LM+CiKgIzQlZmx7uZimORnt9xf/8P/Ued0y77q8ColuJAVDqp/JirqRfEw==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.73.0"
+    metro-source-map "0.73.3"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.73.0.tgz#d00e3481220c1fbb7e1559a6417df0301f341afa"
-  integrity sha512-0mrXCeSKlseJZexe6BgX9RG+mRwaeqkS8x2ueiWMVrc72plOjOqGaN4G4YJvGz5wBa+psOBcfvr8zIA8oOlkrg==
+metro-transform-plugins@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.73.3.tgz#cd620058531758665b55427fcb06a3d259086e6c"
+  integrity sha512-zes8OxN07nLcPq/BD7FgFusoVlVYbmQpdW290SRCsnnQK7ul4amzm9clygX54WYjYm8aHXSEmVrZtd/80Q+rZw==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
@@ -8355,29 +8356,29 @@ metro-transform-plugins@0.73.0:
     "@babel/traverse" "^7.14.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.73.0.tgz#541e54d927ebaa44919843b87cf6d1fb9c6a14b6"
-  integrity sha512-V6joFXdN8rQT9NkoxpWF8/fNQM/9BdrnDEUhpROtNO6bPqtIpl2Cw78KQbdcgY34tBKLOxhq0cyhRzRmX+jdxQ==
+metro-transform-worker@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.73.3.tgz#093735e55e2c3564f560e188ff999d9752fc253d"
+  integrity sha512-oF/hFX8Oj/PLuacpzWwYTgf0k0vSxI/nlWBPQkAUuW7QYOv7w9WRWRNczl8fbYohr8LU7CbwuQ662DRzzQDrAQ==
   dependencies:
     "@babel/core" "^7.14.0"
     "@babel/generator" "^7.14.0"
     "@babel/parser" "^7.14.0"
     "@babel/types" "^7.0.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.73.0"
-    metro-babel-transformer "0.73.0"
-    metro-cache "0.73.0"
-    metro-cache-key "0.73.0"
-    metro-hermes-compiler "0.73.0"
-    metro-source-map "0.73.0"
-    metro-transform-plugins "0.73.0"
+    metro "0.73.3"
+    metro-babel-transformer "0.73.3"
+    metro-cache "0.73.3"
+    metro-cache-key "0.73.3"
+    metro-hermes-compiler "0.73.3"
+    metro-source-map "0.73.3"
+    metro-transform-plugins "0.73.3"
     nullthrows "^1.1.1"
 
-metro@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.73.0.tgz#906eb7dac974ef6d23317c50690af80cc5517bdb"
-  integrity sha512-7ZsGBlb4EWqwH1cLXd8H0agj4ES+siMcpStKiieklOn6R2FxF86mqh7epodlGS959WZl6/C4IQW73LDKh5zcyA==
+metro@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.73.3.tgz#d1e3bd247468e0293b644bca408265e725d686f9"
+  integrity sha512-AHjeWI05YyTPaMNAXW4kUDLVr2MPs6DeawofS6CxiWGh2P9aVosC3GPJmXF2fGRW7MKdGvGWIDqUlWJUw8M0CA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.14.0"
@@ -8402,27 +8403,27 @@ metro@0.73.0:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.73.0"
-    metro-cache "0.73.0"
-    metro-cache-key "0.73.0"
-    metro-config "0.73.0"
-    metro-core "0.73.0"
-    metro-file-map "0.73.0"
-    metro-hermes-compiler "0.73.0"
-    metro-inspector-proxy "0.73.0"
-    metro-minify-terser "0.73.0"
-    metro-minify-uglify "0.73.0"
-    metro-react-native-babel-preset "0.73.0"
-    metro-resolver "0.73.0"
-    metro-runtime "0.73.0"
-    metro-source-map "0.73.0"
-    metro-symbolicate "0.73.0"
-    metro-transform-plugins "0.73.0"
-    metro-transform-worker "0.73.0"
+    metro-babel-transformer "0.73.3"
+    metro-cache "0.73.3"
+    metro-cache-key "0.73.3"
+    metro-config "0.73.3"
+    metro-core "0.73.3"
+    metro-file-map "0.73.3"
+    metro-hermes-compiler "0.73.3"
+    metro-inspector-proxy "0.73.3"
+    metro-minify-terser "0.73.3"
+    metro-minify-uglify "0.73.3"
+    metro-react-native-babel-preset "0.73.3"
+    metro-resolver "0.73.3"
+    metro-runtime "0.73.3"
+    metro-source-map "0.73.3"
+    metro-symbolicate "0.73.3"
+    metro-transform-plugins "0.73.3"
+    metro-transform-worker "0.73.3"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
-    rimraf "^2.5.4"
+    rimraf "^3.0.2"
     serialize-error "^2.1.0"
     source-map "^0.5.6"
     strip-ansi "^6.0.0"
@@ -9030,10 +9031,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.73.0:
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.73.0.tgz#408f426d3840784c68b93055553c93dac3a05950"
-  integrity sha512-tC6BcYpQVsjueT64lGvOxvH+0u+g1dWMIEKhMf7ulWwckUDpftoaakO5KUiSDWGgFpC/SmBBwpwTAX2lZMJuPw==
+ob1@0.73.3:
+  version "0.73.3"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.73.3.tgz#36e796fa6fbea4696063cf711fe53505be7bc9a2"
+  integrity sha512-KpCFQty/eGriUsF3tD4FybV2vsWNzID3Thq/3o0VzXn+rtcQdRk1r6USM5PddWaFjxZqbVXjlr6u7DJGhPz9xw==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -10715,7 +10716,7 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
-rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
+rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==


### PR DESCRIPTION
Summary:
---------

Upgrades Metro dependencies to 0.73.3. This includes the last 3 minor releases with no anticipated compatibility issues.

Metro release notes: https://github.com/facebook/metro/releases/tag/v0.73.3
Changelog between 0.73.0 (latest version in `cli-plugin-metro` https://github.com/react-native-community/cli/pull/1711) and 0.73.1: [https://github.com/facebook/metro/compare/v0.73.0..v0.73.3](https://github.com/facebook/metro/compare/v0.73.0%E2%80%A6v0.73.3)

**Reminder**: When React Native updates the CLI to a version that depends on metro 0.73.3, it must also update `metro-runtime` etc to 0.73.3 in the same commit.

Test Plan:
----------

- Updated dependencies with `yarn`.
- ✅ Ran `yarn test`.

