### PR TITLE
Update Metro dependencies to 0.73.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^4.0.0",
     "lint-staged": "^13.1.0",
-    "metro-memory-fs": "0.73.6",
+    "metro-memory-fs": "0.73.7",
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "slash": "^3.0.0",

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -11,12 +11,12 @@
     "@react-native-community/cli-tools": "^10.0.0",
     "chalk": "^4.1.2",
     "execa": "^1.0.0",
-    "metro": "0.73.6",
-    "metro-config": "0.73.6",
-    "metro-core": "0.73.6",
-    "metro-react-native-babel-transformer": "0.73.6",
-    "metro-resolver": "0.73.6",
-    "metro-runtime": "0.73.6",
+    "metro": "0.73.7",
+    "metro-config": "0.73.7",
+    "metro-core": "0.73.7",
+    "metro-react-native-babel-transformer": "0.73.7",
+    "metro-resolver": "0.73.7",
+    "metro-runtime": "0.73.7",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8607,53 +8607,53 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.73.6.tgz#7f71a9146dcfafc199800013cccc5b2664bccdc4"
-  integrity sha512-yRdMESW6KdJohQwWsUm8TIMv9Pp+1gHqLEbixA0WDx2EwYfEhQELF7RdUL5VIResn3+2yZv+/sfeh2mT/GSbVg==
+metro-babel-transformer@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.73.7.tgz#561ffa0336eb6d7d112e7128e957114c729fdb71"
+  integrity sha512-s7UVkwovGTEXYEQrv5hcmSBbFJ9s9lhCRNMScn4Itgj3UMdqRr9lU8DXKEFlJ7osgRxN6n5+eXqcvhE4B1H1VQ==
   dependencies:
     "@babel/core" "^7.20.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.73.6"
+    metro-source-map "0.73.7"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.73.6.tgz#66521d3d37fb8a2cab2f8992cfa4615c8fa0e67d"
-  integrity sha512-KI0Qm9WpiNnv3pIFCOKNDLnNL58kChlMJUwfsVNVfPp9TaO+TNR4SM8lq9iM3qgyWwywS5fHOu52DoIGTDIHsw==
+metro-cache-key@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.73.7.tgz#fa3b4ece5f3191ce238a623051a0d03bada2a153"
+  integrity sha512-GngYzrHwZU9U0Xl81H4aq9Tn5cjQyU12v9/flB0hzpeiYO5A89TIeilb4Kg8jtfC6JcmmsdK9nxYIGEq7odHhQ==
 
-metro-cache@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.73.6.tgz#73d4707c73d6b33a286ba45eab1a0ecef33fbd80"
-  integrity sha512-wzmR58fyOwe7qTj7nyGdtbZGnscBVXozS3A5/FQE2pgnjknD/vtUtHut4iJGN2l2INTccBorC7l6XlJ6xcMMMA==
+metro-cache@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.73.7.tgz#dd2b6a791b2754eae9c0a86dcf714b98e025fd95"
+  integrity sha512-CPPgI+i9yVzOEDCdmEEZ67JgOvZyNDs8kStmGUFgDuLSjj3//HhkqT5XyfWjGeH6KmyGiS8ip3cgLOVn3IsOSA==
   dependencies:
-    metro-core "0.73.6"
+    metro-core "0.73.7"
     rimraf "^3.0.2"
 
-metro-config@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.73.6.tgz#d8bbe4a01b951621ea37e13566e0a6cf57ef96b2"
-  integrity sha512-LdFbpWq+7uF5gYGU4U4TUJhxsXLc9mEmPSxZaaWxOLUu6Ga54hgybEb1AVDoBfk6zmM02lFhlWNtjCnwqii2Qg==
+metro-config@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.73.7.tgz#8935054ece6155d214420c263272cd3a690a82e2"
+  integrity sha512-pD/F+vK3u37cbj1skYmI6cUsEEscqNRtW2KlDKu1m+n8nooDB2oGTOZatlS5WQa7Ga6jYQRydftlq4CLDexAfA==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.73.6"
-    metro-cache "0.73.6"
-    metro-core "0.73.6"
-    metro-runtime "0.73.6"
+    metro "0.73.7"
+    metro-cache "0.73.7"
+    metro-core "0.73.7"
+    metro-runtime "0.73.7"
 
-metro-core@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.73.6.tgz#e7bc402007973dd7d19603e8618fec1f95e7725a"
-  integrity sha512-cApGmJAP9rZOkTrfvnkauYkNlACrzO3cud41OkHk7fZCbUo431R65aqxnotbzCbapdVfgOSRVXbX/wk55uAsVg==
+metro-core@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.73.7.tgz#f5abe2448ea72a65f54db9bc90068f3308de1df2"
+  integrity sha512-H7j1Egj1VnNnsSYf9ZKv0SRwijgtRKIcaGNQq/T+er73vqqb4kR9H+2VIJYPXi6R8lT+QLIMfs6CWSUHAJUgtg==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.73.6"
+    metro-resolver "0.73.7"
 
-metro-file-map@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.73.6.tgz#6d029b847dbd7c9a10f079e4c0003ce7c2ac2d3c"
-  integrity sha512-63IvFRWdWke/18TRmMID4nAmwXkzwmCYfb29kJ7tqAGa2leWfCMQInX9pH3xcecraF/pAHlDFpOhxC3HU8CjJg==
+metro-file-map@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.73.7.tgz#709f33ac5ea6f87668d454c77973ab296b7a064b"
+  integrity sha512-BYaCo2e/4FMN4nOajeN+Za5cPfecfikzUYuFWWMyLAmHU6dj7B+PFkaJ4OEJO3vmRoeq5vMOmhpKXgysYbNXJg==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -8671,44 +8671,44 @@ metro-file-map@0.73.6:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.73.6.tgz#7edf8d2b59fa78d507d923489cac6dcac529c5a4"
-  integrity sha512-eWhRWoelaIzbVrtFHq9YeIGr1GsjPb7wkRgrHaTcxx06lMJ3ZU5WE0etL5zk4Xrz/R0NwtcqmoyIVQeNJakchA==
+metro-hermes-compiler@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.73.7.tgz#d1b519c4040423240d89e7816340ca9635deeae8"
+  integrity sha512-F8PlJ8mWEEumGNH3eMRA3gjgP70ZvH4Ex5F1KY6ofD/gpn7w5HJHSPTeVw8gtUb1pYLN4nevptpyXGg04Jfcog==
 
-metro-inspector-proxy@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.73.6.tgz#e66cba8884d172e70fd4615a249cbf71ee98f706"
-  integrity sha512-pNrkQJYOH1JZXePf2N0cMf1VS4S6jcUgDGnc8HouCe4xCffGk4UWqkNuphU5Nw4dr1HN3WWZLGkcE1XuNSEI3Q==
+metro-inspector-proxy@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.73.7.tgz#edb966c1581a41a3302860d264f3228e1f57a220"
+  integrity sha512-TsAtQeKr9X7NaQHlpshu+ZkGWlPi5fFKNqieLkfqvT1oXN4PQF/4q38INyiZtWLPvoUzTR6PRnm4pcUbJ7+Nzg==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
     ws "^7.5.1"
     yargs "^17.5.1"
 
-metro-memory-fs@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.73.6.tgz#9c5916dc9194cb20b0cf9a9fdf1c54b30d593481"
-  integrity sha512-TkZ3Wwd2/gJH0c+TWT9D1smKeGwfEETDXbpkhe9X3yp6JE6+2zcuMON9m2JyslB2gi/SJOHF44i+nctpUnkBrQ==
+metro-memory-fs@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.73.7.tgz#dcf68b945095b46327c96c7a5dca10388752cb7a"
+  integrity sha512-O++Tx3qe5A9xINypICltYsuLgAd5TmzXTGLRoReINYvtoUYuPX7jBh4zZMrCd5MHNfZiJTao2BblTsRfBflQCQ==
 
-metro-minify-terser@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.73.6.tgz#7f2fa6a31621ce01cc539e91ae07a2ed8b9805fd"
-  integrity sha512-nJH9hQehSX5T2K8zR9hy4YROPjCai+dhzV5eb274ko/K42UanLqM8E7L9BqSndw9jaysIgxe/UZwq/0VzgS7vA==
+metro-minify-terser@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.73.7.tgz#e45fc05eb2e3bc76c9b4fe4abccee0fffeedcf75"
+  integrity sha512-gbv1fmMOZm6gJ6dQoD+QktlCi2wk6nlTR8j8lQCjeeXGbs6O9e5XLWNPOexHqo7S69bdbohEnfZnLJFcxgHeNw==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.73.6.tgz#70110aab55344722c83a6c575ac33b455a8d67b6"
-  integrity sha512-COA+u5EIShh+zE7MP5d35EzO3kpHl915GKbQtV5PFk0bNdftMNBal8sdrnWXUKHpRuNcIh5MVk3CHAZLVyCPXQ==
+metro-minify-uglify@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.73.7.tgz#3dfd397e8202905731e4a519a58fc334d9232a15"
+  integrity sha512-DmDCzfdbaPExQuQ7NQozCNOSOAgp5Ux9kWzmKAT8seQ38/3NtUepW+PTgxXIHmwNjJV4oHsHwlBlTwJmYihKXg==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.6.tgz#dea0a8a4442608993691a528bd2f4e2c82931ffe"
-  integrity sha512-JyClNoUbWHLD5aUthOhYmuYrunyDCflv7DiSIYoeHCgnqSp+R2y2BIHF6yHAK/5aHHdwwFIykGDa2t1SCeS/xQ==
+metro-react-native-babel-preset@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.73.7.tgz#78e1ce448aa9a5cf3651c0ebe73cb225465211b4"
+  integrity sha512-RKcmRZREjJCzHKP+JhC9QTCohkeb3xa/DtqHU14U5KWzJHdC0mMrkTZYNXhV0cryxsaVKVEw5873KhbZyZHMVw==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -8749,64 +8749,64 @@ metro-react-native-babel-preset@0.73.6:
     "@babel/template" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.6.tgz#54c9200316a8b5e2317fed62d5d6cf1d34deed99"
-  integrity sha512-HdjUY0k3gqdN3xe/9S8DrFawi/eNlqcgofLKo1n/DVnQTwFVOH4F4NqxLKEWx/kdIFApJkCeQDR4HePv+wBa1g==
+metro-react-native-babel-transformer@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.73.7.tgz#a92055fd564cd403255cc34f925c5e99ce457565"
+  integrity sha512-73HW8betjX+VPm3iqsMBe8F/F2Tt+hONO6YJwcF7FonTqQYW1oTz0dOp0dClZGfHUXxpJBz6Vuo7J6TpdzDD+w==
   dependencies:
     "@babel/core" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.73.6"
-    metro-react-native-babel-preset "0.73.6"
-    metro-source-map "0.73.6"
+    metro-babel-transformer "0.73.7"
+    metro-react-native-babel-preset "0.73.7"
+    metro-source-map "0.73.7"
     nullthrows "^1.1.1"
 
-metro-resolver@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.73.6.tgz#b78819a1375c85dd8739e041910f64f0d6653325"
-  integrity sha512-xybEQaUcBCF9DKzs1CiFJo+uE/nnJowLBSrSwcutzDRwT0k7b/huR3d8P8fks2ZVUKDfGzyF75yIdlb5P2ShwQ==
+metro-resolver@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.73.7.tgz#1e174cf59eac84c0869172764316042b466daaa5"
+  integrity sha512-mGW3XPeKBCwZnkHcKo1dhFa9olcx7SyNzG1vb5kjzJYe4Qs3yx04r/qFXIJLcIgLItB69TIGvosznUhpeOOXzg==
   dependencies:
     absolute-path "^0.0.0"
 
-metro-runtime@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.73.6.tgz#4c05662bbdd6073597b3e5aa7e05f1502e389e7a"
-  integrity sha512-gb9Q7n186Z9Gtfj2ux0Dxk1yRjibViwKcGN5fcHWA/iKfVCSMWhuPShD0yhRmuLhXwBV3FiDJPGohVkIR4VwKA==
+metro-runtime@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.73.7.tgz#9f3a7f3ff668c1a87370650e32b47d8f6329fd1e"
+  integrity sha512-2fxRGrF8FyrwwHY0TCitdUljzutfW6CWEpdvPilfrs8p0PI5X8xOWg8ficeYtw+DldHtHIAL2phT59PqzHTyVA==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-source-map@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.73.6.tgz#a882bab6b5363c058fd1ad92573539be04dae50f"
-  integrity sha512-BAIaUx0e/Wh7RSLSdEUVoA8HBtj6kP6mFJTMzbmSG976t4r9Sfyp6TyXT/k9LO4nC6rgPk7NA2X/1dBZBdYJ+w==
+metro-source-map@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.73.7.tgz#8e9f850a72d60ea7ace05b984f981c8ec843e7a0"
+  integrity sha512-gbC/lfUN52TtQhEsTTA+987MaFUpQlufuCI05blLGLosDcFCsARikHsxa65Gtslm/rG2MqvFLiPA5hviONNv9g==
   dependencies:
     "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.73.6"
+    metro-symbolicate "0.73.7"
     nullthrows "^1.1.1"
-    ob1 "0.73.6"
+    ob1 "0.73.7"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.73.6.tgz#241d4e76f547d4e00f416402151710b8cc3c7739"
-  integrity sha512-Hr1/StXOtpQOlvRvLkcyzXqS4u2rK3BmKcGmsHUb7vvjIpDe3zfUKfVYXMh+FkHqn5AfSYXfrae4RrWqVrtEBg==
+metro-symbolicate@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.73.7.tgz#40e4cda81f8030b86afe391b5e686a0b06822b0a"
+  integrity sha512-571ThWmX5o8yGNzoXjlcdhmXqpByHU/bSZtWKhtgV2TyIAzYCYt4hawJAS5+/qDazUvjHdm8BbdqFUheM0EKNQ==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.73.6"
+    metro-source-map "0.73.7"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.73.6.tgz#dda5c9691bbd5a683031fb48a1e163d476c3955b"
-  integrity sha512-1uKjyxiH0xixaXktCz+EGSCpOcYEOaL3Ju6v4Xea0PX7xQ/5AI8Iml4eLi0Sc5cpq1YMybP6KOfCGP3xOOBFhA==
+metro-transform-plugins@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.73.7.tgz#49ff2571742d557f20301880f55b00054e468e52"
+  integrity sha512-M5isiWEau0jMudb5ezaNBZnYqXxcATMqnAYc+Cu25IahT1NHi5aWwLok9EBmBpN5641IZUZXScf+KnS7fPxPCQ==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
@@ -8814,29 +8814,29 @@ metro-transform-plugins@0.73.6:
     "@babel/traverse" "^7.20.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.73.6.tgz#59671c0fd29027029715918c5448d827ad274932"
-  integrity sha512-l7iWnT3s3TbhKdoK66m7MwNWwRMji/FLTK4cC0hBlKvdF9ssbOg8Q5O07Gqs7ZEViBGA7MR6xMCJZ3iEI6/OCA==
+metro-transform-worker@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.73.7.tgz#be111805e92ea48b7c76dd75830798f318e252e0"
+  integrity sha512-gZYIu9JAqEI9Rxi0xGMuMW6QsHGbMSptozlTOwOd7T7yXX3WwYS/I3yLPbLhbZTjOhwMHkTt8Nhm2qBo8nh14g==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.73.6"
-    metro-babel-transformer "0.73.6"
-    metro-cache "0.73.6"
-    metro-cache-key "0.73.6"
-    metro-hermes-compiler "0.73.6"
-    metro-source-map "0.73.6"
-    metro-transform-plugins "0.73.6"
+    metro "0.73.7"
+    metro-babel-transformer "0.73.7"
+    metro-cache "0.73.7"
+    metro-cache-key "0.73.7"
+    metro-hermes-compiler "0.73.7"
+    metro-source-map "0.73.7"
+    metro-transform-plugins "0.73.7"
     nullthrows "^1.1.1"
 
-metro@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.73.6.tgz#27cc6ea02cbaa9f3ece897cc6d92595bd49515ca"
-  integrity sha512-O2wGS+lzHYMRNZ8yJZPZ+cB+nNTSszZ7AipLTj/N3dBnnc7uG5of9l4SJi2bGl+9tQ6ovlXk8OlcbqUVnaP/MA==
+metro@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.73.7.tgz#435081339ac209e4d8802c57ac522638140c802b"
+  integrity sha512-pkRqFhuGUvkiu8HxKPUQelbCuyy6te6okMssTyLzQwsKilNLK4YMI2uD6PHnypg5SiMJ58lwfqkp/t5w72jEvw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.20.0"
@@ -8860,23 +8860,23 @@ metro@0.73.6:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.73.6"
-    metro-cache "0.73.6"
-    metro-cache-key "0.73.6"
-    metro-config "0.73.6"
-    metro-core "0.73.6"
-    metro-file-map "0.73.6"
-    metro-hermes-compiler "0.73.6"
-    metro-inspector-proxy "0.73.6"
-    metro-minify-terser "0.73.6"
-    metro-minify-uglify "0.73.6"
-    metro-react-native-babel-preset "0.73.6"
-    metro-resolver "0.73.6"
-    metro-runtime "0.73.6"
-    metro-source-map "0.73.6"
-    metro-symbolicate "0.73.6"
-    metro-transform-plugins "0.73.6"
-    metro-transform-worker "0.73.6"
+    metro-babel-transformer "0.73.7"
+    metro-cache "0.73.7"
+    metro-cache-key "0.73.7"
+    metro-config "0.73.7"
+    metro-core "0.73.7"
+    metro-file-map "0.73.7"
+    metro-hermes-compiler "0.73.7"
+    metro-inspector-proxy "0.73.7"
+    metro-minify-terser "0.73.7"
+    metro-minify-uglify "0.73.7"
+    metro-react-native-babel-preset "0.73.7"
+    metro-resolver "0.73.7"
+    metro-runtime "0.73.7"
+    metro-source-map "0.73.7"
+    metro-symbolicate "0.73.7"
+    metro-transform-plugins "0.73.7"
+    metro-transform-worker "0.73.7"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -9530,10 +9530,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.73.6:
-  version "0.73.6"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.73.6.tgz#b8e1928b52074d9be5cdf6e05a19ef9bf42d54b9"
-  integrity sha512-pQfNtndvu58qpCPSnl2QLTWigam9rpv7HNHLHfVqUlaSJpm9PgFriq7LRSEe8nFsHNFivx5hl23jVeGuTYqbyQ==
+ob1@0.73.7:
+  version "0.73.7"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.73.7.tgz#14c9b6ddc26cf99144f59eb542d7ae956e6b3192"
+  integrity sha512-DfelfvR843KADhSUATGGhuepVMRcf5VQX+6MQLy5AW0BKDLlO7Usj6YZeAAZP7P86QwsoTxB0RXCFiA7t6S1IQ==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
## Summary:
Updating Metro dependencies in the `cli-plugin-metro` to the Metro 0.73.7 hotfix release. This release fixes an issue where Windows Git Bash users would experience file-not-found redboxes due to Metro having an empty file map - https://github.com/facebook/metro/issues/914.

There's an ongoing discussion (@kelset, @cipolleschi, @cortinico) about whether this should be pulled in urgently to React Native 0.71.0, but if not we should aim to get it into 0.71.1

**Metro release notes:** https://github.com/facebook/metro/releases/tag/v0.73.7

**Changelog between 0.73.5 and 0.73.6:** [facebook/metro@v0.73.6...v0.73.7](https://github.com/facebook/metro/compare/v0.73.6...v0.73.7)

Thanks folks!

## Test Plan:
Updated dependencies with yarn.

*(Reminder : When React Native updates the CLI to a version that depends on metro 0.73.7, it must also update metro-runtime etc to 0.73.7 in the same commit)*