### PR TITLE
feat: add --extra-params to run-ios & build-ios command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -497,6 +497,10 @@ Explicitly set `xcconfig` to use in build.
 
 Location for iOS build artifacts. Corresponds to Xcode's `-derivedDataPath`.
 
+#### `--extra-params <string>`
+
+Custom properties that will be passed to `xcodebuild` command.
+
 ### `build-ios`
 
 Usage:
@@ -576,6 +580,10 @@ Installs passed binary instead of building a fresh one.
 > default: false
 
 List all available iOS devices and simulators and let you choose one to run the app.
+
+#### `--extra-params <string>`
+
+Custom properties that will be passed to `xcodebuild` command.
 
 ### `start`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -414,7 +414,7 @@ Mode to build the app. Either 'debug' (default) or 'release'.
 
 #### `--extra-params <string>`
 
-Custom properties that will be passed to gradle build command.
+Custom params that will be passed to gradle build command.
 Example:
 
 ```sh
@@ -499,7 +499,12 @@ Location for iOS build artifacts. Corresponds to Xcode's `-derivedDataPath`.
 
 #### `--extra-params <string>`
 
-Custom properties that will be passed to `xcodebuild` command.
+Custom params that will be passed to `xcodebuild` command.
+Example:
+
+```sh
+react-native run-ios --extra-params "-jobs 4"
+```
 
 ### `build-ios`
 
@@ -583,7 +588,12 @@ List all available iOS devices and simulators and let you choose one to run the 
 
 #### `--extra-params <string>`
 
-Custom properties that will be passed to `xcodebuild` command.
+Custom params that will be passed to `xcodebuild` command.
+Example:
+
+```sh
+react-native build-ios --extra-params "-jobs 4"
+```
 
 ### `start`
 

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -153,7 +153,7 @@ export const options = [
   },
   {
     name: '--extra-params <string>',
-    description: 'Custom properties passed to gradle build command',
+    description: 'Custom params passed to gradle build command',
     parse: (val: string) => val.split(' '),
   },
 ];

--- a/packages/cli-platform-ios/src/commands/buildIOS/buildProject.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/buildProject.ts
@@ -16,6 +16,7 @@ export type BuildFlags = {
   port: number;
   terminal: string | undefined;
   interactive?: boolean;
+  extraParams?: string[];
 };
 
 export function buildProject(
@@ -41,6 +42,11 @@ export function buildProject(
         ? 'generic/platform=iOS Simulator'
         : 'generic/platform=iOS',
     ];
+
+    if (args.extraParams) {
+      xcodebuildArgs.push(...args.extraParams);
+    }
+
     const loader = getLoader();
     logger.info(
       `Building ${chalk.dim(

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -260,6 +260,11 @@ export const iosBuildOptions = [
     description:
       'Explicitly select which scheme and configuration to use before running a build',
   },
+  {
+    name: '--extra-params <string>',
+    description: 'Custom properties that will be passed to xcodebuild command.',
+    parse: (val: string) => val.split(' '),
+  },
 ];
 
 export default {

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -262,7 +262,7 @@ export const iosBuildOptions = [
   },
   {
     name: '--extra-params <string>',
-    description: 'Custom properties that will be passed to xcodebuild command.',
+    description: 'Custom params that will be passed to xcodebuild command.',
     parse: (val: string) => val.split(' '),
   },
 ];


### PR DESCRIPTION
Summary:
---------

Closes #1821 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run `yarn react-native run-ios --extra-params "-derivedDataPath somePath"` or `yarn react-native build-ios --extra-params "-derivedDataPath somePath"`, and param `-derivedDataPath somePath` should be added to the `xcodebuild` command.