### PR TITLE
chore: Upgrading metro dependencies to v0.75.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^4.0.0",
     "lint-staged": "^13.1.0",
-    "metro-memory-fs": "0.75.0",
+    "metro-memory-fs": "0.75.1",
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "slash": "^3.0.0",

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -11,12 +11,12 @@
     "@react-native-community/cli-tools": "^11.0.0-alpha.0",
     "chalk": "^4.1.2",
     "execa": "^1.0.0",
-    "metro": "0.75.0",
-    "metro-config": "0.75.0",
-    "metro-core": "0.75.0",
-    "metro-react-native-babel-transformer": "0.75.0",
-    "metro-resolver": "0.75.0",
-    "metro-runtime": "0.75.0",
+    "metro": "0.75.1",
+    "metro-config": "0.75.1",
+    "metro-core": "0.75.1",
+    "metro-react-native-babel-transformer": "0.75.1",
+    "metro-resolver": "0.75.1",
+    "metro-runtime": "0.75.1",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,7 +571,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.18.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.8.3":
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.18.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.8.3":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz#774d825256f2379d06139be0c723c4dd444f3ca1"
   integrity sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==
@@ -3643,6 +3643,13 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   version "7.0.0-beta.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
+
+babel-plugin-transform-flow-enums@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz#d1d0cc9bdc799c850ca110d0ddc9f21b9ec3ef25"
+  integrity sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==
+  dependencies:
+    "@babel/plugin-syntax-flow" "^7.12.1"
 
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.0"
@@ -8663,53 +8670,53 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.75.0.tgz#34e343ed6800a182626984f0fd4d2ef15957c190"
-  integrity sha512-O+Lfy2nIw9jf8Zs/if0OSvTczOHe7FlwRslRw8yZkI80YQoSksVTwLdI909bGVp8NQD/RKsFvQfutvKGakc6jg==
+metro-babel-transformer@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.75.1.tgz#72563f30880213d8e5fd3905b01e08f97ee7d362"
+  integrity sha512-E+reiVb0XppbYe8epEp4eCgp5x58BoL2ZnJxp26a/Z9tWfD6X/3+nA0lLzCQ2ujkKJWmDqF1C9H7aRlgcvg/LQ==
   dependencies:
     "@babel/core" "^7.20.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.75.0"
+    metro-source-map "0.75.1"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.75.0.tgz#a2b0686214945d6d998b08882ec869443bb425f3"
-  integrity sha512-rLOmBPwmdhI8LCDAJ3qZT+EiefJpRr1DLJoBLO4x84oMVud9C63uNkW5muAgy0HYOTZHJQo9vRimR2vhkAYc6A==
+metro-cache-key@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.75.1.tgz#c27fde127e2278b544d7db7196f6d33d8dcde004"
+  integrity sha512-SUC+vBhsE/I9lA9l42wsGsFj3bK3h11GLiePaIZueyh5qD16Y5X+9iC+vmgZT3rAsqFyF04Ty5RBxh+sErJmsg==
 
-metro-cache@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.75.0.tgz#020128665705b9b86b66080d557b9b189314256a"
-  integrity sha512-mIOXU5N4a1WjaF1jxx3Ul6B7ZpoYgz4OOllaE5fSD71oNVJOj0/Pbb2cPlwRanu/x4KovFrm5LpCbE1hDEBo0g==
+metro-cache@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.75.1.tgz#5f664127f9571816521c32179e3ec3583c4c4273"
+  integrity sha512-uWfQRtEdUYIsKcfwGHU//eTKdxUQCyjjq0GCsZwMOvfipT5bihpam1VPEFk3W+UEFB+qQ3cZp2DvUX1WoEi+Mw==
   dependencies:
-    metro-core "0.75.0"
+    metro-core "0.75.1"
     rimraf "^3.0.2"
 
-metro-config@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.75.0.tgz#52a79db2d15fdd46fa1c18ac96f68b3109daccfc"
-  integrity sha512-dMAjOt9zbtpmfcz4HIXIIrjiPzcBQVMlyBbmxsgCgMuTanM2H1RtI85cJWjCC9axTtiSePuBXKaF4UZWWVNJJw==
+metro-config@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.75.1.tgz#1fbfdb491eb211327ccfecff026ca499503f4bcb"
+  integrity sha512-zF1DLIxjS/LpJJtr7PhrMS+d4sPQsoMVgFFHv270sNOHNbltLa1Em8Epk/JGOozBzX4ijQOsL4PkBVyJN8WsEg==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.75.0"
-    metro-cache "0.75.0"
-    metro-core "0.75.0"
-    metro-runtime "0.75.0"
+    metro "0.75.1"
+    metro-cache "0.75.1"
+    metro-core "0.75.1"
+    metro-runtime "0.75.1"
 
-metro-core@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.75.0.tgz#ad4c7414ccb702a9b809163f7a817070927952ca"
-  integrity sha512-qLH+uc0C60w7MCScTr8zRgs+9NPSPKY92n2/HELC10WppKHhW6EdqP8OAcpPtOEMwZyo38o4SR7obXsYAdn6wA==
+metro-core@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.75.1.tgz#6ed853160a28a9815d4220081d0bf9e5157d469a"
+  integrity sha512-TGTBqqM3lZ4IA83HTNOsWXZ+sr/4Gi2RgTO9svJ0O1rYNc4UdDpe99EurYmbU709RJ8C7+zl3t8kHMB+1RNyuw==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.75.0"
+    metro-resolver "0.75.1"
 
-metro-file-map@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.75.0.tgz#eb2e224898aedc7ae1741a4317b53ad97f870cd7"
-  integrity sha512-W5NG/CYB9NMg4hUZwRFfHDV+szQPj0mfayEAFarZA+voVGBKjfMLclYCunqu2LfhfurBZnyE/ai0Xzd4Vcp1fg==
+metro-file-map@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.75.1.tgz#43d7c84168a7f8db2a7e7fd75159191c7f7e1396"
+  integrity sha512-fwXHBVe0ABihNvyvhFRU/tGz1N/yVkyrd1X9kOB6IP4/XQllt8GlxUV0aHvjYPYgxCjk+PzrVAbT65WBYYfEMA==
   dependencies:
     abort-controller "^3.0.0"
     anymatch "^3.0.3"
@@ -8727,44 +8734,45 @@ metro-file-map@0.75.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.75.0.tgz#936772de7349d12852b82ac707b0ef8bd8088c17"
-  integrity sha512-/r/SHK/Kw2XIfAct3fvfxKm0lP/PQ9x9GTmdRMnJ6W+j5+NCYPTHl+SxLUFga8Z82fJuLOR/V1SPbXCEH7NGhg==
+metro-hermes-compiler@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.75.1.tgz#5c5a6f71f1a06599a77f973986dbaea06f205f4a"
+  integrity sha512-5JYhUrKaEfQnU3N/RFmne/cM8sl98Y8EzJEiBOKZkhumtx7381ajK+M1jO/pAgpHlsgGNQn3/0snh+7xsveyRQ==
 
-metro-inspector-proxy@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.75.0.tgz#93e5c4aaf99ce89008c381f9fa4db961fa52f3f8"
-  integrity sha512-XzBORb3NRsw1Cv+QeKJyPsScAfXzZXQ/NNe28o0ntFwWVXBVgUCO2z9UAJcmFJym6bVX7k1NvBtCYLd1wKK8VQ==
+metro-inspector-proxy@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.75.1.tgz#0e54802c8e4786341ec62cfb5c1e2efc00487e79"
+  integrity sha512-OzrP5eNZnO9/bu3RrWObC/PMCu0xm1svTolt2vgQjatt+Rf0JU6P8kqoyFB9F6WsV/9oieiHhtHecfXNb1PR+g==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
+    node-fetch "^2.2.0"
     ws "^7.5.1"
     yargs "^17.5.1"
 
-metro-memory-fs@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.75.0.tgz#9fe3fdbc629a3e4ed5f8ed74b87619be67eec2c3"
-  integrity sha512-7OsnZLIwwBGs+u5g89ichEiNP++4Ly56UiM0xXKrj9orYo6lb1fUIxf9XRUxdmeL5Egv2QRSNtpb4Hn2rp4hJA==
+metro-memory-fs@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.75.1.tgz#4f19ad6ed45f28af900d4684a02ea54c024c62ab"
+  integrity sha512-cxyrdPfc/eHWRo4sTCAsLDjS+CztW7zRodtjBeMpm+m+VZOk1ntB/0ZSM7mPCOzVDUAZjUupuXte18TGo4/EXw==
 
-metro-minify-terser@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.75.0.tgz#98c7e3d5f8d24d8501aad87bb76e72134d68ba06"
-  integrity sha512-mcIL0k32xlIswucI9wwlIApvozgF87aNFL+3WGsLMArhjXTfG+NBGiV3WluZcgOUjIM9I96b8yvu/gcZAy19Gw==
+metro-minify-terser@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.75.1.tgz#0a940cac616930b6449838040016d42b2136893b"
+  integrity sha512-SLJpthrK5cowVgxckb0f+aEvFQIwGoJxHq8BE+QCZgfRfkuu5Yvf+lt0koWPFXG6r8ztU2eZE4j/QE429BGq5A==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.75.0.tgz#8f3cf6934879ead53f251f16f8cc0c17f7a0acba"
-  integrity sha512-Fg3nN+ZbhftwKLlH6kdYyXb+sonuxdjybWfTKwrtovlJY0jiCyz+al/q1QUIRz8VrJIHKPy4LHSe1WjBVRaZBg==
+metro-minify-uglify@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.75.1.tgz#311665b15c1a49f54b0a1bb9df3d2b0bbbcf5c23"
+  integrity sha512-964Ft6eyXp+LVXJHn4B32mU3TyG8r8C4c3k1RlRQSuHqtTH//C/8J44c3ruyvAZnT2CuYMRl5xqmJge/gZODug==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.75.0.tgz#a75bafb25f32232f6e1925f76942e1776a719bd5"
-  integrity sha512-QJOoSdkedB+TrKmHiSxMuEkyynmtNzsjRNW9uugaW3/zCMAQW438tvy7k44meLMDohfSAtcr6fclZVxeYq1meQ==
+metro-react-native-babel-preset@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.75.1.tgz#370bb3bba3ca83b3be1d8b0ab628271c864491cd"
+  integrity sha512-a4Se/koIVsH+wmfWsSOiRpFLBSICJcbd6o1wv37QRoFSnH7mYXDOfYxNBZYX46PwN1QwmgR49Iwsef79JOaJMg==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -8803,66 +8811,68 @@ metro-react-native-babel-preset@0.75.0:
     "@babel/plugin-transform-typescript" "^7.5.0"
     "@babel/plugin-transform-unicode-regex" "^7.0.0"
     "@babel/template" "^7.0.0"
+    babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.75.0.tgz#9df44c32e1e2335fbd1a54598fba6621ba437806"
-  integrity sha512-ZcewTj4cgPjx8qbTlc5sGYrW+zib7K1dbVPysdC5IwjJ3f8WBk9KWF+G2qplAI8d2/kWtnu5LBoPKeA3xCEjCQ==
+metro-react-native-babel-transformer@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.75.1.tgz#d06861d519d5188cd9cffc2cdfff4ba54d891ce1"
+  integrity sha512-43lCqiEpe8XreDEJfwoYjQSR+C36q8sbhz/u/M9GJWtec7yWdlIa6IU7SQObmsc6X0S0t+rDFFt5Lspz9c4pbg==
   dependencies:
     "@babel/core" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.75.0"
-    metro-react-native-babel-preset "0.75.0"
-    metro-source-map "0.75.0"
+    metro-babel-transformer "0.75.1"
+    metro-react-native-babel-preset "0.75.1"
+    metro-source-map "0.75.1"
     nullthrows "^1.1.1"
 
-metro-resolver@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.75.0.tgz#d074390bcd60019ba1edf23d3c19e5a4c6837e63"
-  integrity sha512-stGJDh77YCktf070Lx2xbpVRMDIB3P2NRRbzElHMsWbWmccYgo8hIjvrXoo981qXAmL4vRAB9zDuBdqAa/dbbw==
+metro-resolver@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.75.1.tgz#f54f410774f9b58ea766c65c3096ef3a399185e8"
+  integrity sha512-zKhRcfTi5G9jcVFh2VPH1WFuabTl0WaZq5WJNK24Y3xVBTOfgr4MIN0iSz1XLwffPCqj3J8D8w6BPteID3DEoQ==
   dependencies:
     absolute-path "^0.0.0"
+    invariant "^2.2.4"
 
-metro-runtime@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.75.0.tgz#82b922b4522f6bece9cf17cba77d858cd8593a4b"
-  integrity sha512-Jue4w2/Z7hp8bnJXm/VSNQfY0yqIuDVK5F38o/cqMxqZt236+v+pQ2+XH/1SgeL4fFAS0QLcszs7pMhqzj6H5w==
+metro-runtime@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.75.1.tgz#e34936400ef4af28aa4e5f43c7fd7b6fbad68c1b"
+  integrity sha512-AbmDCLPV2efz/LD3+k7bHTchUYmwEzB1L99UJYLYQksLlV1aoW+ri9hurXc/0mc55Jw6h4uKKe1nlAKJYZLJEg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-source-map@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.75.0.tgz#bbfa5cf70ff6c4faf3d4e236d6a516445994acde"
-  integrity sha512-8X30Q2mawCW/SbOgYX8vAtZg8IxUkJRNv/5d/RB3eIpvkwJTvipI+EKjuJgEbDKsFcMrQ5Ko+6XpNIqvqmGLDw==
+metro-source-map@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.75.1.tgz#7aee48d5a9505e01d2de34db529264dc15bb92fe"
+  integrity sha512-QuXoRD0Y0TkSPadhBy6Wf0UKAL4kSJueLPngoe6OKaD0giZjjjgsGymUgmjXaMeM7az9s3MvoyCbAXslKh95KA==
   dependencies:
     "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.75.0"
+    metro-symbolicate "0.75.1"
     nullthrows "^1.1.1"
-    ob1 "0.75.0"
+    ob1 "0.75.1"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.75.0.tgz#85c5ea099ee2e98f71335f7dfd4f62c2ba532500"
-  integrity sha512-8nfB0DltNXQCLLWwNmveum9wAdv3wZjdQjiCIFSjYEfO6LTmQ52DjSO/Q9Obbs7SZoIymONKmM7PPNpTpr69OA==
+metro-symbolicate@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.75.1.tgz#29fd71175d1607187ee2522c3702e4cc27050279"
+  integrity sha512-uMpLWXQgkAG2GAVWqKAN3GUjOBNNZgUewrBg+GZe69xZMe8vbFf/Y62MQRuhw5UTcCGbt4eKckPoRDt4vDLceA==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.75.0"
+    metro-source-map "0.75.1"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.75.0.tgz#5089584586425cfca3647507ba9daea537b1434a"
-  integrity sha512-YHhuF0Ld4SJTQxXdvWcdhIlxo7q7UPCymwFK8fnO3vjeVOYH00GtIghnsdlkUWlzTphi2rZpSL6kX8QqHevYEw==
+metro-transform-plugins@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.75.1.tgz#5e4b338dbbf80a13c0d22e2bed33211c7ea2560a"
+  integrity sha512-XiurTRKY570ZEbEr7kY4vyX11uYXRKmUTVCVQ7+j4SHA6p6RS23d/2cHMUgwtzch6K9vk1zPT5GK3/eYRglWYw==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
@@ -8870,29 +8880,29 @@ metro-transform-plugins@0.75.0:
     "@babel/traverse" "^7.20.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.75.0.tgz#4ec0ef083ee7c178144a92ad04ddb6cf7f8418e0"
-  integrity sha512-9AO+Ty4Uaw4oqxuDj0nHyi6u7YQcliEyM/Vvnca+HXYMaxhTkF/YOkroN+abFLmwRU/5Iel4JYPbFXBGAKnfzA==
+metro-transform-worker@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.75.1.tgz#72cad162d6421e1365d5872685ca9112b922d326"
+  integrity sha512-at96L4h3/OIUIB1MRIm/jvYPk2J27tRZNEjzSnbTgTzR0329RVHySmblJmgBvWj7F8uqOAUepjuVGkRM50USYg==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.75.0"
-    metro-babel-transformer "0.75.0"
-    metro-cache "0.75.0"
-    metro-cache-key "0.75.0"
-    metro-hermes-compiler "0.75.0"
-    metro-source-map "0.75.0"
-    metro-transform-plugins "0.75.0"
+    metro "0.75.1"
+    metro-babel-transformer "0.75.1"
+    metro-cache "0.75.1"
+    metro-cache-key "0.75.1"
+    metro-hermes-compiler "0.75.1"
+    metro-source-map "0.75.1"
+    metro-transform-plugins "0.75.1"
     nullthrows "^1.1.1"
 
-metro@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.75.0.tgz#1fa020ca70e2471d60ab5011f077d3996f106cc6"
-  integrity sha512-9hO1ieJEz5VZOBEoaDsgztA2veDCnjMUJDARb1oV09VWU4N34nuxReFIfqhEvU165c/6gUJD90C7BfYFuvQkGQ==
+metro@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.75.1.tgz#795b6466a5c4a65dd6816d1a2d7cefa22c25d453"
+  integrity sha512-0Hlm3t99bIVie4bWqAZZTKqAFj1OgzAaaYZ0VqCyfeFfo0dyd86Ipaz8XlKSwpMPLiG/3LbG+pZJ5Z9ERV1nIw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.20.0"
@@ -8916,23 +8926,23 @@ metro@0.75.0:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.75.0"
-    metro-cache "0.75.0"
-    metro-cache-key "0.75.0"
-    metro-config "0.75.0"
-    metro-core "0.75.0"
-    metro-file-map "0.75.0"
-    metro-hermes-compiler "0.75.0"
-    metro-inspector-proxy "0.75.0"
-    metro-minify-terser "0.75.0"
-    metro-minify-uglify "0.75.0"
-    metro-react-native-babel-preset "0.75.0"
-    metro-resolver "0.75.0"
-    metro-runtime "0.75.0"
-    metro-source-map "0.75.0"
-    metro-symbolicate "0.75.0"
-    metro-transform-plugins "0.75.0"
-    metro-transform-worker "0.75.0"
+    metro-babel-transformer "0.75.1"
+    metro-cache "0.75.1"
+    metro-cache-key "0.75.1"
+    metro-config "0.75.1"
+    metro-core "0.75.1"
+    metro-file-map "0.75.1"
+    metro-hermes-compiler "0.75.1"
+    metro-inspector-proxy "0.75.1"
+    metro-minify-terser "0.75.1"
+    metro-minify-uglify "0.75.1"
+    metro-react-native-babel-preset "0.75.1"
+    metro-resolver "0.75.1"
+    metro-runtime "0.75.1"
+    metro-source-map "0.75.1"
+    metro-symbolicate "0.75.1"
+    metro-transform-plugins "0.75.1"
+    metro-transform-worker "0.75.1"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -9586,10 +9596,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.75.0:
-  version "0.75.0"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.75.0.tgz#637f1150143979613c94a7149ff8bd7aa2b90bd7"
-  integrity sha512-sV0IMqL9deffQV608jWwenujpLzd+YqhjWhg0EsErkrHH0mBpZ5k9Sb8bOkDMwMPU/y6ymvfGpJB3TE7Nqzmqg==
+ob1@0.75.1:
+  version "0.75.1"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.75.1.tgz#ee1ee0ef0ebc14548ab6b945399299e4062d049a"
+  integrity sha512-JEUNCFtUL4uhgg9++Q8jB9EqQBjFHiAZa/cb9fBWUHmalWH/VMI8zWt7ty0z/Z7IsrV0EK+RO1O9lLA7/gIuGA==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Summary:
---------
Updating the versions of Metro in the `cli-plugin-metro` to incorporate the new Metro Release v0.75.1. 
https://github.com/facebook/metro/releases/tag/v0.75.1

Per the release notes shared below, this is not a breaking change for RN CLI and only patch release.

**Metro release notes:** 

* **[Feature]**: `metro-inspector-proxy`: Add a human-readable reference to each inspector entries/pages.(https://github.com/facebook/metro/pull/921 by @byCedric)
* **[Feature]**: `metro-inspector-proxy`: Report errors in the console. (https://github.com/facebook/metro/commit/da8b41b279e2618786901daa3d6f25f20e9202db)
* **[Fix]**: Race condition where a very recently modified file might have missing metadata.(https://github.com/facebook/metro/commit/baf28ab0ee3e2fd965691e57691c5d87b01897b2)
* **[Fix]**: Source maps may have invalid entries when using Terser minification. (https://github.com/facebook/metro/pull/928)
* **[Fix]**: `metro-inspector-proxy`: Fetch source maps from Metro. (https://github.com/facebook/metro/commit/6690b393cc1812af02f8eb20853504f0a6188a83)
* **[Fix]**: Mitigate potential source map mismatches with concurrent transformations due to [terser#1341](https://github.com/terser/terser/issues/1341). (https://github.com/facebook/metro/pull/929)

> NOTE: Experimental features are not covered by semver and can change at any time.

* **[Experimental]**: Add initial_build annotation to Resolving and Transforming Dependencies (https://github.com/facebook/metro/commit/fc83b521b273f7a29f9f38285d973148bd43c0e3)
* **[Experimental]**: Implement support for Package Exports (enabled via `resolver.unstable_enablePackageExports`) (https://github.com/facebook/metro/commit/4d7ab38ba9f85e7a8d4e2a9f2b26f48c1c070186, https://github.com/facebook/metro/commit/38b96f872a92d0f0650c9af0250c8dc5599a6e62, https://github.com/facebook/metro/commit/216d3e234c14a7c16b9561b2682e60d2e2936114, https://github.com/facebook/metro/commit/6e6f36fd982b9226b7daafd1c942c7be32f9af40)
* **[Experimental]**: Implement support for symlinks (enabled via `resolver.unstable_enableSymlinks`) (https://github.com/facebook/metro/pull/925, https://github.com/facebook/metro/pull/926, etc.)

**Full Changelog:** https://github.com/facebook/metro/compare/v0.75.0...v0.75.1

**Reminder:** When React Native updates the CLI to a version that depends on metro 0.75.1, it must also update metro-runtime etc to 0.75.1 in the same commit.

Test Plan:
----------

Updated dependencies with yarn.

```
yarn upgrade metro-memory-fs@0.75.1
cd packages/cli-plugin-metro
metro_version=0.75.1; yarn upgrade metro@$metro_version metro-config@$metro_version  metro-core@$metro_version metro-react-native-babel-transformer@$metro_version metro-resolver@$metro_version metro-runtime@$metro_version
```