### PR TITLE
fix: avoid considering the Podfile in vendor/bundle/ruby folder as a possibly valid Podfile

### DIFF
--- a/packages/cli-platform-ios/src/config/findPodfilePath.ts
+++ b/packages/cli-platform-ios/src/config/findPodfilePath.ts
@@ -16,16 +16,34 @@ const TEST_PROJECTS = /test|example|sample/i;
 // Base iOS folder
 const IOS_BASE = 'ios';
 
+// Podfile in the bundle package
+const BUNDLE_VENDORED_PODFILE = 'vendor/bundle/ruby';
+
 export default function findPodfilePath(cwd: string) {
   const podfiles = findAllPodfilePaths(cwd)
     /**
      * Then, we will run a simple test to rule out most example projects,
      * unless they are located in a `ios` folder
      */
-    .filter(
-      (project) =>
-        path.dirname(project) === IOS_BASE || !TEST_PROJECTS.test(project),
-    )
+    .filter((project) => {
+      if (path.dirname(project) === IOS_BASE) {
+        // Pick the Podfile in the default project (in the iOS folder)
+        return true;
+      }
+
+      if (TEST_PROJECTS.test(project)) {
+        // Ignore the Podfile in test and example projects
+        return false;
+      }
+
+      if (project.indexOf(BUNDLE_VENDORED_PODFILE) > -1) {
+        // Ignore the podfile shipped with Cocoapods in bundle
+        return false;
+      }
+
+      // Accept all the others
+      return true;
+    })
     /**
      * Podfile from `ios` folder will be picked up as a first one.
      */


### PR DESCRIPTION
Summary:
---------

This PR should fix a problem connected with bundle for which, when we run `bundle exec pod install` in a React Native app, the CLI founds two Podfiles.

This is the output before the change:
<img width="797" alt="Screenshot 2023-02-09 at 17 05 36" src="https://user-images.githubusercontent.com/11162307/218149890-056cc434-fe48-4d99-bb40-ede1550adba8.png">

And this is the output after the change:
<img width="797" alt="Screenshot 2023-02-09 at 17 06 11" src="https://user-images.githubusercontent.com/11162307/218150541-22ff9d24-5aa1-4d4c-946d-20ba55ed2fcc.png">

Test Plan:
----------
Tested manually in a new RN project, by changing the code in `@react-native-community/cli-platform-ios/build/config/findPodfilePath`.