### PR TITLE
feat: Bump minimum Node JS requirement to 16 for RN 0.72 in `doctor`

### DIFF
--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -1,6 +1,6 @@
 export default {
   // Common
-  NODE_JS: '>= 14',
+  NODE_JS: '>= 16',
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
   RUBY: '>= 2.7.6',


### PR DESCRIPTION
Summary:
---------

React Native is increasing the minimum Node JS requirement from 14 to 16 in https://github.com/facebook/react-native/pull/36217, https://github.com/facebook/react-native-website/pull/3580 for 0.72 onwards. This makes the corresponding change in `doctor`.

Test Plan:
----------

CI