### PR TITLE
doctor : Modifying the version ranges to keep up to date with RN 0.72

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/androidNDK.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/androidNDK.test.ts
@@ -33,7 +33,7 @@ describe('androidNDK', () => {
     // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
-      'Android NDK': '18',
+      'Android NDK': '22',
     };
     const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(true);
@@ -43,7 +43,7 @@ describe('androidNDK', () => {
     // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore
     environmentInfo.SDKs['Android SDK'] = {
-      'Android NDK': '19',
+      'Android NDK': '23',
     };
     const diagnostics = await androidNDK.getDiagnostics(environmentInfo);
     expect(diagnostics.needsToBeFixed).toBe(false);

--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -6,8 +6,8 @@ export default {
   RUBY: '>= 2.7.6',
   JAVA: '>= 11',
   // Android
-  ANDROID_SDK: '>= 31.x',
-  ANDROID_NDK: '>= 19.x',
+  ANDROID_SDK: '>= 33.x',
+  ANDROID_NDK: '>= 23.x',
   // iOS
   XCODE: '>= 12.x',
   COCOAPODS: '>= 1.10.0',


### PR DESCRIPTION
Summary:
---------

React Native is increasing the minimum Android_SDK requirement from `Android SDK Platform 31` to `Android SDK Platform 33` for 0.72 onwards.

https://reactnative.dev/docs/next/environment-setup#installing-dependencies

`ANDROID_SDK` from [versionRanges](https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/src/tools/versionRanges.ts) file is not used anymore. For the `ANDROID_SDK` health check we're getting required SDK version from `android/build.gradle` file via `getBuildToolsVersion` helper function. So it depends what is shipped with core but updating the [versionRanges](https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/src/tools/versionRanges.ts) for posterity. Similarly for the `ANDROID_NDK`

https://github.com/facebook/react-native/blob/574653319a1208ee21993da9e2576fc2eb7bf9e9/template/android/build.gradle#L5

Resolves https://github.com/react-native-community/cli/issues/1855 & https://github.com/react-native-community/cli/issues/1856

Test Plan:
----------

No visible change, keeping the [versionRanges](https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/src/tools/versionRanges.ts) for `ANDROID_SDK` & `ANDROID_NDK` up-to-date in order to avoid confusion in future.

