### PR TITLE
download correct sourceMap for dev/prod profiles, add warning for Expo Dev menu profiles

### DIFF
--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import transformer from 'hermes-profile-transformer';
 import {findSourcemap, generateSourcemap} from './sourcemapUtils';
 import {getAndroidProject} from '@react-native-community/cli-platform-android';
+import {getMetroBundleOptions} from './metroBundleOptions';
 /**
  * Get the last modified hermes profile
  * @param packageNameWithSuffix
@@ -44,7 +45,7 @@ export async function downloadProfile(
   sourcemapPath?: string,
   raw?: boolean,
   shouldGenerateSourcemap?: boolean,
-  port?: string,
+  port: string = '8081',
   appId?: string,
   appIdSuffix?: string,
 ) {
@@ -88,13 +89,16 @@ export async function downloadProfile(
       execSyncWithLog(
         `adb shell run-as ${packageNameWithSuffix} cat cache/${file} > ${tempFilePath}`,
       );
+
+      const bundleOptions = getMetroBundleOptions(tempFilePath);
+
       // If path to source map is not given
       if (!sourcemapPath) {
         // Get or generate the source map
         if (shouldGenerateSourcemap) {
-          sourcemapPath = await generateSourcemap(port);
+          sourcemapPath = await generateSourcemap(port, bundleOptions);
         } else {
-          sourcemapPath = await findSourcemap(ctx, port);
+          sourcemapPath = await findSourcemap(ctx, port, bundleOptions);
         }
 
         // Run without source map

--- a/packages/cli-hermes/src/profileHermes/metroBundleOptions.ts
+++ b/packages/cli-hermes/src/profileHermes/metroBundleOptions.ts
@@ -1,0 +1,63 @@
+import {logger} from '@react-native-community/cli-tools';
+import fs from 'fs';
+import type {HermesCPUProfile} from 'hermes-profile-transformer/dist/types/HermesProfile';
+
+export interface MetroBundleOptions {
+  platform: string;
+  dev: boolean;
+  minify: boolean;
+}
+
+export function getMetroBundleOptions(
+  downloadedProfileFilePath: string,
+): MetroBundleOptions {
+  let options: MetroBundleOptions = {
+    platform: 'android',
+    dev: true,
+    minify: false,
+  };
+
+  try {
+    const contents: HermesCPUProfile = JSON.parse(
+      fs.readFileSync(downloadedProfileFilePath, {
+        encoding: 'utf8',
+      }),
+    );
+    const matchBundleUrl = /^.*\((.*index\.bundle.*)\)/;
+    let containsExpoDevMenu = false;
+    let hadMatch = false;
+    for (const frame of Object.values(contents.stackFrames)) {
+      if (frame.name.includes('EXDevMenuApp')) {
+        containsExpoDevMenu = true;
+      }
+      const match = matchBundleUrl.exec(frame.name);
+      if (match) {
+        const parsed = new URL(match[1]);
+        const platform = parsed.searchParams.get('platform'),
+          dev = parsed.searchParams.get('dev'),
+          minify = parsed.searchParams.get('minify');
+        if (platform) {
+          options.platform = platform;
+        }
+        if (dev) {
+          options.dev = dev === 'true';
+        }
+        if (minify) {
+          options.minify = minify === 'true';
+        }
+
+        hadMatch = true;
+        break;
+      }
+    }
+    if (containsExpoDevMenu && !hadMatch) {
+      logger.warn(`Found references to the Expo Dev Menu in your profiling sample.
+You might have accidentally recorded the Expo Dev Menu instead of your own application.
+To work around this, please reload your app twice before starting a profiler recording.`);
+    }
+  } catch (e) {
+    throw e;
+  }
+
+  return options;
+}


### PR DESCRIPTION
This fixes #1831



Summary:
---------

As described over in #1831, until now the `profile-hermes` command would always load the `dev` mode soureMaps, even if a production build was being profiled - this lead to wrong line numbers (at best).

This PR detects if the profile has been recorded with a `dev` or `prod` build, which platform was used and if `minify` was enabled.
Unfortunately, at this point, something further down the line seems to fail with a profile that was produced for a minifed build, so I could not really test that - that seems to be some problem with the general process and not with my changes, though.

With `minify: false`, I verified this to work correctly for both `dev=true` and `dev=false`.

If no URL information is present in the profiler, the PR just defaults to the values that were in the code before this change.

This PR also adds a warning if no URL information is present, but the profile contains calls to `EXDevMenuApp`. That is usually the case when the profiler does not record the user application, but the Expo dev menu. In that case, the user has to reload their app a few times before recording another profile - Hermes always profiles the JS bundle that was loaded last. I'm adding this warning because this is documented nowhere else, and it cost me a day until I found this out for myself.


Test Plan:
----------

Record Profiles with different combinations of "__DEV__" and "minify" selected in the settings reachable from the React Native Dev menu, call `npx react-native profile-hermes --verbose` after each recording and compare the resulting profile line numbers with the actual source code.