### PR TITLE
increase number of operations per run in stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,5 +18,6 @@ jobs:
           days-before-close: 7
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
+          operations-per-run: 300
           stale-issue-message: "There hasn't been any activity on this issue in the past 3 months, so it has been marked as stale and it will be closed automatically if no further activity occurs in the next 7 days."
           stale-pr-message: "There hasn't been any activity on this pull request in the past 3 months, so it has been marked as stale and it will be closed automatically if no further activity occurs in the next 7 days."


### PR DESCRIPTION
Summary:
---------

Noticed that stale action has a default value of operations per run set to 30. In that case, each time the action runs, it goes through the same 30 issues. Increasing the value solves this problem and should go through all the issues and PRs next time.


Test Plan:
----------

Get it merged and run a job manually or wait until cron runs it automatically, then compare the result with the [action from the past](https://github.com/react-native-community/cli/actions/runs/3537470057/jobs/5937467704#step:2:698) 

