### PR TITLE
chore: prevent stale bot from closing no-stale-bot issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,8 @@ jobs:
           days-before-close: 7
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
+          exempt-issue-labels: 'no-stale-bot'
+          exempt-pr-labels: 'no-stale-bot'
           operations-per-run: 300
           stale-issue-message: "There hasn't been any activity on this issue in the past 3 months, so it has been marked as stale and it will be closed automatically if no further activity occurs in the next 7 days."
           stale-pr-message: "There hasn't been any activity on this pull request in the past 3 months, so it has been marked as stale and it will be closed automatically if no further activity occurs in the next 7 days."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,10 @@ When you're sending a pull request:
 
 You can report issues on our [bug tracker](https://github.com/react-native-community/react-native-cli/issues). Please follow the issue template when opening an issue.
 
+## Stale Bot
+
+This repository is using bot to automatically mark issues and PRs as stale and close them. The "stale" label is added after 90 days of inactivity, and it's getting closed 7 days later. If you find the issue important or you want to keep it open for any particular reason, please show any activity in the issue or contact maintainers to add the "no-stale-bot" label, which prevents bot from closing the issues.
+
 ## License
 
 By contributing to React Native CLI, you agree that your contributions will be licensed under its **MIT** license.


### PR DESCRIPTION
Summary:
---------

Added "no-stale-bot" label to prevent bot from marking issues and PRs with this label as stale.
Added info about stale bot in CONTRIBUTING.md file.


Test Plan:
----------
Validated YAML with YAMLint
After 90 days of inactivity the issues marked as "no-stale-bot" won't be marked as stale.
