### PR TITLE
feat: redirect TS template to r-n

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -183,7 +183,7 @@ function createTemplateUri(options: Options, version: string): string {
     logger.warn(
       "Ignoring custom template: 'react-native-template-typescript'. Starting from React Native v0.71 TypeScript is used by default.",
     );
-    return `react-native@${version}`;
+    return 'react-native';
   }
 
   return options.template || `react-native@${version}`;

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -21,7 +21,6 @@ import * as PackageManager from '../../tools/packageManager';
 import {installPods} from '@react-native-community/cli-doctor';
 import banner from './banner';
 import TemplateAndVersionError from './errors/TemplateAndVersionError';
-import semver from 'semver';
 
 const DEFAULT_VERSION = 'latest';
 
@@ -180,14 +179,11 @@ function createTemplateUri(options: Options, version: string): string {
   const isTypescriptTemplate =
     options.template === 'react-native-template-typescript';
 
-  if (isTypescriptTemplate && options.template?.includes('@')) {
-    const typescriptTemplateVersion = options.template.split('@')[1];
-    if (semver.gte(typescriptTemplateVersion, '0.71.0')) {
-      logger.warn(
-        "Ignoring custom template: 'react-native-template-typescript'. Starting from React Native v0.71 TypeScript is used by default.",
-      );
-      return `react-native@${version}`;
-    }
+  if (isTypescriptTemplate) {
+    logger.warn(
+      "Ignoring custom template: 'react-native-template-typescript'. Starting from React Native v0.71 TypeScript is used by default.",
+    );
+    return `react-native@${version}`;
   }
 
   return options.template || `react-native@${version}`;

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -176,7 +176,7 @@ async function installDependencies({
   loader.succeed();
 }
 
-function checkVersionAndTemplate(options: Options, version: string): string {
+function createTemplateUri(options: Options, version: string): string {
   const isTypescriptTemplate = options.template?.includes(
     'react-native-template-typescript',
   );
@@ -185,7 +185,7 @@ function checkVersionAndTemplate(options: Options, version: string): string {
     const typescriptTemplateVersion = options.template.split('@')[1];
     if (semver.gte(typescriptTemplateVersion, '0.71.0')) {
       logger.warn(
-        "Starting from verision '0.71' typescript is used by default.\nDiregarding template and using default react-native",
+        "Ignoring custom template: 'react-native-template-typescript'. Starting from React Native v0.71 TypeScript is used by default.",
       );
       return `react-native@${version}`;
     }
@@ -200,7 +200,7 @@ async function createProject(
   version: string,
   options: Options,
 ) {
-  const templateUri = checkVersionAndTemplate(options, version);
+  const templateUri = createTemplateUri(options, version);
 
   return createFromTemplate({
     projectName,

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -177,9 +177,8 @@ async function installDependencies({
 }
 
 function createTemplateUri(options: Options, version: string): string {
-  const isTypescriptTemplate = options.template?.includes(
-    'react-native-template-typescript',
-  );
+  const isTypescriptTemplate =
+    options.template === 'react-native-template-typescript';
 
   if (isTypescriptTemplate && options.template?.includes('@')) {
     const typescriptTemplateVersion = options.template.split('@')[1];


### PR DESCRIPTION
Summary:
---------

Fixes #1740 

Test Plan:
----------

Fork the branch and try to `init` new project with `react-native-template-typescript`. 
It should print the warning and default to normal r-n template. 
