### PR TITLE
fix: use variant arg in build-android command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -323,6 +323,8 @@ Override the root directory for the Android build (which contains the android di
 
 #### `--variant <string>`
 
+> **DEPRECATED** – use "mode" instead
+
 > default: 'debug'
 
 Specify your app's build variant.

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -7,35 +7,20 @@ import {
 import {Config} from '@react-native-community/cli-types';
 import execa from 'execa';
 import {getAndroidProject} from '../../config/getAndroidProject';
-import {toPascalCase} from '../runAndroid/toPascalCase';
 import adb from '../runAndroid/adb';
 import getAdbPath from '../runAndroid/getAdbPath';
 import {startServerInNewWindow} from './startServerInNewWindow';
+import {getTaskNames} from '../runAndroid/getTaskNames';
 
 export interface BuildFlags {
-  mode: string;
-  variant: string;
+  mode?: string;
+  variant?: string;
   activeArchOnly?: boolean;
-  packager: boolean;
+  packager?: boolean;
   port: number;
   terminal: string;
   tasks?: Array<string>;
   extraParams?: Array<string>;
-}
-
-export function getTaskNames(
-  appName: string,
-  mode: BuildFlags['mode'],
-  variant: BuildFlags['variant'],
-  tasks: BuildFlags['tasks'],
-  taskPrefix: 'assemble' | 'install',
-): Array<string> {
-  const appMode = mode || variant || 'debug';
-  const appTasks = tasks || [taskPrefix + toPascalCase(appMode)];
-
-  return appName
-    ? appTasks.map((command) => `${appName}:${command}`)
-    : appTasks;
 }
 
 export async function runPackager(args: BuildFlags, config: Config) {
@@ -81,8 +66,7 @@ async function buildAndroid(
 
   let gradleArgs = getTaskNames(
     androidProject.appName,
-    args.mode,
-    args.variant,
+    args.mode || args.variant,
     args.tasks,
     'assemble',
   );

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -7,7 +7,7 @@ import {
 import {Config} from '@react-native-community/cli-types';
 import execa from 'execa';
 import {getAndroidProject} from '../../config/getAndroidProject';
-import {toPascalCase} from '../runAndroid/runOnAllDevices';
+import {toPascalCase} from '../runAndroid/toPascalCase';
 import adb from '../runAndroid/adb';
 import getAdbPath from '../runAndroid/getAdbPath';
 import {startServerInNewWindow} from './startServerInNewWindow';

--- a/packages/cli-platform-android/src/commands/runAndroid/getTaskNames.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/getTaskNames.ts
@@ -1,0 +1,15 @@
+import {toPascalCase} from './toPascalCase';
+import type {BuildFlags} from '../buildAndroid';
+
+export function getTaskNames(
+  appName: string,
+  mode: BuildFlags['mode'] = 'debug',
+  tasks: BuildFlags['tasks'],
+  taskPrefix: 'assemble' | 'install',
+): Array<string> {
+  const appTasks = tasks || [taskPrefix + toPascalCase(mode)];
+
+  return appName
+    ? appTasks.map((command) => `${appName}:${command}`)
+    : appTasks;
+}

--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
@@ -2,6 +2,7 @@ import {execSync} from 'child_process';
 import adb from './adb';
 import getAdbPath from './getAdbPath';
 import {getEmulators} from './tryLaunchEmulator';
+import {toPascalCase} from './toPascalCase';
 import os from 'os';
 import prompts from 'prompts';
 import chalk from 'chalk';
@@ -13,10 +14,6 @@ type DeviceData = {
   connected: boolean;
   type: 'emulator' | 'phone';
 };
-
-function toPascalCase(value: string) {
-  return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
-}
 
 /**
  *

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -18,10 +18,6 @@ import tryInstallAppOnDevice from './tryInstallAppOnDevice';
 import {Flags} from '.';
 import {getTaskNames} from '../buildAndroid';
 
-export function toPascalCase(value: string) {
-  return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
-}
-
 type AndroidProject = NonNullable<Config['project']['android']>;
 
 async function runOnAllDevices(

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -15,8 +15,8 @@ import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import tryLaunchEmulator from './tryLaunchEmulator';
 import tryInstallAppOnDevice from './tryInstallAppOnDevice';
-import {Flags} from '.';
-import {getTaskNames} from '../buildAndroid';
+import {getTaskNames} from './getTaskNames';
+import type {Flags} from '.';
 
 type AndroidProject = NonNullable<Config['project']['android']>;
 
@@ -52,8 +52,7 @@ async function runOnAllDevices(
     if (!args.binaryPath) {
       let gradleArgs = getTaskNames(
         androidProject.appName,
-        args.mode,
-        args.variant,
+        args.mode || args.variant,
         args.tasks,
         'install',
       );

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -16,15 +16,7 @@ import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import tryLaunchEmulator from './tryLaunchEmulator';
 import tryInstallAppOnDevice from './tryInstallAppOnDevice';
 import {Flags} from '.';
-
-export function getTaskNames(
-  appName: string,
-  commands: Array<string>,
-): Array<string> {
-  return appName
-    ? commands.map((command) => `${appName}:${command}`)
-    : commands;
-}
+import {getTaskNames} from '../buildAndroid';
 
 export function toPascalCase(value: string) {
   return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
@@ -54,13 +46,21 @@ async function runOnAllDevices(
       );
     }
   }
+  if (args.variant) {
+    logger.warn(
+      '"variant" flag is deprecated and will be removed in future release. Please switch to "mode" flag.',
+    );
+  }
 
   try {
     if (!args.binaryPath) {
-      const tasks = args.tasks || [
-        'install' + toPascalCase(args.mode ?? 'debug'),
-      ];
-      let gradleArgs = getTaskNames(androidProject.appName, tasks);
+      let gradleArgs = getTaskNames(
+        androidProject.appName,
+        args.mode,
+        args.variant,
+        args.tasks,
+        'install',
+      );
 
       if (args.extraParams) {
         gradleArgs = [...gradleArgs, ...args.extraParams];

--- a/packages/cli-platform-android/src/commands/runAndroid/toPascalCase.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/toPascalCase.ts
@@ -1,0 +1,3 @@
+export function toPascalCase(value: string) {
+  return value !== '' ? value[0].toUpperCase() + value.slice(1) : value;
+}


### PR DESCRIPTION
Summary:
---------

Fixes: https://github.com/facebook/react-native/issues/35838

If `variant` is passed to `run-android` command we still should respect it. 

Test Plan:
----------

- `yarn react-native run-android --mode FullDebug --verbose` should output `./gradlew app:installFullDebug` 
- `yarn react-native run-android --variant FullDebug --verbose` should output `./gradlew app:installFullDebug` 
- `yarn react-native build-android --mode FullDebug --verbose` should output `./gradlew app:assembleFullDebug` 
- `yarn react-native build-android --variant FullDebug --verbose` should output `./gradlew app:assembleFullDebug` 

