### PR TITLE
Correctly autolink libraries without manifest

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/files/build.gradle
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/build.gradle
@@ -1,6 +1,10 @@
 apply package: "com.android.application"
 apply package: "com.facebook.react"
 
+android {
+    namespace 'com.some.example'
+}
+
 react {
     libraryName = "justalibrary"
 }

--- a/packages/cli-platform-android/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getProjectConfig.test.ts
@@ -30,22 +30,22 @@ describe('android::getProjectConfig', () => {
       multiple: {
         android: mocks.userConfigManifest,
       },
-      noManifest: {
+      noManifestNoGradle: {
         android: {},
       },
     });
   });
 
-  it("returns `null` if manifest file hasn't been found and userConfig is not defined", () => {
+  it("returns `null` if neither manifest nor gradle file hasn't been found and userConfig is not defined", () => {
     const userConfig = undefined;
-    const folder = '/noManifest';
+    const folder = '/noManifestNoGradle';
 
     expect(getProjectConfig(folder, userConfig)).toBeNull();
   });
 
-  it("returns `null` if manifest file hasn't been found", () => {
+  it("returns `null` if neither manifest nor gradle file hasn't been found", () => {
     const userConfig = {};
-    const folder = '/noManifest';
+    const folder = '/noManifestNoGradle';
 
     expect(getProjectConfig(folder, userConfig)).toBeNull();
   });

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -45,7 +45,7 @@ export function projectConfig(
     : findManifest(path.join(sourceDir, appName));
   const buildGradlePath = findBuildGradle(sourceDir, false);
 
-  if (!manifestPath) {
+  if (!manifestPath && !buildGradlePath) {
     return null;
   }
 
@@ -53,7 +53,9 @@ export function projectConfig(
     userConfig.packageName || getPackageName(manifestPath, buildGradlePath);
 
   if (!packageName) {
-    throw new Error(`Package name not found in ${manifestPath}`);
+    throw new Error(
+      `Package name not found in neither ${manifestPath} nor ${buildGradlePath}`,
+    );
   }
 
   return {
@@ -101,7 +103,7 @@ export function dependencyConfig(
     : findManifest(sourceDir);
   const buildGradlePath = findBuildGradle(sourceDir, true);
 
-  if (!manifestPath) {
+  if (!manifestPath && !buildGradlePath) {
     return null;
   }
 


### PR DESCRIPTION
Summary:
---------

With 0.71, Android libraries could ship without a manifest by having just a `namespace` configured inside their `build.gradle`. I've just noticed that the CLI is not handling autolinking correctly (i.e. it stops the project discovery if the manifest is missing).

This fixes it.

Test Plan:
----------

I've adapted the existing test mocks to have `namespace` in the build.gradle file