### PR TITLE
Upgrade metro dependencies to 0.73.6 in `cli-plugin-metro`

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jest-circus": "^26.6.2",
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^4.0.0",
-    "metro-memory-fs": "0.73.5",
+    "metro-memory-fs": "0.73.6",
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "slash": "^3.0.0",

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -10,12 +10,12 @@
     "@react-native-community/cli-server-api": "^10.0.0",
     "@react-native-community/cli-tools": "^10.0.0",
     "chalk": "^4.1.2",
-    "metro": "0.73.5",
-    "metro-config": "0.73.5",
-    "metro-core": "0.73.5",
-    "metro-react-native-babel-transformer": "0.73.5",
-    "metro-resolver": "0.73.5",
-    "metro-runtime": "0.73.5",
+    "metro": "0.73.6",
+    "metro-config": "0.73.6",
+    "metro-core": "0.73.6",
+    "metro-react-native-babel-transformer": "0.73.6",
+    "metro-resolver": "0.73.6",
+    "metro-runtime": "0.73.6",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,7 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/core@^7.14.0":
+"@babel/core@^7.20.0":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.5.tgz#45e2114dc6cd4ab167f81daf7820e8fa1250d113"
   integrity sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==
@@ -381,7 +381,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
 
-"@babel/parser@^7.14.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.20.5":
+"@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.20.0", "@babel/parser@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.5.tgz#7f3c7335fe417665d929f34ae5dceae4c04015e8"
   integrity sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==
@@ -563,7 +563,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.2.0", "@babel/plugin-syntax-flow@^7.8.3":
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.18.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.8.3":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz#774d825256f2379d06139be0c723c4dd444f3ca1"
   integrity sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==
@@ -1276,7 +1276,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
+"@babel/traverse@^7.14.5", "@babel/traverse@^7.19.1", "@babel/traverse@^7.20.0", "@babel/traverse@^7.20.1", "@babel/traverse@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.5.tgz#78eb244bea8270fdda1ef9af22a5d5e5b7e57133"
   integrity sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==
@@ -8476,53 +8476,53 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.73.5.tgz#e7ebe371cd8bf5df90b0e9153587b4d5089d2ce7"
-  integrity sha512-G3awAJ9of/R2jEg+MRokYcq/TNvMSxJipwybQ2NfwwSj5iLEmRH2YbwTx5w8f5qKgs2K4SS2pmBIs8qjdV6p3Q==
+metro-babel-transformer@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.73.6.tgz#7f71a9146dcfafc199800013cccc5b2664bccdc4"
+  integrity sha512-yRdMESW6KdJohQwWsUm8TIMv9Pp+1gHqLEbixA0WDx2EwYfEhQELF7RdUL5VIResn3+2yZv+/sfeh2mT/GSbVg==
   dependencies:
-    "@babel/core" "^7.14.0"
+    "@babel/core" "^7.20.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.73.5"
+    metro-source-map "0.73.6"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.73.5.tgz#efe2d72f30564a31b66f7eab1872dd12bda03db2"
-  integrity sha512-epEN4GCVkERmZdDeMPpWl7fpsgRNduTS84CAXZXDyWw9zHr0yd1Q+gF/HFkmsg6asOAg9EctuuXf2hFBJ0eP6w==
+metro-cache-key@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.73.6.tgz#66521d3d37fb8a2cab2f8992cfa4615c8fa0e67d"
+  integrity sha512-KI0Qm9WpiNnv3pIFCOKNDLnNL58kChlMJUwfsVNVfPp9TaO+TNR4SM8lq9iM3qgyWwywS5fHOu52DoIGTDIHsw==
 
-metro-cache@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.73.5.tgz#ee7da0cc0927c8e43f6e5031d029ac04fbe14cb5"
-  integrity sha512-eOvUDhWTusuYg+HcoCDsV+w2XtamHduq00FWGrfeS656HBx/jOhq7ufwpN8yKP6plv5U4V1k6MoEKhv218Dy0w==
+metro-cache@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.73.6.tgz#73d4707c73d6b33a286ba45eab1a0ecef33fbd80"
+  integrity sha512-wzmR58fyOwe7qTj7nyGdtbZGnscBVXozS3A5/FQE2pgnjknD/vtUtHut4iJGN2l2INTccBorC7l6XlJ6xcMMMA==
   dependencies:
-    metro-core "0.73.5"
+    metro-core "0.73.6"
     rimraf "^3.0.2"
 
-metro-config@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.73.5.tgz#ae308fcee174fed48a10c904045c84b15b5a054c"
-  integrity sha512-CvddMglr2k0FSBHuBSs/piazu5xuZvyAolB40ksCkfLu0nDbEqKZMSvIRGnkU/1H+OaY8wrcQmou0/L5/PT9Dw==
+metro-config@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.73.6.tgz#d8bbe4a01b951621ea37e13566e0a6cf57ef96b2"
+  integrity sha512-LdFbpWq+7uF5gYGU4U4TUJhxsXLc9mEmPSxZaaWxOLUu6Ga54hgybEb1AVDoBfk6zmM02lFhlWNtjCnwqii2Qg==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.73.5"
-    metro-cache "0.73.5"
-    metro-core "0.73.5"
-    metro-runtime "0.73.5"
+    metro "0.73.6"
+    metro-cache "0.73.6"
+    metro-core "0.73.6"
+    metro-runtime "0.73.6"
 
-metro-core@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.73.5.tgz#1172db6aff4e3860fb4fd4236b8fbd5217249c04"
-  integrity sha512-gubog1DnAIWKMl0GGqQyMJ1ytt/A7y+8Z+E0PmpEFEySk0hMKexOYJ3PqijWilUBH2Od/lMo8TdDR7yIR01uIw==
+metro-core@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.73.6.tgz#e7bc402007973dd7d19603e8618fec1f95e7725a"
+  integrity sha512-cApGmJAP9rZOkTrfvnkauYkNlACrzO3cud41OkHk7fZCbUo431R65aqxnotbzCbapdVfgOSRVXbX/wk55uAsVg==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.73.5"
+    metro-resolver "0.73.6"
 
-metro-file-map@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.73.5.tgz#eda07ddd080e0e32ba7e5caed61ae2f18b21e7d2"
-  integrity sha512-F0snVq8ODO78L8vcX5d91LdfZBKDSLvC7kLe/wWmTI+YRNyTLTGja4WW+MPC0wr2JTNVGVdGQP8g9Ad5429VLg==
+metro-file-map@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.73.6.tgz#6d029b847dbd7c9a10f079e4c0003ce7c2ac2d3c"
+  integrity sha512-63IvFRWdWke/18TRmMID4nAmwXkzwmCYfb29kJ7tqAGa2leWfCMQInX9pH3xcecraF/pAHlDFpOhxC3HU8CjJg==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -8540,46 +8540,46 @@ metro-file-map@0.73.5:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.73.5.tgz#2c8f9e42717f90516a5d8b698fd8fdf434775932"
-  integrity sha512-20ZiicA0J4ylZtrsoOiR7bcM3scvu90iYA5P6bcSz2sKldF2dT30FkmCKcW4fMHhVx77uT3nSy5rb6IbcYfHwA==
+metro-hermes-compiler@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.73.6.tgz#7edf8d2b59fa78d507d923489cac6dcac529c5a4"
+  integrity sha512-eWhRWoelaIzbVrtFHq9YeIGr1GsjPb7wkRgrHaTcxx06lMJ3ZU5WE0etL5zk4Xrz/R0NwtcqmoyIVQeNJakchA==
 
-metro-inspector-proxy@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.73.5.tgz#b6fb59f6384f99673ad90164008a9bc4390d9aca"
-  integrity sha512-8Tx2K37k5wFJgREMnDRekdZtPBZJ/NZlR/Dihy8Rkw6r9lKFM+mfEXKNlnxtG0kzlb3iD8wKD5aOECoKsWy0sg==
+metro-inspector-proxy@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.73.6.tgz#e66cba8884d172e70fd4615a249cbf71ee98f706"
+  integrity sha512-pNrkQJYOH1JZXePf2N0cMf1VS4S6jcUgDGnc8HouCe4xCffGk4UWqkNuphU5Nw4dr1HN3WWZLGkcE1XuNSEI3Q==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
     ws "^7.5.1"
     yargs "^17.5.1"
 
-metro-memory-fs@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.73.5.tgz#3424fd46decbd001706b639f8a2b60273a6b3872"
-  integrity sha512-HSLoCkyOoLNO9q+bpJXrxW5ElvcAbNTPv84EaRZ/tA6CdxcQz7wGc2RioifwF4efVmAy0TRgPN9AaoYO4MhKxw==
+metro-memory-fs@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.73.6.tgz#9c5916dc9194cb20b0cf9a9fdf1c54b30d593481"
+  integrity sha512-TkZ3Wwd2/gJH0c+TWT9D1smKeGwfEETDXbpkhe9X3yp6JE6+2zcuMON9m2JyslB2gi/SJOHF44i+nctpUnkBrQ==
 
-metro-minify-terser@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.73.5.tgz#178cde6567f88a8fe9817fa3b0585918144a54e4"
-  integrity sha512-dzhQdlK+wKUwCrxnTo2h2fcPSDv2NOL3CnNBWEWzoxAWGuZasBDQlYq6ZKHQKEZ5FcwrATlKqgdsSFQdmdaxpw==
+metro-minify-terser@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.73.6.tgz#7f2fa6a31621ce01cc539e91ae07a2ed8b9805fd"
+  integrity sha512-nJH9hQehSX5T2K8zR9hy4YROPjCai+dhzV5eb274ko/K42UanLqM8E7L9BqSndw9jaysIgxe/UZwq/0VzgS7vA==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.73.5.tgz#688c3913f83326d5864415244521d3bfb43b3056"
-  integrity sha512-kA4m3m+anYvu415lOY1UsYdoSVYWb1dsI125O54h/DORCq3vhFTiGxmZp41Z0h89jMbli8Omjgu7oVwR6oKN4g==
+metro-minify-uglify@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.73.6.tgz#70110aab55344722c83a6c575ac33b455a8d67b6"
+  integrity sha512-COA+u5EIShh+zE7MP5d35EzO3kpHl915GKbQtV5PFk0bNdftMNBal8sdrnWXUKHpRuNcIh5MVk3CHAZLVyCPXQ==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.5.tgz#9b92f1ebc2b3d96f511c45a03f8e35e0fc46cc19"
-  integrity sha512-Ej6J8ozWSs6nrh0nwX7hgX4oPXUai40ckah37cSLu8qeED2XiEtfLV1YksTLafFE8fX0EieiP97U97dkOGHP4w==
+metro-react-native-babel-preset@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.6.tgz#dea0a8a4442608993691a528bd2f4e2c82931ffe"
+  integrity sha512-JyClNoUbWHLD5aUthOhYmuYrunyDCflv7DiSIYoeHCgnqSp+R2y2BIHF6yHAK/5aHHdwwFIykGDa2t1SCeS/xQ==
   dependencies:
-    "@babel/core" "^7.14.0"
+    "@babel/core" "^7.20.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
     "@babel/plugin-proposal-class-properties" "^7.0.0"
     "@babel/plugin-proposal-export-default-from" "^7.0.0"
@@ -8589,7 +8589,7 @@ metro-react-native-babel-preset@0.73.5:
     "@babel/plugin-proposal-optional-chaining" "^7.0.0"
     "@babel/plugin-syntax-dynamic-import" "^7.0.0"
     "@babel/plugin-syntax-export-default-from" "^7.0.0"
-    "@babel/plugin-syntax-flow" "^7.2.0"
+    "@babel/plugin-syntax-flow" "^7.18.0"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.0.0"
     "@babel/plugin-syntax-optional-chaining" "^7.0.0"
     "@babel/plugin-transform-arrow-functions" "^7.0.0"
@@ -8618,101 +8618,101 @@ metro-react-native-babel-preset@0.73.5:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.5.tgz#fb1d48cc73ce26371cf2a115f702b7bf3bb5516b"
-  integrity sha512-CZYgUguqFTzV9vSOZb60p8qlp31aWz8aBB6OqoZ2gJday+n/1k+Y0yy6VPr/tfXJheuQYVIXKvG1gMmUDyxt+Q==
+metro-react-native-babel-transformer@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.6.tgz#54c9200316a8b5e2317fed62d5d6cf1d34deed99"
+  integrity sha512-HdjUY0k3gqdN3xe/9S8DrFawi/eNlqcgofLKo1n/DVnQTwFVOH4F4NqxLKEWx/kdIFApJkCeQDR4HePv+wBa1g==
   dependencies:
-    "@babel/core" "^7.14.0"
+    "@babel/core" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.73.5"
-    metro-react-native-babel-preset "0.73.5"
-    metro-source-map "0.73.5"
+    metro-babel-transformer "0.73.6"
+    metro-react-native-babel-preset "0.73.6"
+    metro-source-map "0.73.6"
     nullthrows "^1.1.1"
 
-metro-resolver@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.73.5.tgz#031f12fa6ed9bb100420e7d5d5c2f1d3b10987a8"
-  integrity sha512-2J5TaNdt/OUxdpyfjPntw6oJksJFnP2vRQXdEOykJ/gGbkrzGQET/epw55pVlNRcioR8G5q7yhqnLZ128n1yyg==
+metro-resolver@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.73.6.tgz#b78819a1375c85dd8739e041910f64f0d6653325"
+  integrity sha512-xybEQaUcBCF9DKzs1CiFJo+uE/nnJowLBSrSwcutzDRwT0k7b/huR3d8P8fks2ZVUKDfGzyF75yIdlb5P2ShwQ==
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.73.5.tgz#8c92c3947e97a8dede6347ba6a9844bfb8be8258"
-  integrity sha512-8QJOS7bhJmR6r/Gkki/qY9oX/DdxnLhS8FpdG1Xmm2hDeUVAug12ekWTiCRMu7d1CDVv1F8WvUz09QckZ0dO0g==
+metro-runtime@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.73.6.tgz#4c05662bbdd6073597b3e5aa7e05f1502e389e7a"
+  integrity sha512-gb9Q7n186Z9Gtfj2ux0Dxk1yRjibViwKcGN5fcHWA/iKfVCSMWhuPShD0yhRmuLhXwBV3FiDJPGohVkIR4VwKA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-source-map@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.73.5.tgz#67e14bd1fcc1074b9623640ca311cd99d07426fa"
-  integrity sha512-58p3zNWgUrqYYjFJb0KkZ+uJurTL4oz7i5T7577b3kvTYuJ0eK4y7rtYf8EwOfMYxRAn/m20aH1Y1fHTsLUwjQ==
+metro-source-map@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.73.6.tgz#a882bab6b5363c058fd1ad92573539be04dae50f"
+  integrity sha512-BAIaUx0e/Wh7RSLSdEUVoA8HBtj6kP6mFJTMzbmSG976t4r9Sfyp6TyXT/k9LO4nC6rgPk7NA2X/1dBZBdYJ+w==
   dependencies:
-    "@babel/traverse" "^7.14.0"
+    "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.73.5"
+    metro-symbolicate "0.73.6"
     nullthrows "^1.1.1"
-    ob1 "0.73.5"
+    ob1 "0.73.6"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.73.5.tgz#8de118be231decd55c8c70ed54deb308fdffceda"
-  integrity sha512-aIC8sDlaEdtn0dTt+64IFZFEATatFx3GtzRbJi0+jJx47RjDRiuCt9fzmTMLuadWwnbFK9ZfVMuWEXM9sdtQ7w==
+metro-symbolicate@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.73.6.tgz#241d4e76f547d4e00f416402151710b8cc3c7739"
+  integrity sha512-Hr1/StXOtpQOlvRvLkcyzXqS4u2rK3BmKcGmsHUb7vvjIpDe3zfUKfVYXMh+FkHqn5AfSYXfrae4RrWqVrtEBg==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.73.5"
+    metro-source-map "0.73.6"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.73.5.tgz#ac15053b8746fff3daf45338b9c1094cec9251cb"
-  integrity sha512-VQwWQ7Gtu55uFSN/8hhqfhLYhIa00EtVp06NfgR/XfkvD8EaFlk/4RxinOaWU+d42kZa2UMPCNVECd7UcvVuRA==
+metro-transform-plugins@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.73.6.tgz#dda5c9691bbd5a683031fb48a1e163d476c3955b"
+  integrity sha512-1uKjyxiH0xixaXktCz+EGSCpOcYEOaL3Ju6v4Xea0PX7xQ/5AI8Iml4eLi0Sc5cpq1YMybP6KOfCGP3xOOBFhA==
   dependencies:
-    "@babel/core" "^7.14.0"
+    "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.14.0"
+    "@babel/traverse" "^7.20.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.73.5.tgz#e88179bde91ec515b9b6f4b9ebbede507eec40d6"
-  integrity sha512-2JfEFWtynls94JjLyPNdoehgmGiSyiETD2b6lMcjfG9nLgoOJoPBaf0xHtfcql9jqnt7dvqLWmtvoWtq6c0ymA==
+metro-transform-worker@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.73.6.tgz#59671c0fd29027029715918c5448d827ad274932"
+  integrity sha512-l7iWnT3s3TbhKdoK66m7MwNWwRMji/FLTK4cC0hBlKvdF9ssbOg8Q5O07Gqs7ZEViBGA7MR6xMCJZ3iEI6/OCA==
   dependencies:
-    "@babel/core" "^7.14.0"
+    "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
-    "@babel/parser" "^7.14.0"
+    "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.73.5"
-    metro-babel-transformer "0.73.5"
-    metro-cache "0.73.5"
-    metro-cache-key "0.73.5"
-    metro-hermes-compiler "0.73.5"
-    metro-source-map "0.73.5"
-    metro-transform-plugins "0.73.5"
+    metro "0.73.6"
+    metro-babel-transformer "0.73.6"
+    metro-cache "0.73.6"
+    metro-cache-key "0.73.6"
+    metro-hermes-compiler "0.73.6"
+    metro-source-map "0.73.6"
+    metro-transform-plugins "0.73.6"
     nullthrows "^1.1.1"
 
-metro@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.73.5.tgz#c233215ad278d6851a51f21421a6d0d49773f246"
-  integrity sha512-E7m69LNvm8Lg/stn0DI+ay/zksLff/FeZomZ90wBmO8vnO/HcQuN33R4ZC/Kgd8qwA0HYQ1J+UamITU/PhseAw==
+metro@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.73.6.tgz#27cc6ea02cbaa9f3ece897cc6d92595bd49515ca"
+  integrity sha512-O2wGS+lzHYMRNZ8yJZPZ+cB+nNTSszZ7AipLTj/N3dBnnc7uG5of9l4SJi2bGl+9tQ6ovlXk8OlcbqUVnaP/MA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/core" "^7.14.0"
+    "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
-    "@babel/parser" "^7.14.0"
+    "@babel/parser" "^7.20.0"
     "@babel/template" "^7.0.0"
-    "@babel/traverse" "^7.14.0"
+    "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
     absolute-path "^0.0.0"
     accepts "^1.3.7"
@@ -8729,23 +8729,23 @@ metro@0.73.5:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.73.5"
-    metro-cache "0.73.5"
-    metro-cache-key "0.73.5"
-    metro-config "0.73.5"
-    metro-core "0.73.5"
-    metro-file-map "0.73.5"
-    metro-hermes-compiler "0.73.5"
-    metro-inspector-proxy "0.73.5"
-    metro-minify-terser "0.73.5"
-    metro-minify-uglify "0.73.5"
-    metro-react-native-babel-preset "0.73.5"
-    metro-resolver "0.73.5"
-    metro-runtime "0.73.5"
-    metro-source-map "0.73.5"
-    metro-symbolicate "0.73.5"
-    metro-transform-plugins "0.73.5"
-    metro-transform-worker "0.73.5"
+    metro-babel-transformer "0.73.6"
+    metro-cache "0.73.6"
+    metro-cache-key "0.73.6"
+    metro-config "0.73.6"
+    metro-core "0.73.6"
+    metro-file-map "0.73.6"
+    metro-hermes-compiler "0.73.6"
+    metro-inspector-proxy "0.73.6"
+    metro-minify-terser "0.73.6"
+    metro-minify-uglify "0.73.6"
+    metro-react-native-babel-preset "0.73.6"
+    metro-resolver "0.73.6"
+    metro-runtime "0.73.6"
+    metro-source-map "0.73.6"
+    metro-symbolicate "0.73.6"
+    metro-transform-plugins "0.73.6"
+    metro-transform-worker "0.73.6"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -9379,10 +9379,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.73.5:
-  version "0.73.5"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.73.5.tgz#b80dc4a6f787044e3d8afde3c2d034ae23d05a86"
-  integrity sha512-MxQH/rCq9/COvgTQbjCldArmesGEidZVVQIn4vDUJvJJ8uMphXOTCBsgWTief2ugvb0WUimIaslKSA+qryFjjQ==
+ob1@0.73.6:
+  version "0.73.6"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.73.6.tgz#b8e1928b52074d9be5cdf6e05a19ef9bf42d54b9"
+  integrity sha512-pQfNtndvu58qpCPSnl2QLTWigam9rpv7HNHLHfVqUlaSJpm9PgFriq7LRSEe8nFsHNFivx5hl23jVeGuTYqbyQ==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Summary:
----------

Updating Metro dependencies in the `cli-plugin-metro` to incorporate the new Metro Release v0.73.6. This Metro release fixes duplicate 'add' events and reduces dropped events on new subtrees in `NodeWatcher`

Per the release notes we shared (link below), I am suggesting that this is a minor bump for RN CLI.

**Metro release notes:** https://github.com/facebook/metro/releases/tag/v0.73.6

**Changelog between 0.73.5 and 0.73.6:** https://github.com/facebook/metro/compare/v0.73.5...v0.73.6

Test Plan:
----------
Updated dependencies with yarn.

Commands I ran for future upgrade reference:
```
yarn upgrade metro-memory-fs@0.73.6
cd packages/cli-plugin-metro
metro_version=0.73.6; yarn upgrade metro@$metro_version metro-config@$metro_version  metro-core@$metro_version metro-react-native-babel-transformer@$metro_version metro-resolver@$metro_version metro-runtime@$metro_version
```

Reminder : When React Native updates the CLI to a version that depends on metro 0.73.6, it must also update metro-runtime etc to 0.73.6 in the same commit

