### PR TITLE
fix: avoid renaming a file if it is already renamed

### DIFF
--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -101,8 +101,7 @@ export async function changePlaceholderInTemplate({
     }
     if (shouldRenameFile(filePath, placeholderName)) {
       await renameFile(filePath, placeholderName, projectName);
-    }
-    if (shouldRenameFile(filePath, placeholderName.toLowerCase())) {
+    } else if (shouldRenameFile(filePath, placeholderName.toLowerCase())) {
       await renameFile(
         filePath,
         placeholderName.toLowerCase(),


### PR DESCRIPTION
Fixes https://github.com/react-native-community/cli/issues/1762

Summary:
---------

When using `init` command with `--template` parameter and a custom template in which `placeholderName` as well as the attached files (such as .xcscheme) are written in lowercase, an error occurs. 

![205453978-daf47126-a2f4-435a-a727-79f3633cd097](https://user-images.githubusercontent.com/8215580/205513019-ce9c8f87-be15-42d5-9e34-fd37cf8d8d32.png)

This happens because both `shouldRenameFile(filePath, placeholderName)` and `shouldRenameFile(filePath, placeholderName.toLowerCase())` return True and `renameFile()` tries to rename non-existinf file. This commit implements a workaround so that the lowercase function is only executed if the normal function returns False.

Test Plan:
----------
Given that the change is minimal, I think it is enough that I have tested it on several templates: 

yarn react-native init App --template rnbnr-template@0.0.5 --npm --skip-install --verbose
yarn react-native init App --template react-native-template-typescript --npm --skip-install --verbose

In both cases the application was initialized successfully and the files and folders inside /ios/ were renamed properly.
