### PR TITLE
Fix findBuildGradle for app & libraries

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-platform-android/src/config/__fixtures__/android.ts
@@ -18,8 +18,11 @@ const mainJavaClass = fs.readFileSync(
 const buildGradle = fs.readFileSync(
   path.join(__dirname, './files/build.gradle'),
 );
+const appBuildGradle = fs.readFileSync(
+  path.join(__dirname, './files/appbuild.gradle'),
+);
 
-function generateValidFileStructure(classFileName: string) {
+function generateValidFileStructureForLib(classFileName: string) {
   return {
     'build.gradle': buildGradle,
     src: {
@@ -40,9 +43,23 @@ function generateValidFileStructure(classFileName: string) {
   };
 }
 
-export const valid = generateValidFileStructure('ReactPackage.java');
+function generateValidFileStructureForApp() {
+  return {
+    'build.gradle': buildGradle,
+    app: {
+      'build.gradle': appBuildGradle,
+    },
+    src: {
+      'AndroidManifest.xml': manifest,
+    },
+  };
+}
 
-export const validKotlin = generateValidFileStructure('ReactPackage.kt');
+export const valid = generateValidFileStructureForLib('ReactPackage.java');
+
+export const validKotlin = generateValidFileStructureForLib('ReactPackage.kt');
+
+export const validApp = generateValidFileStructureForApp('ReactPackage.java');
 
 export const userConfigManifest = {
   src: {

--- a/packages/cli-platform-android/src/config/__fixtures__/files/appbuild.gradle
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/appbuild.gradle
@@ -1,0 +1,10 @@
+apply package: "com.android.application"
+apply package: "com.facebook.react"
+
+react {
+    // 
+}
+
+android {
+    compileSdkVersion 33
+}

--- a/packages/cli-platform-android/src/config/__tests__/findBuildGradle.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/findBuildGradle.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {findBuildGradle} from '../findBuildGradle';
+import * as mocks from '../__fixtures__/android';
+
+jest.mock('path');
+jest.mock('fs');
+
+const fs = require('fs');
+
+describe('findBuildGradle for apps', () => {
+  beforeAll(() => {
+    fs.__setMockFilesystem({
+      empty: {},
+      flat: {
+        android: mocks.validApp,
+      },
+    });
+  });
+
+  it('returns the app gradle path if file exists in the folder', () => {
+    expect(findBuildGradle('/flat/android', false)).toBe(
+      '/flat/android/app/build.gradle',
+    );
+  });
+
+  it('returns `null` if there is no gradle in the app folder', () => {
+    expect(findBuildGradle('/empty', false)).toBeNull();
+  });
+});
+
+describe('findBuildGradle for libraries', () => {
+  beforeAll(() => {
+    fs.__setMockFilesystem({
+      empty: {},
+      flat: {
+        android: mocks.valid,
+      },
+    });
+  });
+
+  it('returns the app gradle path if file exists in the folder', () => {
+    expect(findBuildGradle('/flat/android', true)).toBe(
+      '/flat/android/build.gradle',
+    );
+  });
+
+  it('returns `null` if there is no gradle in the app folder', () => {
+    expect(findBuildGradle('/empty', true)).toBeNull();
+  });
+});

--- a/packages/cli-platform-android/src/config/findBuildGradle.ts
+++ b/packages/cli-platform-android/src/config/findBuildGradle.ts
@@ -1,9 +1,15 @@
 import fs from 'fs';
 import path from 'path';
 
-export function findBuildGradle(sourceDir: string) {
-  const buildGradlePath = path.join(sourceDir, 'build.gradle');
-  const buildGradleKtsPath = path.join(sourceDir, 'build.gradle.kts');
+export function findBuildGradle(sourceDir: string, isLibrary: boolean) {
+  const buildGradlePath = path.join(
+    sourceDir,
+    isLibrary ? 'build.gradle' : 'app/build.gradle',
+  );
+  const buildGradleKtsPath = path.join(
+    sourceDir,
+    isLibrary ? 'build.gradle.kts' : 'app/build.gradle.kts',
+  );
 
   if (fs.existsSync(buildGradlePath)) {
     return buildGradlePath;

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -43,7 +43,7 @@ export function projectConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(path.join(sourceDir, appName));
-  const buildGradlePath = findBuildGradle(sourceDir);
+  const buildGradlePath = findBuildGradle(sourceDir, false);
 
   if (!manifestPath) {
     return null;
@@ -99,7 +99,7 @@ export function dependencyConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);
-  const buildGradlePath = path.join(sourceDir, 'build.gradle');
+  const buildGradlePath = findBuildGradle(sourceDir, true);
 
   if (!manifestPath) {
     return null;


### PR DESCRIPTION
Summary:
---------

Apps & Libraries have a different file structure for `build.gradle`, as apps have it inside `app/build.gradle`. I'm adding this logic here as it was missing.


Test Plan:
----------

I've added tests for it.