### PR TITLE
add github action to mark issues & PRs as stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,22 @@
+
+name: Mark issues and PRs as stale
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 90
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          stale-issue-message: "There hasn't been any activity on this issue in the past 3 months, so it has been marked as stale and it will be closed automatically if no further activity occurs in the next 7 days."
+          stale-pr-message: "There hasn't been any activity on this pull request in the past 3 months, so it has been marked as stale and it will be closed automatically if no further activity occurs in the next 7 days."


### PR DESCRIPTION
Summary:
---------

Relates to #1751 
Implements github action that runs once a day (cron set to 3:00am) to mark issues and PRs with no activity for 90 days as stale, and close stale issues/PRs after 7 days


Test Plan:
----------

Tested if the syntax of .yml file is correct using  [YAMLlint](http://www.yamllint.com/)
I guess the rest has to be tested directly on the respository, the job should run at 3:00am after merging this PR and all the issues older than 90 days should be marked as `stale`.
