### PR TITLE
fix: add missing activeArchOnly when using runOnSpecificDevice

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -149,6 +149,18 @@ function runOnSpecificDevice(
         gradleArgs.push(`-PreactNativeDevServerPort=${args.port}`);
       }
 
+      if (args.activeArchOnly) {
+        const architecture = adb.getCPU(adbPath, deviceId);
+
+        if (architecture !== null) {
+          logger.info(`Detected architecture ${architecture}`);
+          // `reactNativeDebugArchitectures` was renamed to `reactNativeArchitectures` in 0.68.
+          // Can be removed when 0.67 no longer needs to be supported.
+          gradleArgs.push(`-PreactNativeDebugArchitectures=${architecture}`);
+          gradleArgs.push(`-PreactNativeArchitectures=${architecture}`);
+        }
+      }
+
       if (!args.binaryPath) {
         build(gradleArgs, androidProject.sourceDir);
       }


### PR DESCRIPTION
Summary:
---------

While investigating issue #1792, I found that the `--active-arch-only`, is ignored, and not added to the gradle arguments.

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Start an Android emulator and get it's name with `adb devices`.
3. Run `yarn react-native run-android --deviceId emulator-5554 --active-arch-only`, and the gradle command should use `-PreactNativeDebugArchitectures` and `-PreactNativeArchitectures`. 
