### PR TITLE
Add `unstable_reactLegacyComponent` to `cli-platform-android`

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -72,7 +72,7 @@ type AndroidProjectParams = {
   manifestPath?: string;
   packageName?: string;
   dependencyConfiguration?: string;
-  unstable_reactLegacyComponent?: string[] | null;
+  unstable_reactLegacyComponentNames?: string[] | null;
 };
 ```
 
@@ -101,7 +101,7 @@ See [`dependency.platforms.android.packageName`](dependencies.md#platformsandroi
 
 See [`dependency.platforms.android.configuration`](dependencies.md#platformsandroiddependencyconfiguration)
 
-#### project.android.unstable_reactLegacyComponent
+#### project.android.unstable_reactLegacyComponentNames
 
 > Note: Only applicable when new architecture is turned on.
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -72,6 +72,7 @@ type AndroidProjectParams = {
   manifestPath?: string;
   packageName?: string;
   dependencyConfiguration?: string;
+  unstable_reactLegacyComponent?: string[] | null;
 };
 ```
 
@@ -99,6 +100,18 @@ See [`dependency.platforms.android.packageName`](dependencies.md#platformsandroi
 #### project.android.dependencyConfiguration
 
 See [`dependency.platforms.android.configuration`](dependencies.md#platformsandroiddependencyconfiguration)
+
+#### project.android.unstable_reactLegacyComponent
+
+> Note: Only applicable when new architecture is turned on.
+
+Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
+hence the `unstable_` prefix.
+
+An array with a list of Legacy Component Name that you want to be registered with the Fabric Interop Layer.
+This will allow you to use on the New Architecture, libreries that are legacy and haven't been migrated yet.
+
+The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
 
 ### platforms
 

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -160,7 +160,7 @@ export const projectConfig = t
             manifestPath: t.string(),
             packageName: t.string(),
             dependencyConfiguration: t.string(),
-            unstable_reactLegacyComponent: t
+            unstable_reactLegacyComponentNames: t
               .array()
               .items(t.string())
               .default([]),

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -160,6 +160,10 @@ export const projectConfig = t
             manifestPath: t.string(),
             packageName: t.string(),
             dependencyConfiguration: t.string(),
+            unstable_reactLegacyComponent: t
+              .array()
+              .items(t.string())
+              .default([]),
           })
           .default({}),
       })

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -94,6 +94,8 @@ def rncliCppTemplate = """/**
 namespace facebook {
 namespace react {
 
+{{ rncliReactLegacyComponentNames }}
+
 std::shared_ptr<TurboModule> rncli_ModuleProvider(const std::string moduleName, const JavaTurboModule::InitParams &params) {
 {{ rncliCppModuleProviders }}
   return nullptr;
@@ -101,6 +103,7 @@ std::shared_ptr<TurboModule> rncli_ModuleProvider(const std::string moduleName, 
 
 void rncli_registerProviders(std::shared_ptr<ComponentDescriptorProviderRegistry const> providerRegistry) {
 {{ rncliCppComponentDescriptors }}
+{{ rncliReactLegacyComponentDescriptors }}
   return;
 }
 
@@ -138,6 +141,7 @@ class ReactNativeModules {
   private String packageName
   private File root
   private ArrayList<HashMap<String, String>> reactNativeModules
+  private ArrayList<String> unstable_reactLegacyComponent
   private HashMap<String, ArrayList> reactNativeModulesBuildVariants
 
   private static String LOG_PREFIX = ":ReactNative:"
@@ -146,10 +150,11 @@ class ReactNativeModules {
     this.logger = logger
     this.root = root
 
-    def (nativeModules, reactNativeModulesBuildVariants, packageName) = this.getReactNativeConfig()
+    def (nativeModules, reactNativeModulesBuildVariants, androidProject) = this.getReactNativeConfig()
     this.reactNativeModules = nativeModules
     this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
-    this.packageName = packageName
+    this.packageName = androidProject["packageName"]
+    this.unstable_reactLegacyComponent = androidProject["unstable_reactLegacyComponent"]
   }
 
   /**
@@ -287,9 +292,12 @@ class ReactNativeModules {
 
   void generateRncliCpp(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
     ArrayList<HashMap<String, String>> packages = this.reactNativeModules
+    ArrayList<String> unstable_reactLegacyComponent = this.unstable_reactLegacyComponent
     String rncliCppIncludes = ""
     String rncliCppModuleProviders = ""
     String rncliCppComponentDescriptors = ""
+    String rncliReactLegacyComponentDescriptors = ""
+    String rncliReactLegacyComponentNames = ""
     String codegenComponentDescriptorsHeaderFile = "ComponentDescriptors.h"
     String codegenReactComponentsDir = "react/renderer/components"
 
@@ -321,10 +329,22 @@ class ReactNativeModules {
       }.join("\n")
     }
 
+    rncliReactLegacyComponentDescriptors = unstable_reactLegacyComponent.collect {
+      "  providerRegistry->add(concreteComponentDescriptorProvider<UnstableLegacyViewManagerInteropComponentDescriptor<${it}>>());"
+    }.join("\n")
+    rncliReactLegacyComponentNames = unstable_reactLegacyComponent.collect {
+      "extern const char ${it}[] = \"${it}\";"
+    }.join("\n")
+    if (unstable_reactLegacyComponent && unstable_reactLegacyComponent.size() > 0) {
+      rncliCppIncludes += "\n#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h>"
+    }
+
     String generatedFileContents = generatedFileContentsTemplate
       .replace("{{ rncliCppIncludes }}", rncliCppIncludes)
       .replace("{{ rncliCppModuleProviders }}", rncliCppModuleProviders)
       .replace("{{ rncliCppComponentDescriptors }}", rncliCppComponentDescriptors)
+      .replace("{{ rncliReactLegacyComponentDescriptors }}", rncliReactLegacyComponentDescriptors)
+      .replace("{{ rncliReactLegacyComponentNames }}", rncliReactLegacyComponentNames)
 
     outputDir.mkdirs()
     final FileTreeBuilder treeBuilder = new FileTreeBuilder(outputDir)
@@ -452,7 +472,7 @@ class ReactNativeModules {
       }
     }
 
-    return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]["packageName"]];
+    return [reactNativeModules, reactNativeModulesBuildVariants, json["project"]["android"]];
   }
 }
 

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -141,7 +141,7 @@ class ReactNativeModules {
   private String packageName
   private File root
   private ArrayList<HashMap<String, String>> reactNativeModules
-  private ArrayList<String> unstable_reactLegacyComponent
+  private ArrayList<String> unstable_reactLegacyComponentNames
   private HashMap<String, ArrayList> reactNativeModulesBuildVariants
 
   private static String LOG_PREFIX = ":ReactNative:"
@@ -154,7 +154,7 @@ class ReactNativeModules {
     this.reactNativeModules = nativeModules
     this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
     this.packageName = androidProject["packageName"]
-    this.unstable_reactLegacyComponent = androidProject["unstable_reactLegacyComponent"]
+    this.unstable_reactLegacyComponentNames = androidProject["unstable_reactLegacyComponentNames"]
   }
 
   /**
@@ -292,7 +292,7 @@ class ReactNativeModules {
 
   void generateRncliCpp(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
     ArrayList<HashMap<String, String>> packages = this.reactNativeModules
-    ArrayList<String> unstable_reactLegacyComponent = this.unstable_reactLegacyComponent
+    ArrayList<String> unstable_reactLegacyComponentNames = this.unstable_reactLegacyComponentNames
     String rncliCppIncludes = ""
     String rncliCppModuleProviders = ""
     String rncliCppComponentDescriptors = ""
@@ -329,13 +329,13 @@ class ReactNativeModules {
       }.join("\n")
     }
 
-    rncliReactLegacyComponentDescriptors = unstable_reactLegacyComponent.collect {
+    rncliReactLegacyComponentDescriptors = unstable_reactLegacyComponentNames.collect {
       "  providerRegistry->add(concreteComponentDescriptorProvider<UnstableLegacyViewManagerInteropComponentDescriptor<${it}>>());"
     }.join("\n")
-    rncliReactLegacyComponentNames = unstable_reactLegacyComponent.collect {
+    rncliReactLegacyComponentNames = unstable_reactLegacyComponentNames.collect {
       "extern const char ${it}[] = \"${it}\";"
     }.join("\n")
-    if (unstable_reactLegacyComponent && unstable_reactLegacyComponent.size() > 0) {
+    if (unstable_reactLegacyComponentNames && unstable_reactLegacyComponentNames.size() > 0) {
       rncliCppIncludes += "\n#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h>"
     }
 

--- a/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -6,6 +6,7 @@ Object {
   "dependencyConfiguration": undefined,
   "packageName": "com.some.example",
   "sourceDir": "/flat/android",
+  "unstable_reactLegacyComponent": undefined,
 }
 `;
 
@@ -15,6 +16,7 @@ Object {
   "dependencyConfiguration": undefined,
   "packageName": "com.some.example",
   "sourceDir": "/multiple/android",
+  "unstable_reactLegacyComponent": undefined,
 }
 `;
 
@@ -24,5 +26,6 @@ Object {
   "dependencyConfiguration": undefined,
   "packageName": "com.some.example",
   "sourceDir": "/nested/android",
+  "unstable_reactLegacyComponent": undefined,
 }
 `;

--- a/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -6,7 +6,7 @@ Object {
   "dependencyConfiguration": undefined,
   "packageName": "com.some.example",
   "sourceDir": "/flat/android",
-  "unstable_reactLegacyComponent": undefined,
+  "unstable_reactLegacyComponentNames": undefined,
 }
 `;
 
@@ -16,7 +16,7 @@ Object {
   "dependencyConfiguration": undefined,
   "packageName": "com.some.example",
   "sourceDir": "/multiple/android",
-  "unstable_reactLegacyComponent": undefined,
+  "unstable_reactLegacyComponentNames": undefined,
 }
 `;
 
@@ -26,6 +26,6 @@ Object {
   "dependencyConfiguration": undefined,
   "packageName": "com.some.example",
   "sourceDir": "/nested/android",
-  "unstable_reactLegacyComponent": undefined,
+  "unstable_reactLegacyComponentNames": undefined,
 }
 `;

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -63,6 +63,7 @@ export function projectConfig(
     appName,
     packageName,
     dependencyConfiguration: userConfig.dependencyConfiguration,
+    unstable_reactLegacyComponent: userConfig.unstable_reactLegacyComponent,
   };
 }
 

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -63,7 +63,8 @@ export function projectConfig(
     appName,
     packageName,
     dependencyConfiguration: userConfig.dependencyConfiguration,
-    unstable_reactLegacyComponent: userConfig.unstable_reactLegacyComponent,
+    unstable_reactLegacyComponentNames:
+      userConfig.unstable_reactLegacyComponentNames,
   };
 }
 

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -3,7 +3,7 @@ export interface AndroidProjectConfig {
   appName: string;
   packageName: string;
   dependencyConfiguration?: string;
-  unstable_reactLegacyComponent?: string[] | null;
+  unstable_reactLegacyComponentNames?: string[] | null;
 }
 
 export type AndroidProjectParams = {
@@ -12,7 +12,7 @@ export type AndroidProjectParams = {
   manifestPath?: string;
   packageName?: string;
   dependencyConfiguration?: string;
-  unstable_reactLegacyComponent?: string[] | null;
+  unstable_reactLegacyComponentNames?: string[] | null;
 };
 
 export type AndroidDependencyConfig = {

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -3,6 +3,7 @@ export interface AndroidProjectConfig {
   appName: string;
   packageName: string;
   dependencyConfiguration?: string;
+  unstable_reactLegacyComponent?: string[] | null;
 }
 
 export type AndroidProjectParams = {
@@ -11,6 +12,7 @@ export type AndroidProjectParams = {
   manifestPath?: string;
   packageName?: string;
   dependencyConfiguration?: string;
+  unstable_reactLegacyComponent?: string[] | null;
 };
 
 export type AndroidDependencyConfig = {


### PR DESCRIPTION
Summary:
---------

This adds the `unstable_reactLegacyComponent` config key inside the `android.project.` object, so that users can use the `react-native.config.js` file to register a list of component they want to use on the New Architecture that are not yet migrated to support Fabric.

I've added the `unstable_` prefix as this is most likely going to change, but we'd like to have it out so soon-ish we can ask users to try it and report back if there are blockers.

I've added docs for this field:

> An array with a list of Legacy Component Name that you want to be registered with the Fabric Interop Layer. This will allow you to use on the New Architecture, libreries that are legacy and haven't been migrated yet.
> The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).

Test Plan:
----------

I've tested this on the latest nightly and I was able to build correctly.