### PR TITLE
feat: check if configuration for iOS project exists

### DIFF
--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -45,7 +45,7 @@ function buildIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 
   const {xcodeProject, sourceDir} = ctx.project.ios;
-  const projectInfo = getProjectInfo();
+  const projectInfo = getProjectInfo(sourceDir);
   checkIfConfigurationExists(projectInfo, args.mode);
 
   process.chdir(sourceDir);

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -36,6 +36,16 @@ function buildIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     );
   }
 
+  const {xcodeProject, sourceDir} = ctx.project.ios;
+
+  if (!xcodeProject) {
+    throw new CLIError(
+      `Could not find Xcode project files in "${sourceDir}" folder`,
+    );
+  }
+
+  process.chdir(sourceDir);
+
   if (args.configuration) {
     logger.warn('--configuration has been deprecated. Use --mode instead.');
     logger.warn(
@@ -44,17 +54,8 @@ function buildIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     args.mode = args.configuration;
   }
 
-  const {xcodeProject, sourceDir} = ctx.project.ios;
-  const projectInfo = getProjectInfo(sourceDir);
+  const projectInfo = getProjectInfo();
   checkIfConfigurationExists(projectInfo, args.mode);
-
-  process.chdir(sourceDir);
-
-  if (!xcodeProject) {
-    throw new CLIError(
-      `Could not find Xcode project files in "${sourceDir}" folder`,
-    );
-  }
 
   const inferredSchemeName = path.basename(
     xcodeProject.name,

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -18,6 +18,8 @@ import {Device} from '../../types';
 import {BuildFlags, buildProject} from './buildProject';
 import {getDestinationSimulator} from '../../tools/getDestinationSimulator';
 import {getDevices} from '../../tools/getDevices';
+import {getProjectInfo} from '../../tools/getProjectInfo';
+import {checkIfConfigurationExists} from '../../tools/checkIfConfigurationExists';
 
 export interface FlagsT extends BuildFlags {
   configuration?: string;
@@ -43,6 +45,8 @@ function buildIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 
   const {xcodeProject, sourceDir} = ctx.project.ios;
+  const projectInfo = getProjectInfo();
+  checkIfConfigurationExists(projectInfo, args.mode);
 
   process.chdir(sourceDir);
 

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -39,6 +39,16 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     );
   }
 
+  const {xcodeProject, sourceDir} = ctx.project.ios;
+
+  if (!xcodeProject) {
+    throw new CLIError(
+      `Could not find Xcode project files in "${sourceDir}" folder`,
+    );
+  }
+
+  process.chdir(sourceDir);
+
   if (args.binaryPath) {
     args.binaryPath = path.isAbsolute(args.binaryPath)
       ? args.binaryPath
@@ -58,17 +68,9 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     );
     args.mode = args.configuration;
   }
-  const {xcodeProject, sourceDir} = ctx.project.ios;
-  const projectInfo = getProjectInfo(sourceDir);
+
+  const projectInfo = getProjectInfo();
   checkIfConfigurationExists(projectInfo, args.mode);
-
-  process.chdir(sourceDir);
-
-  if (!xcodeProject) {
-    throw new CLIError(
-      `Could not find Xcode project files in "${sourceDir}" folder`,
-    );
-  }
 
   const inferredSchemeName = path.basename(
     xcodeProject.name,

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -59,7 +59,7 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     args.mode = args.configuration;
   }
   const {xcodeProject, sourceDir} = ctx.project.ios;
-  const projectInfo = getProjectInfo();
+  const projectInfo = getProjectInfo(sourceDir);
   checkIfConfigurationExists(projectInfo, args.mode);
 
   process.chdir(sourceDir);

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -11,11 +11,17 @@ import path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
 import {Config, IOSProjectInfo} from '@react-native-community/cli-types';
-import {getDestinationSimulator} from '../../tools/getDestinationSimulator';
-import {logger, CLIError} from '@react-native-community/cli-tools';
-import {BuildFlags, buildProject} from '../buildIOS/buildProject';
-import {iosBuildOptions} from '../buildIOS';
-import {Device} from '../../types';
+import parseIOSDevicesList from './parseIOSDevicesList';
+import parseXctraceIOSDevicesList from './parseXctraceIOSDevicesList';
+import findMatchingSimulator from './findMatchingSimulator';
+import {
+  logger,
+  CLIError,
+  getDefaultUserTerminal,
+} from '@react-native-community/cli-tools';
+import {Device, IosProjectInfo} from '../../types';
+import ora from 'ora';
+import execa from 'execa';
 
 import listIOSDevices, {promptForDeviceSelection} from './listIOSDevices';
 
@@ -57,6 +63,8 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     args.mode = args.configuration;
   }
   const {xcodeProject, sourceDir} = ctx.project.ios;
+
+  checkIfConfigurationExists(args);
 
   process.chdir(sourceDir);
 
@@ -525,6 +533,60 @@ function printFoundDevices(devices: Array<Device>) {
     'Available devices:',
     ...devices.map((device) => `  - ${device.name} (${device.udid})`),
   ].join('\n');
+}
+
+function checkIfConfigurationExists(args: FlagsT) {
+  if (args.configuration) {
+    const project = getProjectInfo();
+
+    if (!project.configurations.includes(args.configuration)) {
+      throw new CLIError(
+        `Configuration "${
+          args.configuration
+        }" does not exist in your project. Please use one of the existing configurations: ${project.configurations.join(
+          ', ',
+        )}`,
+      );
+    }
+  }
+}
+
+function getProjectInfo(): IosProjectInfo {
+  process.chdir('./ios');
+  const {project} = JSON.parse(
+    execa.sync('xcodebuild', ['-list', '-json']).stdout,
+  );
+  process.chdir('..');
+
+  return project;
+}
+
+function getProcessOptions({
+  packager,
+  terminal,
+  port,
+}: {
+  packager: boolean;
+  terminal: string | undefined;
+  port: number;
+}): SpawnOptionsWithoutStdio {
+  if (packager) {
+    return {
+      env: {
+        ...process.env,
+        RCT_TERMINAL: terminal,
+        RCT_METRO_PORT: port.toString(),
+      },
+    };
+  }
+
+  return {
+    env: {
+      ...process.env,
+      RCT_TERMINAL: terminal,
+      RCT_NO_LAUNCH_PACKAGER: 'true',
+    },
+  };
 }
 
 export default {

--- a/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
@@ -1,7 +1,9 @@
 import {checkIfConfigurationExists} from '../checkIfConfigurationExists';
 
+const CONFIGURATIONS = ['Debug', 'Release'];
+const NON_EXISTING_CONFIG = 'Test';
 const PROJECT_INFO = {
-  configurations: ['Debug', 'Release'],
+  configurations: CONFIGURATIONS,
   name: 'MyApp',
   schemes: ['MyApp', 'Scheme'],
   targets: ['MyApp', 'MyAppTests'],
@@ -9,9 +11,14 @@ const PROJECT_INFO = {
 
 describe('checkIfConfigurationExists', () => {
   test('should throw an error if project info does not contain selected configuration', () => {
-    const checkConfig = () => checkIfConfigurationExists(PROJECT_INFO, 'Test');
+    const checkConfig = () =>
+      checkIfConfigurationExists(PROJECT_INFO, NON_EXISTING_CONFIG);
 
-    expect(checkConfig).toThrow();
+    expect(checkConfig).toThrowError(
+      `Configuration "${NON_EXISTING_CONFIG}" does not exist in your project. Please use one of the existing configurations: ${CONFIGURATIONS.join(
+        ', ',
+      )}`,
+    );
   });
 
   test('should not throw an error if project info contains selected configuration', () => {

--- a/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
@@ -1,0 +1,22 @@
+import {checkIfConfigurationExists} from '../checkIfConfigurationExists';
+
+const PROJECT_INFO = {
+  configurations: ['Debug', 'Release'],
+  name: 'MyApp',
+  schemes: ['MyApp', 'Scheme'],
+  targets: ['MyApp', 'MyAppTests'],
+};
+
+describe('checkIfConfigurationExists', () => {
+  test('should throw an error if project info does not contain selected configuration', () => {
+    const checkConfig = () => checkIfConfigurationExists(PROJECT_INFO, 'Test');
+
+    expect(checkConfig).toThrow();
+  });
+
+  test('should not throw an error if project info contains selected configuration', () => {
+    const checkConfig = () => checkIfConfigurationExists(PROJECT_INFO, 'Debug');
+
+    expect(checkConfig).not.toThrow();
+  });
+});

--- a/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
+++ b/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
@@ -1,0 +1,15 @@
+import {CLIError} from '@react-native-community/cli-tools';
+import {IosProjectInfo} from '../types';
+
+export function checkIfConfigurationExists(
+  project: IosProjectInfo,
+  mode: string,
+) {
+  if (!project.configurations.includes(mode)) {
+    throw new CLIError(
+      `Configuration "${mode}" does not exist in your project. Please use one of the existing configurations: ${project.configurations.join(
+        ', ',
+      )}`,
+    );
+  }
+}

--- a/packages/cli-platform-ios/src/tools/getProjectInfo.ts
+++ b/packages/cli-platform-ios/src/tools/getProjectInfo.ts
@@ -1,0 +1,12 @@
+import execa from 'execa';
+import {IosProjectInfo} from '../types';
+
+export function getProjectInfo(): IosProjectInfo {
+  process.chdir('./ios');
+  const {project} = JSON.parse(
+    execa.sync('xcodebuild', ['-list', '-json']).stdout,
+  );
+  process.chdir('..');
+
+  return project;
+}

--- a/packages/cli-platform-ios/src/tools/getProjectInfo.ts
+++ b/packages/cli-platform-ios/src/tools/getProjectInfo.ts
@@ -1,12 +1,12 @@
 import execa from 'execa';
 import {IosProjectInfo} from '../types';
 
-export function getProjectInfo(): IosProjectInfo {
-  process.chdir('./ios');
+export function getProjectInfo(sourceDir: string): IosProjectInfo {
+  process.chdir(sourceDir);
+
   const {project} = JSON.parse(
     execa.sync('xcodebuild', ['-list', '-json']).stdout,
   );
-  process.chdir('..');
 
   return project;
 }

--- a/packages/cli-platform-ios/src/tools/getProjectInfo.ts
+++ b/packages/cli-platform-ios/src/tools/getProjectInfo.ts
@@ -1,12 +1,15 @@
+import {CLIError} from '@react-native-community/cli-tools';
 import execa from 'execa';
 import {IosProjectInfo} from '../types';
 
-export function getProjectInfo(sourceDir: string): IosProjectInfo {
-  process.chdir(sourceDir);
+export function getProjectInfo(): IosProjectInfo {
+  try {
+    const {project} = JSON.parse(
+      execa.sync('xcodebuild', ['-list', '-json']).stdout,
+    );
 
-  const {project} = JSON.parse(
-    execa.sync('xcodebuild', ['-list', '-json']).stdout,
-  );
-
-  return project;
+    return project;
+  } catch (error) {
+    throw new CLIError(error);
+  }
 }

--- a/packages/cli-platform-ios/src/types.ts
+++ b/packages/cli-platform-ios/src/types.ts
@@ -10,3 +10,10 @@ export interface Device {
   booted?: boolean;
   lastBootedAt?: string;
 }
+
+export interface IosProjectInfo {
+  configurations: string[];
+  name: string;
+  schemes: string[];
+  targets: string[];
+}


### PR DESCRIPTION
Summary:
---------

When running `run-ios` or `build-ios` command with `--mode` option, throw error if the configuration does not exist in the project.

Test Plan:
----------

1. Use `run-ios --mode Release` - should run correctly
2. Use `run-ios --mode Test` - should throw an error
3. Use `build-ios --mode Release` - should run correctly
4. Use `build-ios --mode Test` - should throw an error
