### PR TITLE
fix: Make paths in the CmakeLists scripts Windows friendly

### DIFF
--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -135,7 +135,7 @@ export function dependencyConfig(
   let cmakeListsPath = userConfig.cmakeListsPath
     ? path.join(sourceDir, userConfig.cmakeListsPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
-  if(process.platform == "win32") {
+  if (process.platform === "win32") {
     cmakeListsPath = cmakeListsPath.replace(/\\/g, "/");
   }
   return {

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -136,7 +136,7 @@ export function dependencyConfig(
     ? path.join(sourceDir, userConfig.cmakeListsPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
   if(process.platform == "win32") {
-    cmakeListsPath = cmakeListsPath.replaceAll("\\", "/")
+    cmakeListsPath = cmakeListsPath.replace(/\\/g, "/");
   }
   return {
     sourceDir,

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -132,10 +132,12 @@ export function dependencyConfig(
   const androidMkPath = userConfig.androidMkPath
     ? path.join(sourceDir, userConfig.androidMkPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/Android.mk');
-  const cmakeListsPath = userConfig.cmakeListsPath
+  let cmakeListsPath = userConfig.cmakeListsPath
     ? path.join(sourceDir, userConfig.cmakeListsPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
-
+  if(process.platform == "win32") {
+    cmakeListsPath = cmakeListsPath.replaceAll("\\", "/")
+  }
   return {
     sourceDir,
     packageImportPath,

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -135,8 +135,8 @@ export function dependencyConfig(
   let cmakeListsPath = userConfig.cmakeListsPath
     ? path.join(sourceDir, userConfig.cmakeListsPath)
     : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
-  if (process.platform === "win32") {
-    cmakeListsPath = cmakeListsPath.replace(/\\/g, "/");
+  if (process.platform === 'win32') {
+    cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
   }
   return {
     sourceDir,


### PR DESCRIPTION
Summary:
---------

The paths in the CMake script generated for autolinking the modules contains backslashes which CMake don't like. This patch fixes the file paths to replace the backslashes with forward slases.

Test Plan:
----------

Tested autolinking modules locally on windows.