### PR TITLE
fix: select iPhone 14 as a default simulator

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -596,7 +596,7 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between ' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
-      default: 'iPhone 13',
+      default: 'iPhone 14',
     },
     {
       name: '--configuration <string>',


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
`npx react-native run-ios` starts iPhone 13 simulator by default. This PR tries to fix this by selecting iPhone 14 as default simulator.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
`npx react-native run-ios` should run iPhone 14 as default simulator.
