### PR TITLE
Fix: Prohibit passing both version and template to init command

### DIFF
--- a/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
+++ b/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
@@ -5,7 +5,7 @@ export default class TemplateAndVersionError extends Error {
       
       --template ${template}@x.y.z
       
-      where x.y.z is the version containing the "react-native" you'd like. Check: https://www.npmjs.com/package/${template} for available versions`,
+      where x.y.z is the release of the template that contains the desired "react-native" version. Check the version tab of https://www.npmjs.com/package/${template} for available versions`,
     );
   }
 }

--- a/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
+++ b/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
@@ -1,0 +1,11 @@
+export default class TemplateAndVersionError extends Error {
+  constructor(template: string) {
+    super(
+      `Passing both "version" and "template" is not supported. Templates are in control of "react-native" version. Please choose only one of these, like so:
+      
+      --template ${template}@x.y.z
+      
+      where x.y.z is the version containing the "react-native" you'd like. Check: https://www.npmjs.com/package/${template} for available versions`,
+    );
+  }
+}

--- a/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
+++ b/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
@@ -1,7 +1,7 @@
 export default class TemplateAndVersionError extends Error {
   constructor(template: string) {
     super(
-      `Passing both "version" and "template" is not supported. Templates are in control of "react-native" version. Please choose only one of these, like so:
+      `Passing both "version" and "template" is not supported. The template you select determines the version of react-native used. Please use only one of these options, for example:
       
       --template ${template}@x.y.z
       

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -20,6 +20,7 @@ import {changePlaceholderInTemplate} from './editTemplate';
 import * as PackageManager from '../../tools/packageManager';
 import {installPods} from '@react-native-community/cli-doctor';
 import banner from './banner';
+import TemplateAndVersionError from './errors/TemplateAndVersionError';
 
 const DEFAULT_VERSION = 'latest';
 
@@ -197,6 +198,10 @@ export default (async function initialize(
   options: Options,
 ) {
   validateProjectName(projectName);
+
+  if (!!options.template && !!options.version) {
+    throw new TemplateAndVersionError(options.template);
+  }
 
   const root = process.cwd();
   const version = options.version || DEFAULT_VERSION;


### PR DESCRIPTION
Summary:
---------

When we pass both `--version` and `--template` options to `init` command we are using version of react-native taken from template not the one passed with init command. 

This PR will raise and error in such case and show appropriate message:  

```ts
❯ node ./cli/packages/cli/build/bin.js init MyApp --version 0.68.4 --template react-native-template-typescript
error Passing both "version" and "template" is not supported. Templates are in control of "react-native" version. Please choose only one of these, like so:
      
      --template react-native-template-typescript@x.y.z
      
      where x.y.z is the version containing the "react-native" you'd like. Check: https://www.npmjs.com/package/react-native-template-typescript for available versions.
```

Test Plan:
----------

Clone the repo and try to init new project with command:
`> node ./cli/packages/cli/build/bin.js init MyApp --version 0.68.4 --template react-native-template-typescript`