### PR TITLE
fix: correctly exec launchEmulator when no port param is passed

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -24,7 +24,7 @@ const launchEmulator = async (
 
   const cp = execa(
     emulatorCommand,
-    [`@${emulatorName}`, port ? '-port' : '', port ? `${port}` : ''],
+    port ? [`@${emulatorName}`, '-port', `${port}`] : [`@${emulatorName}`],
     {
       detached: true,
       stdio: 'ignore',


### PR DESCRIPTION
Summary:
---------

Correctly exec launch emulator command when no `port` param is passed. 

fixes: #1801 

