### PR TITLE
Remove useless simulator check in parseXctraceIOSDevicesList

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/parseXctraceIOSDevicesList.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/parseXctraceIOSDevicesList.ts
@@ -26,9 +26,7 @@ import {Device} from '../../types';
 function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];
   let isSimulator = false;
-  if (text.indexOf('== Simulators ==') === -1) {
-    return [];
-  }
+
   text.split('\n').forEach((line) => {
     if (line === '== Simulators ==') {
       isSimulator = true;

--- a/packages/cli-platform-ios/src/commands/runIOS/parseXctraceIOSDevicesList.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/parseXctraceIOSDevicesList.ts
@@ -27,6 +27,13 @@ function parseIOSDevicesList(text: string): Array<Device> {
   const devices: Array<Device> = [];
   let isSimulator = false;
 
+  if (
+    text.indexOf('== Simulators ==') === -1 &&
+    text.indexOf('== Devices ==') === -1
+  ) {
+    return [];
+  }
+
   text.split('\n').forEach((line) => {
     if (line === '== Simulators ==') {
       isSimulator = true;


### PR DESCRIPTION
Summary:
---------
I was just sitting 4h in front of the computer debugging why my metro bundler couldn't find the device.  :D

Although the `xcrun xctrace list devices` returned me all the correct devices.
```bash
== Devices ==
Pauls & Simons Mac (*****)
iPhone von Simon (15.4.1) (****)
```

Right before that I uninstalled all my simulators. Now because of the simulator check, the function returned an empty array.