### PR TITLE
Add missing doctor descriptions

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/androidHomeEnvVariable.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidHomeEnvVariable.ts
@@ -9,6 +9,8 @@ const URLS = {
 };
 
 const label = 'ANDROID_HOME';
+const description =
+  'Environment variable that points to your Android SDK installation';
 
 // Force the options for the platform to avoid providing a link
 // for `ANDROID_HOME` for every platform NodeJS supports
@@ -20,6 +22,7 @@ const message = `Read more about how to set the ${label} at ${chalk.dim(
 
 export default {
   label,
+  description,
   getDiagnostics: async () => ({
     needsToBeFixed: !process.env.ANDROID_HOME,
   }),

--- a/packages/cli-doctor/src/tools/healthchecks/jdk.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/jdk.ts
@@ -10,6 +10,7 @@ import {
 
 export default {
   label: 'JDK',
+  description: 'Required to compile Java code',
   getDiagnostics: async ({Languages}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version:

--- a/packages/cli-doctor/src/tools/healthchecks/nodeJS.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/nodeJS.ts
@@ -4,6 +4,7 @@ import {HealthCheckInterface} from '../../types';
 
 export default {
   label: 'Node.js',
+  description: 'Required to execute JavaScript code',
   getDiagnostics: async ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Node.version,

--- a/packages/cli-doctor/src/tools/healthchecks/packageManagers.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/packageManagers.ts
@@ -21,6 +21,7 @@ const packageManager = (() => {
 
 const yarn: HealthCheckInterface = {
   label: 'yarn',
+  description: 'Required to install NPM dependencies',
   getDiagnostics: async ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.Yarn.version,
@@ -44,6 +45,7 @@ const yarn: HealthCheckInterface = {
 
 const npm: HealthCheckInterface = {
   label: 'npm',
+  description: 'Required to install NPM dependencies',
   getDiagnostics: async ({Binaries}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Binaries.npm.version,


### PR DESCRIPTION
Summary:
---------

I've noticed that some of our `doctor` inspections are missing labels. I've added the missing ones:

```
Common
 ✓ Node.js
 ✓ yarn
 ✓ Watchman - Used for watching changes in the filesystem when in development mode

Android
 ✓ JDK
 ✓ Android Studio - Required for building and installing your app on Android
 ✓ Android SDK - Required for building and installing your app on Android
 ✓ ANDROID_HOME

iOS
 ✓ Xcode - Required for building and installing your app on iOS
 ✓ CocoaPods - Required for installing iOS dependencies
 ✓ ios-deploy - Required for installing your app on a physical device with the CLI
 ✓ .xcode.env - File to customize Xcode environment
```

Test Plan:
----------

Not sure how to test this as that's mostly string changes
