### PR TITLE
feat: read build configuration from scheme file

### DIFF
--- a/packages/cli-platform-ios/package.json
+++ b/packages/cli-platform-ios/package.json
@@ -10,6 +10,7 @@
     "@react-native-community/cli-tools": "^10.1.1",
     "chalk": "^4.1.2",
     "execa": "^1.0.0",
+    "fast-xml-parser": "^4.0.12",
     "glob": "^7.1.3",
     "ora": "^5.4.1"
   },

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -20,6 +20,7 @@ import {getDestinationSimulator} from '../../tools/getDestinationSimulator';
 import {getDevices} from '../../tools/getDevices';
 import {getProjectInfo} from '../../tools/getProjectInfo';
 import {checkIfConfigurationExists} from '../../tools/checkIfConfigurationExists';
+import {getConfigurationScheme} from '../../tools/getConfigurationScheme';
 
 export interface FlagsT extends BuildFlags {
   configuration?: string;
@@ -62,6 +63,11 @@ function buildIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     path.extname(xcodeProject.name),
   );
   const scheme = args.scheme || inferredSchemeName;
+
+  args.mode = getConfigurationScheme(
+    {scheme: args.scheme, mode: args.mode},
+    sourceDir,
+  );
 
   logger.info(
     `Found Xcode ${

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -187,7 +187,6 @@ export const iosBuildOptions = [
   {
     name: '--mode <string>',
     description: 'Explicitly set the scheme configuration to use',
-    default: 'Debug',
   },
   {
     name: '--configuration <string>',

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import child_process, {SpawnOptionsWithoutStdio} from 'child_process';
+import child_process from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import {XMLParser} from 'fast-xml-parser';
@@ -538,34 +538,6 @@ function printFoundDevices(devices: Array<Device>) {
   ].join('\n');
 }
 
-function getProcessOptions({
-  packager,
-  terminal,
-  port,
-}: {
-  packager: boolean;
-  terminal: string | undefined;
-  port: number;
-}): SpawnOptionsWithoutStdio {
-  if (packager) {
-    return {
-      env: {
-        ...process.env,
-        RCT_TERMINAL: terminal,
-        RCT_METRO_PORT: port.toString(),
-      },
-    };
-  }
-
-  return {
-    env: {
-      ...process.env,
-      RCT_TERMINAL: terminal,
-      RCT_NO_LAUNCH_PACKAGER: 'true',
-    },
-  };
-}
-
 function getBuildConfigurationFromXcScheme(
   {scheme, configuration}: FlagsT,
   sourceDir: string,
@@ -594,7 +566,9 @@ function getBuildConfigurationFromXcScheme(
       return Scheme.LaunchAction['@_buildConfiguration'];
     }
   } catch {
-    logger.error(`Could not find scheme ${scheme}.`);
+    throw new CLIError(
+      `Could not find scheme ${scheme}. Please make sure the schema you want to run exists.`,
+    );
   }
 
   return configuration;

--- a/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
+++ b/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
@@ -1,0 +1,43 @@
+import {CLIError} from '@react-native-community/cli-tools';
+import {XMLParser} from 'fast-xml-parser';
+import fs from 'fs';
+import path from 'path';
+
+const xmlParser = new XMLParser({ignoreAttributes: false});
+
+export function getBuildConfigurationFromXcScheme(
+  scheme: string,
+  configuration: string,
+  sourceDir: string,
+) {
+  try {
+    const xcProject = fs
+      .readdirSync(sourceDir)
+      .find((dir) => dir.includes('.xcodeproj'));
+
+    if (xcProject) {
+      const xmlScheme = fs.readFileSync(
+        path.join(
+          sourceDir,
+          xcProject,
+          'xcshareddata',
+          'xcschemes',
+          `${scheme}.xcscheme`,
+        ),
+        {
+          encoding: 'utf-8',
+        },
+      );
+
+      const {Scheme} = xmlParser.parse(xmlScheme);
+
+      return Scheme.LaunchAction['@_buildConfiguration'];
+    }
+  } catch {
+    throw new CLIError(
+      `Could not find scheme ${scheme}. Please make sure the schema you want to run exists.`,
+    );
+  }
+
+  return configuration;
+}

--- a/packages/cli-platform-ios/src/tools/getConfigurationScheme.ts
+++ b/packages/cli-platform-ios/src/tools/getConfigurationScheme.ts
@@ -1,0 +1,19 @@
+import {getBuildConfigurationFromXcScheme} from './getBuildConfigurationFromXcScheme';
+
+interface Args {
+  scheme?: string;
+  mode: string;
+}
+
+export function getConfigurationScheme(
+  {scheme, mode}: Args,
+  sourceDir: string,
+) {
+  if (scheme && mode) {
+    return mode;
+  } else if (scheme) {
+    return getBuildConfigurationFromXcScheme(scheme, mode, sourceDir);
+  }
+
+  return mode || 'Debug';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5987,6 +5987,13 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-xml-parser@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.0.12.tgz#9e3117d76523d20dfbd30482c1621fb9b03a7817"
+  integrity sha512-/Nmo3823Rfx7UTJosQNz6hBVbszfv1Unb7A4iNJZhvCGCgtIHv/uODmrYIH8vc05+XKZ4hNIOv6SlBejvJgATw==
+  dependencies:
+    strnum "^1.0.5"
+
 fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
@@ -12100,6 +12107,11 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strnum@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/strnum/-/strnum-1.0.5.tgz#5c4e829fe15ad4ff0d20c3db5ac97b73c9b072db"
+  integrity sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==
 
 strong-log-transformer@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Summary:
---------

Closes #1454 
This PR implements using build configuration value associated to scheme provided with a `--scheme` flag.


Test Plan:
----------
Create new scheme in XCode with build configuration set to Release

In the app:

- [x]  run `yarn ios` - it should use default scheme and Debug configuration
- [x] run `yarn ios --scheme YourSchemeName` - it should use newly created scheme and use Release configuration
- [x] run `yarn ios --scheme YourSchemeName --configuration Debug` - it should use newly created scheme and use Debug configuration
- [x] run `yarn ios --configuration Release` - it should use default scheme with Release configuration

When running commands, watch for `info Building...` message and check if configuration and scheme values are properly set in `xcodebuild` command