### PR TITLE
fix: passing simulator via name

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -236,7 +236,7 @@ async function runOnSimulator(
       },
       findMatchingSimulator(simulators, {
         ...args,
-        simulator: args.simulator ?? defaultSimulator,
+        simulator: args.simulator ?? fallbackSimulators[0],
       }),
     );
   }

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -85,7 +85,7 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   const devices = getDevices();
 
-  if (!args.device && !args.udid) {
+  if (!args.device && !args.udid && !args.simulator) {
     const bootedDevices = devices.filter(({type}) => type === 'device');
 
     const simulators = getSimulators();
@@ -133,12 +133,14 @@ function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     } else {
       return runOnDevice(device, scheme, xcodeProject, args);
     }
-  } else {
+  } else if (args.device) {
     const physicalDevices = devices.filter((d) => d.type !== 'simulator');
     const device = matchingDevice(physicalDevices, args.device);
     if (device) {
       return runOnDevice(device, scheme, xcodeProject, args);
     }
+  } else {
+    runOnSimulator(xcodeProject, scheme, args);
   }
 }
 
@@ -209,6 +211,8 @@ async function runOnSimulator(
   } else {
     const simulators = getSimulators();
 
+    const defaultSimulator = 'iPhone 14';
+
     /**
      * If provided simulator does not exist, try simulators in following order
      * - iPhone 14
@@ -230,7 +234,10 @@ async function runOnSimulator(
           findMatchingSimulator(simulators, {simulator: fallback})
         );
       },
-      findMatchingSimulator(simulators, args),
+      findMatchingSimulator(simulators, {
+        ...args,
+        simulator: args.simulator ?? defaultSimulator,
+      }),
     );
   }
 
@@ -704,7 +711,6 @@ export default {
       description:
         'Explicitly set simulator to use. Optionally include iOS version between ' +
         'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
-      default: 'iPhone 14',
     },
     {
       name: '--configuration <string>',

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -211,8 +211,6 @@ async function runOnSimulator(
   } else {
     const simulators = getSimulators();
 
-    const defaultSimulator = 'iPhone 14';
-
     /**
      * If provided simulator does not exist, try simulators in following order
      * - iPhone 14
@@ -235,7 +233,7 @@ async function runOnSimulator(
         );
       },
       findMatchingSimulator(simulators, {
-        ...args,
+        udid: args.udid,
         simulator: args.simulator ?? fallbackSimulators[0],
       }),
     );


### PR DESCRIPTION
Summary:
---------
Fixes: https://github.com/facebook/react-native/issues/35907


Test Plan:
----------
`yarn react-native run-ios --simulator "iPhone 14"` -> should run app on iPhone 14
`yarn react-native run-ios --device "iPhone Name"` -> should run app on iPhone Name
`yarn react-native run-ios --udid "xyz"` -> should run app on device with id xyz
`yarn react-native run-ios` -> should run on all booted devices