### PR TITLE
fix: avoid catching `init` errors and avoid printing their stack

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -43,7 +43,7 @@ test('init fails if the directory already exists', () => {
   fs.mkdirSync(path.join(DIR, 'TestInit'));
 
   const {stderr} = runCLI(DIR, ['init', 'TestInit'], {expectedFailure: true});
-  expect(stderr).toBe(
+  expect(stderr).toContain(
     'error Cannot initialize new project because directory "TestInit" already exists.',
   );
 });

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -204,6 +204,8 @@ ${chalk.bold('args:')}    ${(args || []).join(' ')}
 ${chalk.bold('stderr:')}  ${result.stderr}
 ${chalk.bold('stdout:')}  ${result.stdout}
 ${chalk.bold('code:')}    ${result.code}`);
+  } else if (options.expectedFailure && result.code === 0) {
+    throw new Error("Expected command to fail, but it didn't");
   }
 }
 

--- a/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
@@ -1,4 +1,6 @@
-export default class DirectoryAlreadyExistsError extends Error {
+import {CLIError} from '@react-native-community/cli-tools';
+
+export default class DirectoryAlreadyExistsError extends CLIError {
   constructor(directory: string) {
     super(
       `Cannot initialize new project because directory "${directory}" already exists.`,

--- a/packages/cli/src/commands/init/errors/HelloWorldError.ts
+++ b/packages/cli/src/commands/init/errors/HelloWorldError.ts
@@ -1,4 +1,6 @@
-export default class HelloWorldError extends Error {
+import {CLIError} from '@react-native-community/cli-tools';
+
+export default class HelloWorldError extends CLIError {
   constructor() {
     super(
       'Project name shouldn\'t contain "HelloWorld" name in it, because it is CLI\'s default placeholder name.',

--- a/packages/cli/src/commands/init/errors/InvalidNameError.ts
+++ b/packages/cli/src/commands/init/errors/InvalidNameError.ts
@@ -1,4 +1,6 @@
-export default class InvalidNameError extends Error {
+import {CLIError} from '@react-native-community/cli-tools';
+
+export default class InvalidNameError extends CLIError {
   constructor(name: string) {
     super(
       `"${name}" is not a valid name for a project. Please use a valid identifier name (alphanumeric).`,

--- a/packages/cli/src/commands/init/errors/ReservedNameError.ts
+++ b/packages/cli/src/commands/init/errors/ReservedNameError.ts
@@ -1,4 +1,6 @@
-export default class ReservedNameError extends Error {
+import {CLIError} from '@react-native-community/cli-tools';
+
+export default class ReservedNameError extends CLIError {
   constructor(name: string) {
     super(
       `Not a valid name for a project. Please do not use the reserved word "${name}".`,

--- a/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
+++ b/packages/cli/src/commands/init/errors/TemplateAndVersionError.ts
@@ -1,4 +1,6 @@
-export default class TemplateAndVersionError extends Error {
+import {CLIError} from '@react-native-community/cli-tools';
+
+export default class TemplateAndVersionError extends CLIError {
   constructor(template: string) {
     super(
       `Passing both "version" and "template" is not supported. The template you select determines the version of react-native used. Please use only one of these options, for example:

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -207,12 +207,8 @@ export default (async function initialize(
   const version = options.version || DEFAULT_VERSION;
   const directoryName = path.relative(root, options.directory || projectName);
 
-  try {
-    await createProject(projectName, directoryName, version, options);
+  await createProject(projectName, directoryName, version, options);
 
-    const projectFolder = path.join(root, directoryName);
-    printRunInstructions(projectFolder, projectName);
-  } catch (e) {
-    logger.error(e.message);
-  }
+  const projectFolder = path.join(root, directoryName);
+  printRunInstructions(projectFolder, projectName);
 });


### PR DESCRIPTION
Summary:
---------

I experienced the following issue: https://github.com/react-native-community/cli/issues/1741 and decided to fix it too.

I've made four changes:
- I removed the try-catch around the body of the init command, to allow errors to bubble up and be handled by the `handleError` in `src/index.ts`.
- I made all the init related errors extend `CLIError` to avoid printing the stack, since "we know exactly what went wrong" and expects the user to have the means to fix it.
- Fixed a failing e2e test (due to a trailing `\n` in the stderr)
- Added a branch to `jest/helpers.ts`'s `handleTestFailure` to assert a non-zero exit code if expectedFailure is true. This could have caught this (or a similar issue) earlier.

Test Plan:
----------

I suggest following the instructions for reproducing this on the original issue, only this time, notice how the command exits with status code 1 as expected and it still doesn't print the error stack.
