### PR TITLE
Feat: List android devices

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -379,6 +379,13 @@ Example: `yarn react-native run-android --tasks clean,installDebug`.
 
 Build native libraries only for the current device architecture for debug builds.
 
+#### `--list-devices`
+
+> default: false
+
+List all available Android devices and simulators and let you choose one to run the app.
+
+
 ### `run-ios`
 
 Usage:

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -100,6 +100,12 @@ async function buildAndRun(args: Flags, androidProject: AndroidProject) {
 
   const adbPath = getAdbPath();
   if (args.listDevices) {
+    if (args.deviceId) {
+      logger.warn(
+        'Both "deviceId" and "--list-devices" parameters were passed to "run" command. We will list available devices and let you choose from one',
+      );
+    }
+
     const device = await listAndroidDevices();
     if (!device) {
       return logger.error(

--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
@@ -18,6 +18,11 @@ function toPascalCase(value: string) {
   return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
 }
 
+/**
+ *
+ * @param deviceId string
+ * @returns name of Android emulator
+ */
 function getEmulatorName(deviceId: string) {
   // maybe close it with trycatch block?
   const adbPath = getAdbPath();
@@ -31,6 +36,11 @@ function getEmulatorName(deviceId: string) {
     .trim();
 }
 
+/**
+ *
+ * @param deviceId string
+ * @returns Android device name in readable format
+ */
 function getPhoneName(deviceId: string) {
   const adbPath = getAdbPath();
   const buffer = execSync(
@@ -97,6 +107,7 @@ async function listAndroidDevices() {
 
   // Find not booted ones:
   emulators.forEach((emulatorName) => {
+    // skip those already booted
     if (allDevices.some((device) => device.readableName === emulatorName)) {
       return;
     }
@@ -108,8 +119,6 @@ async function listAndroidDevices() {
     };
     allDevices = [...allDevices, emulatorData];
   });
-
-  console.log('allDevices', allDevices);
 
   const selectedDevice = await promptForDeviceSelection(allDevices);
   return selectedDevice;

--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
@@ -1,0 +1,118 @@
+import {execSync} from 'child_process';
+import adb from './adb';
+import getAdbPath from './getAdbPath';
+import {getEmulators} from './tryLaunchEmulator';
+import os from 'os';
+import prompts from 'prompts';
+import chalk from 'chalk';
+import {CLIError} from '@react-native-community/cli-tools';
+
+type DeviceData = {
+  deviceId: string | undefined;
+  readableName: string;
+  connected: boolean;
+  type: 'emulator' | 'phone';
+};
+
+function toPascalCase(value: string) {
+  return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
+}
+
+function getEmulatorName(deviceId: string) {
+  // maybe close it with trycatch block?
+  const adbPath = getAdbPath();
+  const buffer = execSync(`${adbPath} -s ${deviceId} emu avd name`);
+
+  // 1st line should get us emu name
+  return buffer
+    .toString()
+    .split(os.EOL)[0]
+    .replace(/(\r\n|\n|\r)/gm, '')
+    .trim();
+}
+
+function getPhoneName(deviceId: string) {
+  const adbPath = getAdbPath();
+  const buffer = execSync(
+    `${adbPath} -s ${deviceId} shell getprop | grep ro.product.model`,
+  );
+  return buffer
+    .toString()
+    .replace(/[[\]:ro/.product/.model]+/g, '')
+    .replace(/(\r\n|\n|\r)/gm, '')
+    .trim();
+}
+
+async function promptForDeviceSelection(
+  allDevices: Array<DeviceData>,
+): Promise<DeviceData | undefined> {
+  if (!allDevices.length) {
+    throw new CLIError(
+      'No devices and/or emulators connected. Please create emulator with Android Studio or connect Android device.',
+    );
+  }
+  const {device} = await prompts({
+    type: 'select',
+    name: 'device',
+    message: 'Select the device / emulator you want to use',
+    choices: allDevices.map((d) => ({
+      title: `${chalk.bold(`${toPascalCase(d.type)}`)} ${chalk.green(
+        `${d.readableName}`,
+      )} (${d.connected ? 'connected' : 'disconnected'})`,
+      value: d,
+    })),
+    min: 1,
+  });
+
+  return device;
+}
+
+async function listAndroidDevices() {
+  const adbPath = getAdbPath();
+  const devices = adb.getDevices(adbPath);
+
+  let allDevices: Array<DeviceData> = [];
+
+  devices.forEach((deviceId) => {
+    if (deviceId.includes('emulator')) {
+      const emulatorData: DeviceData = {
+        deviceId,
+        readableName: getEmulatorName(deviceId),
+        connected: true,
+        type: 'emulator',
+      };
+      allDevices = [...allDevices, emulatorData];
+    } else {
+      const phoneData: DeviceData = {
+        deviceId,
+        readableName: getPhoneName(deviceId),
+        type: 'phone',
+        connected: true,
+      };
+      allDevices = [...allDevices, phoneData];
+    }
+  });
+
+  const emulators = getEmulators();
+
+  // Find not booted ones:
+  emulators.forEach((emulatorName) => {
+    if (allDevices.some((device) => device.readableName === emulatorName)) {
+      return;
+    }
+    const emulatorData: DeviceData = {
+      deviceId: undefined,
+      readableName: emulatorName,
+      type: 'emulator',
+      connected: false,
+    };
+    allDevices = [...allDevices, emulatorData];
+  });
+
+  console.log('allDevices', allDevices);
+
+  const selectedDevice = await promptForDeviceSelection(allDevices);
+  return selectedDevice;
+}
+
+export default listAndroidDevices;

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -6,7 +6,7 @@ const emulatorCommand = process.env.ANDROID_HOME
   ? `${process.env.ANDROID_HOME}/emulator/emulator`
   : 'emulator';
 
-const getEmulators = () => {
+export const getEmulators = () => {
   try {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
     return emulatorsOutput.split(os.EOL).filter((name) => name !== '');
@@ -15,12 +15,22 @@ const getEmulators = () => {
   }
 };
 
-const launchEmulator = async (emulatorName: string, adbPath: string) => {
+export const launchEmulator = async (
+  emulatorName: string,
+  adbPath: string,
+  port?: string,
+) => {
+  console.log('emulatorNAme', emulatorName);
+  console.log('port', port);
   return new Promise((resolve, reject) => {
-    const cp = execa(emulatorCommand, [`@${emulatorName}`], {
-      detached: true,
-      stdio: 'ignore',
-    });
+    const cp = execa(
+      emulatorCommand,
+      [`@${emulatorName}`, port ? '-port' : '', port ? `${port}` : ''],
+      {
+        detached: true,
+        stdio: 'ignore',
+      },
+    );
     cp.unref();
     const timeout = 30;
 
@@ -56,11 +66,13 @@ const launchEmulator = async (emulatorName: string, adbPath: string) => {
 
 export default async function tryLaunchEmulator(
   adbPath: string,
+  emulatorName?: string,
+  port?: string,
 ): Promise<{success: boolean; error?: string}> {
   const emulators = getEmulators();
   if (emulators.length > 0) {
     try {
-      await launchEmulator(emulators[0], adbPath);
+      await launchEmulator(emulatorName ?? emulators[0], adbPath, port);
       return {success: true};
     } catch (error) {
       return {success: false, error};

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import execa from 'execa';
-import Adb from './adb';
+import adb from './adb';
 
 const emulatorCommand = process.env.ANDROID_HOME
   ? `${process.env.ANDROID_HOME}/emulator/emulator`
@@ -15,51 +15,59 @@ export const getEmulators = () => {
   }
 };
 
-export const launchEmulator = async (
+const launchEmulator = async (
   emulatorName: string,
   adbPath: string,
-  port?: string,
-) => {
-  console.log('emulatorNAme', emulatorName);
-  console.log('port', port);
-  return new Promise((resolve, reject) => {
-    const cp = execa(
-      emulatorCommand,
-      [`@${emulatorName}`, port ? '-port' : '', port ? `${port}` : ''],
-      {
-        detached: true,
-        stdio: 'ignore',
-      },
-    );
-    cp.unref();
-    const timeout = 30;
+  port?: number,
+): Promise<boolean> => {
+  const manualCommand = `${emulatorCommand} @${emulatorName}`;
+
+  const cp = execa(
+    emulatorCommand,
+    [`@${emulatorName}`, port ? '-port' : '', port ? `${port}` : ''],
+    {
+      detached: true,
+      stdio: 'ignore',
+    },
+  );
+  cp.unref();
+  const timeout = 30;
+
+  return new Promise<boolean>((resolve, reject) => {
+    const bootCheckInterval = setInterval(async () => {
+      const devices = adb.getDevices(adbPath);
+      const connected = port
+        ? devices.find((d) => d.includes(`${port}`))
+        : devices.length > 0;
+      if (connected) {
+        cleanup();
+        resolve(true);
+      }
+    }, 1000);
 
     // Reject command after timeout
     const rejectTimeout = setTimeout(() => {
-      cleanup();
-      reject(`Could not start emulator within ${timeout} seconds.`);
+      stopWaitingAndReject(
+        `It took too long to start and connect with Android emulator: ${emulatorName}. You can try starting the emulator manually from the terminal with: ${manualCommand}`,
+      );
     }, timeout * 1000);
-
-    const bootCheckInterval = setInterval(() => {
-      if (Adb.getDevices(adbPath).length > 0) {
-        cleanup();
-        resolve();
-      }
-    }, 1000);
 
     const cleanup = () => {
       clearTimeout(rejectTimeout);
       clearInterval(bootCheckInterval);
     };
 
-    cp.on('exit', () => {
+    const stopWaitingAndReject = (message: string) => {
       cleanup();
-      reject('Emulator exited before boot.');
-    });
+      reject(new Error(message));
+    };
 
-    cp.on('error', (error) => {
-      cleanup();
-      reject(error.message);
+    cp.on('error', ({message}) => stopWaitingAndReject(message));
+
+    cp.on('exit', () => {
+      stopWaitingAndReject(
+        `The emulator (${emulatorName}) quit before it finished opening. You can try starting the emulator manually from the terminal with: ${manualCommand}`,
+      );
     });
   });
 };
@@ -67,7 +75,7 @@ export const launchEmulator = async (
 export default async function tryLaunchEmulator(
   adbPath: string,
   emulatorName?: string,
-  port?: string,
+  port?: number,
 ): Promise<{success: boolean; error?: string}> {
   const emulators = getEmulators();
   if (emulators.length > 0) {


### PR DESCRIPTION
Summary:
---------

Similar to #1676 - list available devices and let user choose from one. 

![Screenshot 2022-12-05 at 11 55 08](https://user-images.githubusercontent.com/13610886/205620711-b15e94b6-eab3-4d19-8c9f-48bd3b8ac75b.png)



Test Plan:
----------

Clone the fork and run `run-android` script with proper flag:
```bash
❯ node ../cli/packages/cli/build/bin.js run-android --list-devices
```