### PR TITLE
docs: make `description` field mandatory

### DIFF
--- a/docs/healthChecks.md
+++ b/docs/healthChecks.md
@@ -57,7 +57,7 @@ type HealthCheckInterface = {
   label: string;
   visible?: boolean | void;
   isRequired?: boolean;
-  description?: string;
+  description: string;
   getDiagnostics: (
     environmentInfo: EnvironmentInfo,
   ) => Promise<{

--- a/packages/cli-doctor/src/tools/healthchecks/ruby.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/ruby.ts
@@ -5,6 +5,7 @@ import {HealthCheckInterface} from '../../types';
 export default {
   label: 'Ruby',
   isRequired: false,
+  description: 'Required for installing iOS dependencies',
   getDiagnostics: async ({Managers}) => ({
     needsToBeFixed: doesSoftwareNeedToBeFixed({
       version: Managers.RubyGems.version,

--- a/packages/cli-doctor/src/types.ts
+++ b/packages/cli-doctor/src/types.ts
@@ -85,7 +85,7 @@ export type HealthCheckInterface = {
   label: string;
   visible?: boolean | void;
   isRequired?: boolean;
-  description?: string;
+  description: string;
   getDiagnostics: (
     environmentInfo: EnvironmentInfo,
   ) => Promise<{


### PR DESCRIPTION
Summary:
---------
Follow up to: https://github.com/react-native-community/cli/pull/1835#issuecomment-1434420221, I'm making `description` field in `HealthCheckInterface` mandatory.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
