### PR TITLE
Remove unwanted spaces `add_subdirectory` paths in Android-rncli.cmake

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -303,12 +303,12 @@ class ReactNativeModules {
         if (it.libraryName != null && it.cmakeListsPath != null) {
           // If user provided a custom cmakeListsPath, let's honor it.
           String nativeFolderPath = it.cmakeListsPath.replace("CMakeLists.txt", "")
-          "add_subdirectory($nativeFolderPath ${it.libraryName}_autolinked_build)"
+          "add_subdirectory($nativeFolderPath${it.libraryName}_autolinked_build)"
         } else if (it.libraryName != null && it.androidMkPath != null) {
           // Fallback to previous behavior: reusing androidMkPath.
           // We assume CMakeLists.txt file is in the same folder as the Android.mk
           String nativeFolderPath = it.androidMkPath.replace("Android.mk", "")
-          "add_subdirectory($nativeFolderPath ${it.libraryName}_autolinked_build)"
+          "add_subdirectory($nativeFolderPath${it.libraryName}_autolinked_build)"
         } else {
           null
         }


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

This PR removes unwanted spaces in paths in `add_subdirectory` command in autogenerated `Android-rncli.cmake`:

![obraz](https://user-images.githubusercontent.com/20516055/199940341-dc4c8b47-3351-42c8-bf93-63801f8a1771.png)

Along with #1734, this should fix building new-arch RN apps for Android on Windows.

Test Plan:
----------

I couldn't find any snapshot tests that would contain `add_subdirectory` so not sure how to prove it works 🤷 
