### PR TITLE
fix: move bundle install above pod version check

### DIFF
--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -183,6 +183,10 @@ async function installPods({
       return;
     }
 
+    if (fs.existsSync('../Gemfile')) {
+      await runBundleInstall(loader);
+    }
+
     try {
       // Check if "pod" is available and usable. It happens that there are
       // multiple versions of "pod" command and even though it's there, it exits
@@ -193,7 +197,6 @@ async function installPods({
       await installCocoaPods(loader);
     }
 
-    await runBundleInstall(loader);
     await runPodInstall(loader, directory);
   } catch (error) {
     throw error;

--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -198,8 +198,6 @@ async function installPods({
     }
 
     await runPodInstall(loader, directory);
-  } catch (error) {
-    throw error;
   } finally {
     process.chdir('..');
   }


### PR DESCRIPTION
Summary:
---------

This change should fix the issue with falling `react-native init` for people with `rvm` installed.
I believe this logic was invalid since we have `Gemfile` in the template root responsible for installing cocoa pods it seems to have no sense to verify its version before.


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

- clone repo
- run `yarn build`
- `node ./packages/cli/build/bin.js init ReactNativeUnicorn`

Test scenarios:
- [x] with `rvm` installed
- [ ] without ruby version managers
- [ ] with other ruby version managers
