### PR TITLE
fix: run cli when dev dependencies are not installed

### DIFF
--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -98,32 +98,38 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
     const localDependencyRoot =
       userConfig.dependencies[dependencyName] &&
       userConfig.dependencies[dependencyName].root;
-    let root =
-      localDependencyRoot || resolveNodeModuleDir(projectRoot, dependencyName);
-    let config = readDependencyConfigFromDisk(root, dependencyName);
 
-    const isPlatform = Object.keys(config.platforms).length > 0;
+    try {
+      let root =
+        localDependencyRoot ||
+        resolveNodeModuleDir(projectRoot, dependencyName);
+      let config = readDependencyConfigFromDisk(root, dependencyName);
 
-    return assign({}, acc, {
-      dependencies: assign({}, acc.dependencies, {
-        get [dependencyName](): DependencyConfig {
-          return getDependencyConfig(
-            root,
-            dependencyName,
-            finalConfig,
-            config,
-            userConfig,
-            isPlatform,
-          );
+      const isPlatform = Object.keys(config.platforms).length > 0;
+
+      return assign({}, acc, {
+        dependencies: assign({}, acc.dependencies, {
+          get [dependencyName](): DependencyConfig {
+            return getDependencyConfig(
+              root,
+              dependencyName,
+              finalConfig,
+              config,
+              userConfig,
+              isPlatform,
+            );
+          },
+        }),
+        commands: [...acc.commands, ...config.commands],
+        platforms: {
+          ...acc.platforms,
+          ...config.platforms,
         },
-      }),
-      commands: [...acc.commands, ...config.commands],
-      platforms: {
-        ...acc.platforms,
-        ...config.platforms,
-      },
-      healthChecks: [...acc.healthChecks, ...config.healthChecks],
-    }) as Config;
+        healthChecks: [...acc.healthChecks, ...config.healthChecks],
+      }) as Config;
+    } catch {
+      return acc;
+    }
   }, initialConfig);
 
   return finalConfig;

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -8,6 +8,7 @@ import {
 } from '@react-native-community/cli-types';
 import {
   findProjectRoot,
+  logger,
   resolveNodeModuleDir,
 } from '@react-native-community/cli-tools';
 import findDependencies from './findDependencies';
@@ -55,6 +56,7 @@ function getDependencyConfig(
  * Loads CLI configuration
  */
 function loadConfig(projectRoot: string = findProjectRoot()): Config {
+  let hasMissingDependencies = false;
   let lazyProject: ProjectConfig;
   const userConfig = readConfigFromDisk(projectRoot);
 
@@ -127,10 +129,15 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
         },
         healthChecks: [...acc.healthChecks, ...config.healthChecks],
       }) as Config;
-    } catch {
+    } catch (error) {
+      hasMissingDependencies = true;
       return acc;
     }
   }, initialConfig);
+
+  if (hasMissingDependencies) {
+    logger.warn('Please check if your project dependencies are installed.');
+  }
 
   return finalConfig;
 }

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -8,7 +8,6 @@ import {
 } from '@react-native-community/cli-types';
 import {
   findProjectRoot,
-  logger,
   resolveNodeModuleDir,
 } from '@react-native-community/cli-tools';
 import findDependencies from './findDependencies';
@@ -56,7 +55,6 @@ function getDependencyConfig(
  * Loads CLI configuration
  */
 function loadConfig(projectRoot: string = findProjectRoot()): Config {
-  let hasMissingDependencies = false;
   let lazyProject: ProjectConfig;
   const userConfig = readConfigFromDisk(projectRoot);
 
@@ -129,15 +127,10 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
         },
         healthChecks: [...acc.healthChecks, ...config.healthChecks],
       }) as Config;
-    } catch (error) {
-      hasMissingDependencies = true;
+    } catch {
       return acc;
     }
   }, initialConfig);
-
-  if (hasMissingDependencies) {
-    logger.warn('Please check if your project dependencies are installed.');
-  }
 
   return finalConfig;
 }


### PR DESCRIPTION
Summary:
---------

Relates to #1750 
When user is running `yarn install --production` command, the `devDependencies` are not installed. Because of that, they cannot be found in the `node_modules` when loading  CLI's configuration and it ends up with an error `Failed to load configuration of your project.` while running any command. This PR prevents CLI from failing when `devDependencies` are not installed.


Test Plan:
----------

1. Clone the repo and checkout this branch
2. Run `yarn install` in the root catalog
3. Create new React Native project
4. Add any dev dependency, e.g. `yarn add left-pad --dev`
5. Run `yarn install --production`
6. Run `yarn start` - at this stage the command should fail
7. Link packages using [this setup guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#setup)
8. Run `yarn start` - at this stage the command should work

Can be tested with other CLI commands as well