### PR TITLE
fix: parsing namespace with single quotes

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/getAndroidProject.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getAndroidProject.test.ts
@@ -79,6 +79,19 @@ android {
     );
   });
 
+  it('should parse namespace with single quotes from build.gradle', () => {
+    const buildGradle = `apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion 31
+    namespace 'com.example.app'
+}`;
+
+    expect(parseNamespaceFromBuildGradleFile(buildGradle)).toBe(
+      'com.example.app',
+    );
+  });
+
   // Test that it can parse a namespace from a build.gradle.kts file
   it('should parse namespace from build.gradle.kts', () => {
     const buildGradle = `plugins {

--- a/packages/cli-platform-android/src/config/getAndroidProject.ts
+++ b/packages/cli-platform-android/src/config/getAndroidProject.ts
@@ -96,7 +96,7 @@ export function parseNamespaceFromBuildGradleFile(buildGradle: string) {
   // search for namespace = inside the build.gradle file via regex
   const matchArray = buildGradle.match(/namespace\s*[=]*\s*("(.+?)"|'(.+?)')/);
   if (matchArray && matchArray.length > 0) {
-    return matchArray[1];
+    return matchArray[2];
   } else {
     return null;
   }

--- a/packages/cli-platform-android/src/config/getAndroidProject.ts
+++ b/packages/cli-platform-android/src/config/getAndroidProject.ts
@@ -94,7 +94,7 @@ export function parsePackageNameFromAndroidManifestFile(
 
 export function parseNamespaceFromBuildGradleFile(buildGradle: string) {
   // search for namespace = inside the build.gradle file via regex
-  const matchArray = buildGradle.match(/namespace\s*[=]*\s*"(.+?)"/);
+  const matchArray = buildGradle.match(/namespace\s*[=]*\s*("(.+?)"|'(.+?)')/);
   if (matchArray && matchArray.length > 0) {
     return matchArray[1];
   } else {

--- a/packages/cli-platform-android/src/config/getAndroidProject.ts
+++ b/packages/cli-platform-android/src/config/getAndroidProject.ts
@@ -94,9 +94,9 @@ export function parsePackageNameFromAndroidManifestFile(
 
 export function parseNamespaceFromBuildGradleFile(buildGradle: string) {
   // search for namespace = inside the build.gradle file via regex
-  const matchArray = buildGradle.match(/namespace\s*[=]*\s*("(.+?)"|'(.+?)')/);
+  const matchArray = buildGradle.match(/namespace\s*[=]*\s*["'](.+?)["']/);
   if (matchArray && matchArray.length > 0) {
-    return matchArray[2] ?? matchArray[3];
+    return matchArray[1];
   } else {
     return null;
   }

--- a/packages/cli-platform-android/src/config/getAndroidProject.ts
+++ b/packages/cli-platform-android/src/config/getAndroidProject.ts
@@ -96,7 +96,7 @@ export function parseNamespaceFromBuildGradleFile(buildGradle: string) {
   // search for namespace = inside the build.gradle file via regex
   const matchArray = buildGradle.match(/namespace\s*[=]*\s*("(.+?)"|'(.+?)')/);
   if (matchArray && matchArray.length > 0) {
-    return matchArray[2];
+    return matchArray[2] ?? matchArray[3];
   } else {
     return null;
   }


### PR DESCRIPTION
Summary:
---------

When [adding react-native to existing APPs](https://reactnative.dev/docs/integration-with-existing-apps), namespaces with single quotes are quite common, e.g. `namespace 'com.example.myandroid'`

And `./gradlew --info` fails with

```
FAILURE: Build failed with an exception.

* Where:
Script '/home/user/w/Sunbreak/react-native-fabric-module.trial/node_modules/@react-native-community/cli-platform-android/native_modules.gradle' line: 450

* What went wrong:
A problem occurred evaluating script.
> Calling `[node, /home/user/w/Sunbreak/react-native-fabric-module.trial/node_modules/@react-native-community/cli/build/bin.js, config]` finished with an exception. Error message: groovy.json.JsonException: Unable to determine the current character, it is not a string, number, array, or object
  
  The current character read is 'i' with an int value of 105
  Unable to determine the current character, it is not a string, number, array, or object
  line number 1
  index number 0
  info Run CLI with --verbose flag for more details.
  ^. Output: info Run CLI with --verbose flag for more details.
```

Which is actually calling `node cli/build/bin.js config`

```
$ node node_modules/@react-native-community/cli/build/bin.js config
error Failed to build the app: No package name found. We couldn't parse the namespace from neither your build.gradle[.kts] file at /home/user/w/Sunbreak/react-native-fabric-module.trial/android/app/build.gradle nor your package in the AndroidManifest at /home/user/w/Sunbreak/react-native-fabric-module.trial/android/app/src/main/AndroidManifest.xml.
info Run CLI with --verbose flag for more details.
```

Test Plan:
----------

Added as the code