### PR TITLE
Feat: customise ios build folder location with `iosBuildFolder` flag

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -38,6 +38,7 @@ type FlagsT = {
   port: number;
   terminal: string | undefined;
   xcconfig?: string;
+  iosBuildFolder?: string;
 };
 
 function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
@@ -320,6 +321,7 @@ function buildProject(
       xcodeProject.isWorkspace ? '-workspace' : '-project',
       xcodeProject.name,
       ...(args.xcconfig ? ['-xcconfig', args.xcconfig] : []),
+      ...(args.iosBuildFolder ? ['-derivedDataPath', args.iosBuildFolder] : []),
       '-configuration',
       args.configuration,
       '-scheme',
@@ -638,6 +640,10 @@ export default {
     {
       name: '--xcconfig [string]',
       description: 'Explicitly set xcconfig to use',
+    },
+    {
+      name: '--iosBuildFolder <string>',
+      description: 'Location for iOS build artifacts',
     },
   ],
 };

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -38,7 +38,7 @@ type FlagsT = {
   port: number;
   terminal: string | undefined;
   xcconfig?: string;
-  iosBuildFolder?: string;
+  buildFolder?: string;
 };
 
 function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
@@ -321,7 +321,7 @@ function buildProject(
       xcodeProject.isWorkspace ? '-workspace' : '-project',
       xcodeProject.name,
       ...(args.xcconfig ? ['-xcconfig', args.xcconfig] : []),
-      ...(args.iosBuildFolder ? ['-derivedDataPath', args.iosBuildFolder] : []),
+      ...(args.buildFolder ? ['-derivedDataPath', args.buildFolder] : []),
       '-configuration',
       args.configuration,
       '-scheme',
@@ -642,7 +642,7 @@ export default {
       description: 'Explicitly set xcconfig to use',
     },
     {
-      name: '--iosBuildFolder <string>',
+      name: '--buildFolder <string>',
       description: 'Location for iOS build artifacts',
     },
   ],


### PR DESCRIPTION
Summary:

Fixes #1706 

Test Plan:

Clone the branch and run `react-native run-ios --buildFolder "build"` command.
It should run the app as usual but put build artifacts into `ios/build` folder. 

![image](https://user-images.githubusercontent.com/13610886/198869098-8dacd078-c590-4763-b93c-0d2a393e426a.png)
