### PR TITLE
feat: build-android command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@ React Native CLI comes with following commands:
 - [`log-ios`](#log-ios)
 - [`ram-bundle`](#ram-bundle)
 - [`run-android`](#run-android)
+- [`build-android`](#build-android)
 - [`run-ios`](#run-ios)
 - [`start`](#start)
 - [`upgrade`](#upgrade)
@@ -378,6 +379,35 @@ Example: `yarn react-native run-android --tasks clean,installDebug`.
 > default: false
 
 Build native libraries only for the current device architecture for debug builds.
+
+### `build-android`
+
+Usage:
+
+```sh
+react-native build-android [options]
+```
+
+Builds Android app.
+
+#### Options
+
+#### `--mode <release|debug>`
+
+> default: debug
+
+Mode to build the app. Either 'debug' (default) or 'release'. 
+
+#### `--variant <string>`
+
+Custom build variant that is set in `build.gradle` file. Will override `mode` option.
+
+Example: this will build Android app with Staging variant (run `./gradlew bundleStaging` under the hood):
+
+```bash
+react-native build-android --variant staging
+```
+
 
 ### `run-ios`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -398,14 +398,13 @@ Builds Android app.
 
 Mode to build the app. Either 'debug' (default) or 'release'. 
 
-#### `--variant <string>`
 
-Custom build variant that is set in `build.gradle` file. Will override `mode` option.
+#### `--extra-params <string>`
 
-Example: this will build Android app with Staging variant (run `./gradlew bundleStaging` under the hood):
-
-```bash
-react-native build-android --variant staging
+Custom properties that will be passed to gradle build command. 
+Example: 
+```sh
+react-native build-android --extra-params "-x lint -x test"
 ```
 
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -392,7 +392,7 @@ Builds Android app.
 
 #### Options
 
-#### `--mode <release|debug>`
+#### `--mode <string>`
 
 > default: debug
 

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -54,10 +54,9 @@ async function buildAndroid(
   const tasks = args.tasks || ['assemble' + toPascalCase(variant)];
   const gradleArgs = getTaskNames(androidProject.appName, tasks);
 
-  const adbPath = getAdbPath();
-  const devices = adb.getDevices(adbPath);
-
   if (args.activeArchOnly) {
+    const adbPath = getAdbPath();
+    const devices = adb.getDevices(adbPath);
     const architectures = devices
       .map((device) => {
         return adb.getCPU(adbPath, device);

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -1,0 +1,54 @@
+import {CLIError, logger} from '@react-native-community/cli-tools';
+import {Config} from '@react-native-community/cli-types';
+import execa from 'execa';
+import {getAndroidProject} from '../../config/getAndroidProject';
+import {toPascalCase} from '../runAndroid/runOnAllDevices';
+
+export interface BuildFlags {
+  mode: 'debug' | 'release';
+  '--variant'?: string;
+}
+type AndroidProject = NonNullable<Config['project']['android']>;
+
+async function buildAndroid(
+  _argv: Array<string>,
+  config: Config,
+  args: BuildFlags,
+) {
+  const androidProject = getAndroidProject(config);
+  return build(args, androidProject);
+}
+
+function build(args: BuildFlags, androidProject: AndroidProject) {
+  const variant = args['--variant'] ?? (args.mode || 'debug');
+  process.chdir(androidProject.sourceDir);
+  const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
+  const gradleArgs = [`bundle${toPascalCase(variant)}`];
+  logger.info('Building the app...');
+  logger.debug(`Running command "${cmd} ${gradleArgs.join(' ')}"`);
+  try {
+    execa.sync(cmd, gradleArgs, {
+      stdio: 'inherit',
+      cwd: androidProject.sourceDir,
+    });
+  } catch (error) {
+    throw new CLIError('Failed to build the app.', error);
+  }
+}
+
+export default {
+  name: 'build-android',
+  description: 'builds your app',
+  func: buildAndroid,
+  options: [
+    {
+      name: '--mode <release|debug>',
+      description: "Specify your app's build variant",
+      default: 'debug',
+    },
+    {
+      name: '--variant <string>',
+      description: 'Override mode with your custom configuration',
+    },
+  ],
+};

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -1,14 +1,49 @@
-import {CLIError, logger} from '@react-native-community/cli-tools';
+import {
+  CLIError,
+  getDefaultUserTerminal,
+  isPackagerRunning,
+  logger,
+} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
 import execa from 'execa';
 import {getAndroidProject} from '../../config/getAndroidProject';
-import {toPascalCase} from '../runAndroid/runOnAllDevices';
+import {getTaskNames, toPascalCase} from '../runAndroid/runOnAllDevices';
+import adb from '../runAndroid/adb';
+import getAdbPath from '../runAndroid/getAdbPath';
+import {startServerInNewWindow} from '../runAndroid';
 
 export interface BuildFlags {
   mode: 'debug' | 'release';
-  '--variant'?: string;
+  variant?: string;
+  activeArchOnly?: boolean;
+  packager: boolean;
+  port: number;
+  terminal: string;
+  tasks?: Array<string>;
 }
-type AndroidProject = NonNullable<Config['project']['android']>;
+
+export async function checkPackager(args: BuildFlags, config: Config) {
+  if (!args.packager) {
+    return Promise.resolve();
+  }
+  const result = await isPackagerRunning(args.port);
+  if (result === 'running') {
+    logger.info('JS server already running.');
+  } else if (result === 'unrecognized') {
+    logger.warn('JS server not recognized, continuing with build...');
+  } else {
+    // result == 'not_running'
+    logger.info('Starting JS server...');
+    try {
+      startServerInNewWindow(args.port, args.terminal, config.reactNativePath);
+    } catch (error) {
+      logger.warn(
+        `Failed to automatically start the packager server. Please run "react-native start" manually. Error details: ${error.message}`,
+      );
+    }
+  }
+  return Promise.resolve();
+}
 
 async function buildAndroid(
   _argv: Array<string>,
@@ -16,20 +51,44 @@ async function buildAndroid(
   args: BuildFlags,
 ) {
   const androidProject = getAndroidProject(config);
-  return build(args, androidProject);
+  const variant = args.variant ?? (args.mode || 'debug');
+  const tasks = args.tasks || ['assemble' + toPascalCase(variant)];
+  const gradleArgs = getTaskNames(androidProject.appName, tasks);
+
+  const adbPath = getAdbPath();
+  const devices = adb.getDevices(adbPath);
+
+  if (args.activeArchOnly) {
+    const architectures = devices
+      .map((device) => {
+        return adb.getCPU(adbPath, device);
+      })
+      .filter(
+        (arch, index, array) => arch != null && array.indexOf(arch) === index,
+      );
+    if (architectures.length > 0) {
+      logger.info(`Detected architectures ${architectures.join(', ')}`);
+      // `reactNativeDebugArchitectures` was renamed to `reactNativeArchitectures` in 0.68.
+      // Can be removed when 0.67 no longer needs to be supported.
+      gradleArgs.push(
+        '-PreactNativeDebugArchitectures=' + architectures.join(','),
+      );
+      gradleArgs.push('-PreactNativeArchitectures=' + architectures.join(','));
+    }
+  }
+  await checkPackager(args, config);
+  return build(gradleArgs, androidProject.sourceDir);
 }
 
-function build(args: BuildFlags, androidProject: AndroidProject) {
-  const variant = args['--variant'] ?? (args.mode || 'debug');
-  process.chdir(androidProject.sourceDir);
+export function build(gradleArgs: string[], sourceDir: string) {
+  process.chdir(sourceDir);
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
-  const gradleArgs = [`bundle${toPascalCase(variant)}`];
   logger.info('Building the app...');
   logger.debug(`Running command "${cmd} ${gradleArgs.join(' ')}"`);
   try {
     execa.sync(cmd, gradleArgs, {
       stdio: 'inherit',
-      cwd: androidProject.sourceDir,
+      cwd: sourceDir,
     });
   } catch (error) {
     throw new CLIError('Failed to build the app.', error);
@@ -49,6 +108,33 @@ export default {
     {
       name: '--variant <string>',
       description: 'Override mode with your custom configuration',
+    },
+    {
+      name: '--no-packager',
+      description: 'Do not launch packager while building',
+    },
+    {
+      name: '--port <number>',
+      default: process.env.RCT_METRO_PORT || 8081,
+      parse: Number,
+    },
+    {
+      name: '--terminal <string>',
+      description:
+        'Launches the Metro Bundler in a new window using the specified terminal path.',
+      default: getDefaultUserTerminal(),
+    },
+    {
+      name: '--tasks <list>',
+      description:
+        'Run custom Gradle tasks. By default it\'s "assembleDebug". Will override passed mode and variant arguments.',
+      parse: (val: string) => val.split(','),
+    },
+    {
+      name: '--active-arch-only',
+      description:
+        'Build native libraries only for the current device architecture for debug builds.',
+      default: false,
     },
   ],
 };

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -24,7 +24,7 @@ export interface BuildFlags {
 
 export async function checkPackager(args: BuildFlags, config: Config) {
   if (!args.packager) {
-    return Promise.resolve();
+    return;
   }
   const result = await isPackagerRunning(args.port);
   if (result === 'running') {

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -22,7 +22,7 @@ export interface BuildFlags {
   tasks?: Array<string>;
 }
 
-export async function checkPackager(args: BuildFlags, config: Config) {
+export async function runPackager(args: BuildFlags, config: Config) {
   if (!args.packager) {
     return;
   }
@@ -74,7 +74,7 @@ async function buildAndroid(
       gradleArgs.push('-PreactNativeArchitectures=' + architectures.join(','));
     }
   }
-  await checkPackager(args, config);
+  await runPackager(args, config);
   return build(gradleArgs, androidProject.sourceDir);
 }
 

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -42,7 +42,6 @@ export async function checkPackager(args: BuildFlags, config: Config) {
       );
     }
   }
-  return Promise.resolve();
 }
 
 async function buildAndroid(

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -13,7 +13,8 @@ import getAdbPath from '../runAndroid/getAdbPath';
 import {startServerInNewWindow} from '../runAndroid';
 
 export interface BuildFlags {
-  mode: 'debug' | 'release';
+  mode: string;
+  variant: string;
   activeArchOnly?: boolean;
   packager: boolean;
   port: number;
@@ -50,7 +51,14 @@ async function buildAndroid(
   args: BuildFlags,
 ) {
   const androidProject = getAndroidProject(config);
-  const variant = args.mode || 'debug';
+
+  if (args.variant) {
+    logger.warn(
+      '"variant" flag is deprecated and will be removed in future release. Please switch to "mode" flag.',
+    );
+  }
+
+  const mode = args.variant || args.mode;
 
   if (args.tasks && args.mode) {
     logger.warn(
@@ -58,7 +66,7 @@ async function buildAndroid(
     );
   }
 
-  const tasks = args.tasks || ['assemble' + toPascalCase(variant)];
+  const tasks = args.tasks || ['assemble' + toPascalCase(mode)];
 
   let gradleArgs = getTaskNames(androidProject.appName, tasks);
 
@@ -111,9 +119,14 @@ export default {
   func: buildAndroid,
   options: [
     {
-      name: '--mode <release|debug>',
+      name: '--mode <string>',
       description: "Specify your app's build variant",
       default: 'debug',
+    },
+    {
+      name: '--variant <string>',
+      description:
+        "Specify your app's build variant. Deprecated! Use 'mode' instead",
     },
     {
       name: '--no-packager',

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -10,7 +10,7 @@ import {getAndroidProject} from '../../config/getAndroidProject';
 import {getTaskNames, toPascalCase} from '../runAndroid/runOnAllDevices';
 import adb from '../runAndroid/adb';
 import getAdbPath from '../runAndroid/getAdbPath';
-import {startServerInNewWindow} from '../runAndroid';
+import {startServerInNewWindow} from './startServerInNewWindow';
 
 export interface BuildFlags {
   mode: string;
@@ -113,52 +113,54 @@ export function build(gradleArgs: string[], sourceDir: string) {
   }
 }
 
+export const options = [
+  {
+    name: '--mode <string>',
+    description: "Specify your app's build variant",
+    default: 'debug',
+  },
+  {
+    name: '--variant <string>',
+    description:
+      "Specify your app's build variant. Deprecated! Use 'mode' instead",
+  },
+  {
+    name: '--no-packager',
+    description: 'Do not launch packager while building',
+  },
+  {
+    name: '--port <number>',
+    default: process.env.RCT_METRO_PORT || 8081,
+    parse: Number,
+  },
+  {
+    name: '--terminal <string>',
+    description:
+      'Launches the Metro Bundler in a new window using the specified terminal path.',
+    default: getDefaultUserTerminal(),
+  },
+  {
+    name: '--tasks <list>',
+    description:
+      'Run custom Gradle tasks. By default it\'s "assembleDebug". Will override passed mode and variant arguments.',
+    parse: (val: string) => val.split(','),
+  },
+  {
+    name: '--active-arch-only',
+    description:
+      'Build native libraries only for the current device architecture for debug builds.',
+    default: false,
+  },
+  {
+    name: '--extra-params <string>',
+    description: 'Custom properties passed to gradle build command',
+    parse: (val: string) => val.split(' '),
+  },
+];
+
 export default {
   name: 'build-android',
   description: 'builds your app',
   func: buildAndroid,
-  options: [
-    {
-      name: '--mode <string>',
-      description: "Specify your app's build variant",
-      default: 'debug',
-    },
-    {
-      name: '--variant <string>',
-      description:
-        "Specify your app's build variant. Deprecated! Use 'mode' instead",
-    },
-    {
-      name: '--no-packager',
-      description: 'Do not launch packager while building',
-    },
-    {
-      name: '--port <number>',
-      default: process.env.RCT_METRO_PORT || 8081,
-      parse: Number,
-    },
-    {
-      name: '--terminal <string>',
-      description:
-        'Launches the Metro Bundler in a new window using the specified terminal path.',
-      default: getDefaultUserTerminal(),
-    },
-    {
-      name: '--tasks <list>',
-      description:
-        'Run custom Gradle tasks. By default it\'s "assembleDebug". Will override passed mode and variant arguments.',
-      parse: (val: string) => val.split(','),
-    },
-    {
-      name: '--active-arch-only',
-      description:
-        'Build native libraries only for the current device architecture for debug builds.',
-      default: false,
-    },
-    {
-      name: '--extra-params <string>',
-      description: 'Custom properties passed to gradle build command',
-      parse: (val: string) => val.split(' '),
-    },
-  ],
+  options: options,
 };

--- a/packages/cli-platform-android/src/commands/buildAndroid/startServerInNewWindow.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/startServerInNewWindow.ts
@@ -1,0 +1,81 @@
+import path from 'path';
+import fs from 'fs';
+import execa from 'execa';
+import {logger} from '@react-native-community/cli-tools';
+
+export function startServerInNewWindow(
+  port: number,
+  terminal: string,
+  reactNativePath: string,
+) {
+  /**
+   * Set up OS-specific filenames and commands
+   */
+  const isWindows = /^win/.test(process.platform);
+  const scriptFile = isWindows
+    ? 'launchPackager.bat'
+    : 'launchPackager.command';
+  const packagerEnvFilename = isWindows ? '.packager.bat' : '.packager.env';
+  const portExportContent = isWindows
+    ? `set RCT_METRO_PORT=${port}`
+    : `export RCT_METRO_PORT=${port}`;
+
+  /**
+   * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port.
+   */
+  const launchPackagerScript = path.join(
+    reactNativePath,
+    `scripts/${scriptFile}`,
+  );
+
+  /**
+   * Set up the `launchpackager.(command|bat)` file.
+   * It lives next to `.packager.(bat|env)`
+   */
+  const scriptsDir = path.dirname(launchPackagerScript);
+  const packagerEnvFile = path.join(scriptsDir, packagerEnvFilename);
+  const procConfig: execa.SyncOptions = {cwd: scriptsDir};
+
+  /**
+   * Ensure we overwrite file by passing the `w` flag
+   */
+  fs.writeFileSync(packagerEnvFile, portExportContent, {
+    encoding: 'utf8',
+    flag: 'w',
+  });
+
+  if (process.platform === 'darwin') {
+    try {
+      return execa.sync(
+        'open',
+        ['-a', terminal, launchPackagerScript],
+        procConfig,
+      );
+    } catch (error) {
+      return execa.sync('open', [launchPackagerScript], procConfig);
+    }
+  }
+  if (process.platform === 'linux') {
+    try {
+      return execa.sync(terminal, ['-e', `sh ${launchPackagerScript}`], {
+        ...procConfig,
+        detached: true,
+      });
+    } catch (error) {
+      // By default, the child shell process will be attached to the parent
+      return execa.sync('sh', [launchPackagerScript], procConfig);
+    }
+  }
+  if (/^win/.test(process.platform)) {
+    // Awaiting this causes the CLI to hang indefinitely, so this must execute without await.
+    return execa('cmd.exe', ['/C', launchPackagerScript], {
+      ...procConfig,
+      detached: true,
+      stdio: 'ignore',
+    });
+  }
+  logger.error(
+    `Cannot start the packager. Unknown platform ${process.platform}`,
+  );
+  return;
+}

--- a/packages/cli-platform-android/src/commands/index.ts
+++ b/packages/cli-platform-android/src/commands/index.ts
@@ -1,4 +1,5 @@
+import buildAndroid from './buildAndroid';
 import logAndroid from './logAndroid';
 import runAndroid from './runAndroid';
 
-export default [logAndroid, runAndroid];
+export default [logAndroid, runAndroid, buildAndroid];

--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -19,7 +19,7 @@ describe('--appFolder', () => {
   const args: Flags = {
     appId: '',
     tasks: undefined,
-    variant: 'debug',
+    mode: 'debug',
     appIdSuffix: '',
     mainActivity: 'MainActivity',
     deviceId: undefined,
@@ -39,7 +39,7 @@ describe('--appFolder', () => {
 
   it('uses task "install[Variant]" as default task', async () => {
     await runOnAllDevices(
-      {...args, variant: 'debug'},
+      {...args, mode: 'debug'},
       './gradlew',
       'adb',
       androidProject,
@@ -50,7 +50,7 @@ describe('--appFolder', () => {
   });
 
   it('uses appName and default variant', async () => {
-    await runOnAllDevices({...args, variant: 'debug'}, './gradlew', 'adb', {
+    await runOnAllDevices({...args, mode: 'debug'}, './gradlew', 'adb', {
       ...androidProject,
       appName: 'someApp',
     });
@@ -61,13 +61,13 @@ describe('--appFolder', () => {
   });
 
   it('uses appName and custom variant', async () => {
-    await runOnAllDevices({...args, variant: 'staging'}, './gradlew', 'adb', {
+    await runOnAllDevices({...args, mode: 'release'}, './gradlew', 'adb', {
       ...androidProject,
       appName: 'anotherApp',
     });
 
     expect(((execa as unknown) as jest.Mock).mock.calls[0][1]).toContain(
-      'anotherApp:installStaging',
+      'anotherApp:installRelease',
     );
   });
 

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -16,8 +16,8 @@ import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import getAdbPath from './getAdbPath';
 import {
   logger,
-  getDefaultUserTerminal,
   CLIError,
+  getDefaultUserTerminal,
 } from '@react-native-community/cli-tools';
 import {getAndroidProject} from '../../config/getAndroidProject';
 import {build, runPackager, BuildFlags} from '../buildAndroid';
@@ -238,11 +238,6 @@ export default {
   func: runAndroid,
   options: [
     {
-      name: '--mode <release|debug>',
-      description: "Specify your app's build variant",
-      default: 'debug',
-    },
-    {
       name: '--appId <string>',
       description:
         'Specify an applicationId to launch after build. If not specified, `package` from AndroidManifest.xml will be used.',
@@ -265,6 +260,17 @@ export default {
         'given device id (listed by running "adb devices" on the command line).',
     },
     {
+      name: '--mode <string>',
+      description: "Specify your app's build variant",
+      default: 'debug',
+    },
+    {
+      name: '--variant <string>',
+      description:
+        "Specify your app's build variant. Deprecated! Use 'mode' instead",
+    },
+
+    {
       name: '--no-packager',
       description: 'Do not launch packager while building',
     },
@@ -281,7 +287,8 @@ export default {
     },
     {
       name: '--tasks <list>',
-      description: 'Run custom Gradle tasks. By default it\'s "installDebug"',
+      description:
+        'Run custom Gradle tasks. By default it\'s "assembleDebug". Will override passed mode and variant arguments.',
       parse: (val: string) => val.split(','),
     },
     {

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -20,7 +20,7 @@ import {
   CLIError,
 } from '@react-native-community/cli-tools';
 import {getAndroidProject} from '../../config/getAndroidProject';
-import {build, checkPackager, BuildFlags} from '../buildAndroid';
+import {build, runPackager, BuildFlags} from '../buildAndroid';
 
 export interface Flags extends BuildFlags {
   appId: string;
@@ -37,7 +37,7 @@ type AndroidProject = NonNullable<Config['project']['android']>;
 async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
   const androidProject = getAndroidProject(config);
 
-  await checkPackager(args, config);
+  await runPackager(args, config);
   return buildAndRun(args, androidProject);
 }
 

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -64,7 +64,10 @@ function runOnSpecificDevice(
   if (devices.length > 0 && deviceId) {
     if (devices.indexOf(deviceId) !== -1) {
       // using '-x lint' in order to ignore linting errors while building the apk
-      const gradleArgs = ['build', '-x', 'lint'];
+      let gradleArgs = ['build', '-x', 'lint'];
+      if (args.extraParams) {
+        gradleArgs = [...gradleArgs, ...args.extraParams];
+      }
       build(gradleArgs, androidProject.sourceDir);
       installAndLaunchOnDevice(args, deviceId, adbPath, androidProject);
     } else {
@@ -87,7 +90,7 @@ function tryInstallAppOnDevice(
   try {
     // "app" is usually the default value for Android apps with only 1 app
     const {appName, sourceDir} = androidProject;
-    const variant = (args.variant ?? (args.mode || 'debug')).toLowerCase();
+    const variant = (args.mode || 'debug').toLowerCase();
     const buildDirectory = `${sourceDir}/${appName}/build/outputs/apk/${variant}`;
     const apkFile = getInstallApkName(
       appName,
@@ -235,7 +238,7 @@ export default {
   func: runAndroid,
   options: [
     {
-      name: '--variant <string>',
+      name: '--mode <release|debug>',
       description: "Specify your app's build variant",
       default: 'debug',
     },
@@ -286,6 +289,11 @@ export default {
       description:
         'Build native libraries only for the current device architecture for debug builds.',
       default: false,
+    },
+    {
+      name: '--extra-params <string>',
+      description: 'Custom properties passed to gradle build command',
+      parse: (val: string) => val.split(' '),
     },
   ],
 };

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -16,7 +16,10 @@ import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import tryLaunchEmulator from './tryLaunchEmulator';
 import {Flags} from '.';
 
-function getTaskNames(appName: string, commands: Array<string>): Array<string> {
+export function getTaskNames(
+  appName: string,
+  commands: Array<string>,
+): Array<string> {
   return appName
     ? commands.map((command) => `${appName}:${command}`)
     : commands;

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -56,9 +56,13 @@ async function runOnAllDevices(
 
   try {
     const tasks = args.tasks || [
-      'install' + toPascalCase(args.variant ?? 'debug'),
+      'install' + toPascalCase(args.mode ?? 'debug'),
     ];
-    const gradleArgs = getTaskNames(androidProject.appName, tasks);
+    let gradleArgs = getTaskNames(androidProject.appName, tasks);
+
+    if (args.extraParams) {
+      gradleArgs = [...gradleArgs, ...args.extraParams];
+    }
 
     if (args.port != null) {
       gradleArgs.push('-PreactNativeDevServerPort=' + args.port);

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -55,7 +55,9 @@ async function runOnAllDevices(
   }
 
   try {
-    const tasks = args.tasks || ['install' + toPascalCase(args.variant)];
+    const tasks = args.tasks || [
+      'install' + toPascalCase(args.variant ?? 'debug'),
+    ];
     const gradleArgs = getTaskNames(androidProject.appName, tasks);
 
     if (args.port != null) {

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -22,7 +22,7 @@ function getTaskNames(appName: string, commands: Array<string>): Array<string> {
     : commands;
 }
 
-function toPascalCase(value: string) {
+export function toPascalCase(value: string) {
   return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
 }
 


### PR DESCRIPTION
Summary:
---------

`build-android` command that will create android build without starting packager and launching emulator. 


Fixes #1128 
Fixes #1150 
Part of #179 (together with #1744 ) 
Closes #1055 

Test Plan:
----------

Clone the fork and run `build-android` command with desired options. 
- [x] tested `react-native build-android`
- [x] tested `react-native build-android --mode release`
- [x] tested `react-native build-android --tasks 'assembleDebug'`
- [x] tested `react-native build-android --mode 'release' --tasks 'assembleDebug'` (should issue a warning in terminal)
- [x] tested `react-native build-android --extra-params "--configure-on-demand -x lint -x test --scan --info"`

