### PR TITLE
feat: run app on iOS and Android with a hotkey

### DIFF
--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -10,6 +10,7 @@
     "@react-native-community/cli-server-api": "^10.0.0",
     "@react-native-community/cli-tools": "^10.0.0",
     "chalk": "^4.1.2",
+    "execa": "^1.0.0",
     "metro": "0.73.6",
     "metro-config": "0.73.6",
     "metro-core": "0.73.6",

--- a/packages/cli-plugin-metro/src/commands/start/watchMode.ts
+++ b/packages/cli-plugin-metro/src/commands/start/watchMode.ts
@@ -1,9 +1,16 @@
 import readline from 'readline';
+import fs from 'fs';
 import {logger, hookStdout} from '@react-native-community/cli-tools';
+import execa from 'execa';
+import chalk from 'chalk';
 
 function printWatchModeInstructions() {
   logger.log(
-    '\n\nTo reload the app press "r"\nTo open developer menu press "d"',
+    `${chalk.bold('r')} - reload the app\n${chalk.bold(
+      'd',
+    )} - open developer menu\n${chalk.bold('i')} - run on iOS\n${chalk.bold(
+      'a',
+    )} - run on Android`,
   );
 }
 
@@ -47,6 +54,14 @@ function enableWatchMode(messageSocket: any) {
     } else if (name === 'd') {
       messageSocket.broadcast('devMenu', null);
       logger.info('Opening developer menu...');
+    } else if (name === 'i' || name === 'a') {
+      const isUsingYarn = fs
+        .readdirSync(`${process.cwd()}`)
+        .includes('yarn.lock');
+      logger.info(`Opening the app on ${name === 'i' ? 'iOS' : 'Android'}...`);
+      execa(isUsingYarn ? 'yarn' : 'npm run', [
+        name === 'i' ? 'ios' : 'android',
+      ]).stdout?.pipe(process.stdout);
     } else {
       console.log(_key);
     }

--- a/packages/cli-plugin-metro/src/commands/start/watchMode.ts
+++ b/packages/cli-plugin-metro/src/commands/start/watchMode.ts
@@ -1,5 +1,4 @@
 import readline from 'readline';
-import fs from 'fs';
 import {logger, hookStdout} from '@react-native-community/cli-tools';
 import execa from 'execa';
 import chalk from 'chalk';
@@ -55,12 +54,10 @@ function enableWatchMode(messageSocket: any) {
       messageSocket.broadcast('devMenu', null);
       logger.info('Opening developer menu...');
     } else if (name === 'i' || name === 'a') {
-      const isUsingYarn = fs
-        .readdirSync(`${process.cwd()}`)
-        .includes('yarn.lock');
       logger.info(`Opening the app on ${name === 'i' ? 'iOS' : 'Android'}...`);
-      execa(isUsingYarn ? 'yarn' : 'npm run', [
-        name === 'i' ? 'ios' : 'android',
+      execa('npx', [
+        'react-native',
+        name === 'i' ? 'run-ios' : 'run-android',
       ]).stdout?.pipe(process.stdout);
     } else {
       console.log(_key);


### PR DESCRIPTION
Summary:
---------

This PR introduces running an app from terminal using Metro watch mode. The `run-ios` and `run-android` commands are running when `i` or `a` keys are pressed in the Terminal.


iOS:

https://user-images.githubusercontent.com/13985840/207847756-75ce1e13-00b9-425e-a015-1feee21bc4fe.mov

Android:

https://user-images.githubusercontent.com/13985840/207847801-9c13f152-bc4f-4efd-bf92-70fd840a6a5e.mov

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run `yarn start --watchFolders path/to/cloned/cli`
3. Press `a` to run the app on Android
4. Press `i` to run the app on iOS