### PR TITLE
docs: update commands documentation, mention derivedDataPath

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -436,13 +436,17 @@ Do not use `xcbeautify` or `xcpretty` even if installed.
 
 #### `--port <number>`
 
-Runs packager on specified port
+Runs packager on specified port.
 
 Default: `process.env.RCT_METRO_PORT || 8081`
 
 #### `--xcconfig <string>`
 
-Explicitly pass `xcconfig` options from the command line 
+Explicitly pass `xcconfig` options from the command line.
+
+#### `--buildFolder <string>`
+
+Location for iOS build artifacts. Corresponds to Xcode's `-derivedDataPath`.
 
 ### `start`
 

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -643,7 +643,8 @@ export default {
     },
     {
       name: '--buildFolder <string>',
-      description: 'Location for iOS build artifacts',
+      description:
+        'Location for iOS build artifacts. Corresponds to Xcode\'s "-derivedDataPath".',
     },
   ],
 };


### PR DESCRIPTION
Summary:
---------

Update commands documentation about `buildFolder` for `run-ios`, mention it corresponds to `-derivedDataPath`.


Test Plan:
----------

Docs