### PR TITLE
fix: when used with option --port and --deviceId not working on run-android

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -140,12 +140,19 @@ function runOnSpecificDevice(
     if (devices.indexOf(deviceId) !== -1) {
       // using '-x lint' in order to ignore linting errors while building the apk
       let gradleArgs = ['build', '-x', 'lint'];
+
       if (args.extraParams) {
         gradleArgs = [...gradleArgs, ...args.extraParams];
       }
+
+      if (args.port) {
+        gradleArgs.push(`-PreactNativeDevServerPort=${args.port}`);
+      }
+
       if (!args.binaryPath) {
         build(gradleArgs, androidProject.sourceDir);
       }
+
       installAndLaunchOnDevice(args, deviceId, adbPath, androidProject);
     } else {
       logger.error(


### PR DESCRIPTION
fixes #1784 

Summary:
---------
When used with option --port and --deviceId, not working port option on run-android.
The reason is as follows.

### run-android with port args.
This command is run with runOnAllDevices function.
runOnAllDevices function is include port argument push on gradle argument logic like below.
```typescript
if (args.port != null) {
  gradleArgs.push('-PreactNativeDevServerPort=' + args.port);
}
```

### run-android with deviceId args.
This command is run with runOnSpecificDevice function.
but runOnSpecificDevice function is not include port argument logic.

### Solution
I added port argument logic on runOnSpecificDevice function like below.
```typescript
// using '-x lint' in order to ignore linting errors while building the apk
let gradleArgs = ['build', '-x', 'lint'];

if (args.extraParams) {
  gradleArgs = [...gradleArgs, ...args.extraParams];
}

if (args.port) {
  gradleArgs.push(`-PreactNativeDevServerPort=${args.port}`);
}

if (!args.binaryPath) {
  build(gradleArgs, androidProject.sourceDir);
}

installAndLaunchOnDevice(args, deviceId, adbPath, androidProject);
```

Test Plan:
----------
* Connect two android device.
* Link CLI
* When running the two options together, check that it runs with the port set on the specific device without problems.
