### PR TITLE
feat: allow initialising project with custom package name with `init --package-name`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -256,6 +256,11 @@ Skip dependencies installation
 
 Force use of npm during initialization
 
+#### `--package-name <string>`
+
+Create project with custom package name for Android and bundle identifier for iOS. The correct package name should:
+- contain at least two segments separated by dots, e.g. `com.example`
+- contain only alphanumeric characters and dots
 ### `info`
 
 Usage:

--- a/packages/cli/src/commands/init/__fixtures__/editTemplate/android/com/placeholdername/MainActivity.java
+++ b/packages/cli/src/commands/init/__fixtures__/editTemplate/android/com/placeholdername/MainActivity.java
@@ -1,0 +1,35 @@
+package com.example.app;
+
+import com.facebook.react.ReactActivity;
+import com.facebook.react.ReactActivityDelegate;
+import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+import com.facebook.react.defaults.DefaultReactActivityDelegate;
+
+public class MainActivity extends ReactActivity {
+
+  /**
+   * Returns the name of the main component registered from JavaScript. This is used to schedule
+   * rendering of the component.
+   */
+  @Override
+  protected String getMainComponentName() {
+    return "PlaceholderName";
+  }
+
+  /**
+   * Returns the instance of the {@link ReactActivityDelegate}. Here we use a util class {@link
+   * DefaultReactActivityDelegate} which allows you to easily enable Fabric and Concurrent React
+   * (aka React 18) with two boolean flags.
+   */
+  @Override
+  protected ReactActivityDelegate createReactActivityDelegate() {
+    return new DefaultReactActivityDelegate(
+        this,
+        getMainComponentName(),
+        // If you opted-in for the New Architecture, we enable the Fabric Renderer.
+        DefaultNewArchitectureEntryPoint.getFabricEnabled(), // fabricEnabled
+        // If you opted-in for the New Architecture, we enable Concurrent React (i.e. React 18).
+        DefaultNewArchitectureEntryPoint.getConcurrentReactEnabled() // concurrentRootEnabled
+        );
+  }
+}

--- a/packages/cli/src/commands/init/__fixtures__/editTemplate/ios/PlaceholderName/project.pbxproj
+++ b/packages/cli/src/commands/init/__fixtures__/editTemplate/ios/PlaceholderName/project.pbxproj
@@ -1,0 +1,4 @@
+// !$*UTF8*$!
+{
+    PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+}

--- a/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.ts.snap
+++ b/packages/cli/src/commands/init/__tests__/__snapshots__/editTemplate.test.ts.snap
@@ -51,23 +51,27 @@ exports[`should edit template 3`] = `
 - First value
 + Second value
 
-@@ -4,12 +4,12 @@
+@@ -4,14 +4,14 @@
     \\"/android/com\\",
 -   \\"/android/com/placeholdername\\",
 -   \\"/android/com/placeholdername/Main.java\\",
+-   \\"/android/com/placeholdername/MainActivity.java\\",
 -   \\"/android/com/placeholdername/PlaceholderName.java\\",
 +   \\"/android/com/projectname\\",
 +   \\"/android/com/projectname/Main.java\\",
++   \\"/android/com/projectname/MainActivity.java\\",
 +   \\"/android/com/projectname/ProjectName.java\\",
     \\"/ios\\",
 -   \\"/ios/PlaceholderName\\",
 -   \\"/ios/PlaceholderName/AppDelegate.m\\",
+-   \\"/ios/PlaceholderName/project.pbxproj\\",
 -   \\"/ios/PlaceholderName-tvOS\\",
 -   \\"/ios/PlaceholderName-tvOS/.gitkeep\\",
 -   \\"/ios/PlaceholderNameTests\\",
 -   \\"/ios/PlaceholderNameTests/.gitkeep\\",
 +   \\"/ios/ProjectName\\",
 +   \\"/ios/ProjectName/AppDelegate.m\\",
++   \\"/ios/ProjectName/project.pbxproj\\",
 +   \\"/ios/ProjectName-tvOS\\",
 +   \\"/ios/ProjectName-tvOS/.gitkeep\\",
 +   \\"/ios/ProjectNameTests\\",

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -131,20 +131,24 @@ async function createAndroidPackagePaths(
       const initialDir = process.cwd();
       process.chdir(filePath);
 
-      fs.rename(
-        `${filePath}/${segmentsList.join('.')}`,
-        `${filePath}/${segmentsList[segmentsList.length - 1]}`,
-      );
+      try {
+        await fs.rename(
+          `${filePath}/${segmentsList.join('.')}`,
+          `${filePath}/${segmentsList[segmentsList.length - 1]}`,
+        );
 
-      for (const segment of segmentsList) {
-        fs.mkdirSync(segment);
-        process.chdir(segment);
+        for (const segment of segmentsList) {
+          fs.mkdirSync(segment);
+          process.chdir(segment);
+        }
+
+        await fs.rename(
+          `${filePath}/${segmentsList[segmentsList.length - 1]}`,
+          process.cwd(),
+        );
+      } catch {
+        throw 'Failed to create correct paths for Android.';
       }
-
-      fs.rename(
-        `${filePath}/${segmentsList[segmentsList.length - 1]}`,
-        process.cwd(),
-      );
 
       process.chdir(initialDir);
     }
@@ -228,8 +232,11 @@ export async function replacePlaceholderWithPackageName({
         fileName.toLowerCase(),
       );
     }
-
-    createAndroidPackagePaths(filePath, packageName);
+    try {
+      await createAndroidPackagePaths(filePath, packageName);
+    } catch (error) {
+      throw new CLIError('Failed to create correct paths for Android.');
+    }
 
     await processDotfiles(filePath);
   }

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import walk from '../../tools/walk';
-import chalk from 'chalk';
 
 // We need `graceful-fs` behavior around async file renames on Win32.
 // `gracefulify` does not support patching `fs.promises`. Use `fs-extra`, which
@@ -22,24 +21,16 @@ interface PlaceholderConfig {
 */
 const DEFAULT_TITLE_PLACEHOLDER = 'Hello App Display Name';
 
-function validatePackageName(packageName: string) {
+export function validatePackageName(packageName: string) {
   const packageNameParts = packageName.split('.');
   const packageNameRegex = /^([a-zA-Z]([a-zA-Z0-9_])*\.)+[a-zA-Z]([a-zA-Z0-9_])*$/u;
 
   if (packageNameParts.length < 2) {
-    throw new CLIError(
-      `The package name ${chalk.bold(
-        packageName,
-      )} is invalid. It should contain at least two segments, e.g. com.app`,
-    );
+    throw `The package name ${packageName} is invalid. It should contain at least two segments, e.g. com.app`;
   }
 
   if (!packageNameRegex.test(packageName)) {
-    throw new CLIError(
-      `The ${chalk.bold(
-        packageName,
-      )} package name is not valid. It can contain only alphanumeric characters and dots.`,
-    );
+    throw `The ${packageName} package name is not valid. It can contain only alphanumeric characters and dots.`;
   }
 }
 
@@ -133,7 +124,6 @@ async function createAndroidPackagePaths(
     packageName,
   );
   const pathFolders = filePath.split('/').slice(-2);
-
   if (pathFolders[0] === 'java' && pathFolders[1] === 'com') {
     const segmentsList = startsWithCom ? segments : packageNameArray;
 
@@ -161,7 +151,7 @@ async function createAndroidPackagePaths(
   }
 }
 
-async function replacePlaceholderWithPackageName({
+export async function replacePlaceholderWithPackageName({
   projectName,
   placeholderName,
   placeholderTitle,
@@ -255,12 +245,16 @@ export async function changePlaceholderInTemplate({
   logger.debug(`Changing ${placeholderName} for ${projectName} in template`);
 
   if (packageName) {
-    replacePlaceholderWithPackageName({
-      projectName,
-      placeholderName,
-      placeholderTitle,
-      packageName,
-    });
+    try {
+      await replacePlaceholderWithPackageName({
+        projectName,
+        placeholderName,
+        placeholderTitle,
+        packageName,
+      });
+    } catch (error) {
+      throw new CLIError(error);
+    }
   } else {
     for (const filePath of walk(process.cwd()).reverse()) {
       if (shouldIgnoreFile(filePath)) {

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -32,5 +32,10 @@ export default {
       name: '--skip-install',
       description: 'Skips dependencies installation step',
     },
+    {
+      name: '--package-name <string>',
+      description:
+        'Inits a project with a custom package name (Android) and bundle ID (iOS), e.g. com.example.app',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -32,6 +32,7 @@ type Options = {
   title?: string;
   skipInstall?: boolean;
   version?: string;
+  packageName?: string;
 };
 
 interface TemplateOptions {
@@ -41,6 +42,7 @@ interface TemplateOptions {
   directory: string;
   projectTitle?: string;
   skipInstall?: boolean;
+  packageName?: string;
 }
 
 function doesDirectoryExist(dir: string) {
@@ -83,6 +85,7 @@ async function createFromTemplate({
   directory,
   projectTitle,
   skipInstall,
+  packageName,
 }: TemplateOptions) {
   logger.debug('Initializing new project');
   logger.log(banner);
@@ -118,6 +121,7 @@ async function createFromTemplate({
       projectTitle,
       placeholderName: templateConfig.placeholderName,
       placeholderTitle: templateConfig.titlePlaceholder,
+      packageName,
     });
 
     loader.succeed();
@@ -204,6 +208,7 @@ async function createProject(
     directory,
     projectTitle: options.title,
     skipInstall: options.skipInstall,
+    packageName: options.packageName,
   });
 }
 


### PR DESCRIPTION
Summary:
---------
Closes #1269 
Relates to #1111 

Added `--package-name` option to `init` command, which allows initialising project with custom package name for Android and iOS.

Test Plan:
----------
Use `init` command with `--package-name` option:
1. If package name is incorrect e.g. it contains any special chars except dots or have only one segment it should end up with error. Examples: `example`, `com.example@2.app`
2. Initialise project with `--package-name example.app` - project should be initialised with `com.example.app` Android package name and iOS bundleID
3. Initialise project with `--package-name com.example.app` - project should be initialised with `com.example.app` Android package name and iOS bundleID

For 2. and 3., app should be installed on the device/emulator named by project name - not package name.