### PR TITLE
fix: add chalk to cli-config dependencies

### DIFF
--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -9,7 +9,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@react-native-community/cli-tools": "^10.0.0-alpha.0",
-    "chalk": "^4.1.2",
+    "chalk": "^5.1.2",
     "cosmiconfig": "^5.1.0",
     "deepmerge": "^3.2.0",
     "glob": "^7.1.3",

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -9,7 +9,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@react-native-community/cli-tools": "^10.0.0-alpha.0",
-    "chalk": "^5.1.2",
+    "chalk": "^4.1.2",
     "cosmiconfig": "^5.1.0",
     "deepmerge": "^3.2.0",
     "glob": "^7.1.3",

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -9,6 +9,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@react-native-community/cli-tools": "^10.0.0-alpha.0",
+    "chalk": "^4.1.2",
     "cosmiconfig": "^5.1.0",
     "deepmerge": "^3.2.0",
     "glob": "^7.1.3",


### PR DESCRIPTION
Summary:
---------

Adds `chalk` as a dependency. The [source code](https://github.com/react-native-community/cli/blob/main/packages/cli-config/src/readConfigFromDisk.ts#L9) uses [chalk](https://www.npmjs.com/package/chalk) but does not include it as a dependency. 

Test Plan:
----------
N/A
