### PR TITLE
fix: launch android emulator when using `run-android` command

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -21,15 +21,14 @@ const launchEmulator = async (
   port?: number,
 ): Promise<boolean> => {
   const manualCommand = `${emulatorCommand} @${emulatorName}`;
+  const command = port
+    ? [`@${emulatorName}`, '-port', `${port}`]
+    : [`@${emulatorName}`];
 
-  const cp = execa(
-    emulatorCommand,
-    [`@${emulatorName}`, port ? '-port' : '', port ? `${port}` : ''],
-    {
-      detached: true,
-      stdio: 'ignore',
-    },
-  );
+  const cp = execa(emulatorCommand, command, {
+    detached: true,
+    stdio: 'ignore',
+  });
   cp.unref();
   const timeout = 30;
 


### PR DESCRIPTION
Summary:
---------

Closes #1801 
When Android emulator is not running, launch emulator when running `run-android` command


Test Plan:
----------
Make sure the Android emulator is not running

1. Run `run-android` command
2. Android emulator should be launched

With port specified:
1. Run `run-android --port <port>` command
2. Android emulator should be launched with packager on specific port
