### PR TITLE
chore: run release drafter on pull request open

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,8 +3,6 @@ name: Release Drafter
 on:
   release:
     types: [published]
-  pull_request:
-    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,10 +3,11 @@ name: Release Drafter
 on:
   release:
     types: [published]
-  pull_request:
-    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,11 +3,10 @@ name: Release Drafter
 on:
   release:
     types: [published]
+  pull_request:
+    types: [opened, reopened, synchronize]
   pull_request_target:
     types: [opened, reopened, synchronize]
-
-permissions:
-  contents: read
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Summary:
---------

Checking if removing `pull_request` works on this repository - based on this answer: [Forked PRs don't work with release-drafter action (and create an error)](https://github.com/release-drafter/release-drafter/issues/785#issuecomment-927616495)


Test Plan:
----------

On forked repository creating a pull request ended up with success. Let's see what happens here
