### PR TITLE
Add support for namespace inside build.gradle file.

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/getAndroidProject.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getAndroidProject.test.ts
@@ -6,7 +6,11 @@
  *
  */
 
-import {validatePackageName} from '../getAndroidProject';
+import {
+  validatePackageName,
+  parsePackageNameFromAndroidManifestFile,
+  parseNamespaceFromBuildGradleFile,
+} from '../getAndroidProject';
 
 describe('android::getAndroidProject', () => {
   const expectedResults = {
@@ -32,5 +36,72 @@ describe('android::getAndroidProject', () => {
         expectedResults[packageName],
       );
     });
+  });
+});
+
+describe('parsePackageNameFromAndroidManifestFile', () => {
+  it('should parse package name from AndroidManifest', () => {
+    const androidManifest = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.app"
+    android:versionCode="1"
+    android:versionName="1.0" >
+</manifest>`;
+
+    expect(parsePackageNameFromAndroidManifestFile(androidManifest)).toBe(
+      'com.example.app',
+    );
+  });
+
+  it('should return null if package name is missing from AndroidManifest', () => {
+    const androidManifest = `<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
+    android:versionName="1.0" >
+</manifest>`;
+
+    expect(parsePackageNameFromAndroidManifestFile(androidManifest)).toBeNull();
+  });
+});
+
+describe('parseNamespaceFromBuildGradleFile', () => {
+  // Test that it can parse a namespace from a build.gradle file
+  it('should parse namespace from build.gradle', () => {
+    const buildGradle = `apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 31
+    namespace "com.example.app"
+}`;
+
+    expect(parseNamespaceFromBuildGradleFile(buildGradle)).toBe(
+      'com.example.app',
+    );
+  });
+
+  // Test that it can parse a namespace from a build.gradle.kts file
+  it('should parse namespace from build.gradle.kts', () => {
+    const buildGradle = `plugins {
+    id 'com.android.application'
+}
+
+android {
+    compileSdk = 31
+    namespace = "com.example.app"
+}`;
+
+    expect(parseNamespaceFromBuildGradleFile(buildGradle)).toBe(
+      'com.example.app',
+    );
+  });
+
+  // Test that it returns null if namespace is missing from build.gradle
+  it('should return null if namespace is missing from build.gradle', () => {
+    const buildGradle = `apply plugin: 'com.android.application'
+android {
+    compileSdkVersion 31
+}`;
+
+    expect(parseNamespaceFromBuildGradleFile(buildGradle)).toBeNull();
   });
 });

--- a/packages/cli-platform-android/src/config/findBuildGradle.ts
+++ b/packages/cli-platform-android/src/config/findBuildGradle.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+
+export function findBuildGradle(sourceDir: string) {
+  const buildGradlePath = path.join(sourceDir, 'build.gradle');
+  const buildGradleKtsPath = path.join(sourceDir, 'build.gradle.kts');
+
+  if (fs.existsSync(buildGradlePath)) {
+    return buildGradlePath;
+  } else if (fs.existsSync(buildGradleKtsPath)) {
+    return buildGradleKtsPath;
+  } else {
+    return null;
+  }
+}

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -20,6 +20,7 @@ import {
 import {getPackageName} from './getAndroidProject';
 import {findLibraryName} from './findLibraryName';
 import {findComponentDescriptors} from './findComponentDescriptors';
+import {findBuildGradle} from './findBuildGradle';
 
 /**
  * Gets android project config by analyzing given folder and taking some
@@ -42,12 +43,14 @@ export function projectConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(path.join(sourceDir, appName));
+  const buildGradlePath = findBuildGradle(sourceDir);
 
   if (!manifestPath) {
     return null;
   }
 
-  const packageName = userConfig.packageName || getPackageName(manifestPath);
+  const packageName =
+    userConfig.packageName || getPackageName(manifestPath, buildGradlePath);
 
   if (!packageName) {
     throw new Error(`Package name not found in ${manifestPath}`);
@@ -96,12 +99,14 @@ export function dependencyConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);
+  const buildGradlePath = path.join(sourceDir, 'build.gradle');
 
   if (!manifestPath) {
     return null;
   }
 
-  const packageName = userConfig.packageName || getPackageName(manifestPath);
+  const packageName =
+    userConfig.packageName || getPackageName(manifestPath, buildGradlePath);
   const packageClassName = findPackageClassName(sourceDir);
 
   /**


### PR DESCRIPTION
Summary:
---------

This commit introduces the support for getting the Android package from the `namespace` field inside the build.gradle file.

Starting from the recent version of AGP, users should use namespace to setup the package rather than AndroidManifest.xml

Not doing this, is causing this warning on new apps on console:
```
package="com.androidtemplateproject" found in source AndroidManifest.xml: /tmp/AndroidTemplateProject/android/app/src/main/AndroidManifest.xml.
Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
```
This commit allows user to setup the namespace inside the build.gradle to suppress this resolve this warning and still being able to build.

Fixes: #1721
Also related to https://github.com/facebook/react-native/pull/35094

Test Plan:
----------

I've wrote Jest tests for this + for also the package parsing which were missing.