### PR TITLE
Add the `unstable_reactLegacyComponentNames` to iOS project config

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -64,6 +64,7 @@ The following settings are available on iOS and Android:
 ```ts
 type IOSProjectParams = {
   sourceDir?: string;
+  unstable_reactLegacyComponentNames?: string[] | null;
 };
 
 type AndroidProjectParams = {
@@ -80,6 +81,18 @@ type AndroidProjectParams = {
 
 A path to a directory where iOS source files are located. In most cases, you shouldn't need to set it, unless you have
 multiple `Podfile` files in your project.
+
+#### project.ios.unstable_reactLegacyComponentNames
+
+> Note: Only applicable when new architecture is turned on.
+
+Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
+hence the `unstable_` prefix.
+
+An array with a list of Legacy Component Name that you want to be registered with the Fabric Interop Layer.
+This will allow you to use libraries that haven't been migrated yet on the New Architecture.
+
+The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
 
 #### project.android.appName
 
@@ -109,7 +122,7 @@ Please note that this is part of the **Unstable Fabric Interop Layer**, and migh
 hence the `unstable_` prefix.
 
 An array with a list of Legacy Component Name that you want to be registered with the Fabric Interop Layer.
-This will allow you to use on the New Architecture, libreries that are legacy and haven't been migrated yet.
+This will allow you to use libraries that haven't been migrated yet on the New Architecture.
 
 The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
 

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -150,6 +150,10 @@ export const projectConfig = t
           // IOSProjectParams
           .object({
             sourceDir: t.string(),
+            unstable_reactLegacyComponentNames: t
+              .array()
+              .items(t.string())
+              .default([]),
           })
           .default({}),
         android: t


### PR DESCRIPTION
Summary:
---------
This PR is the equivalent of [this other](https://github.com/react-native-community/cli/pull/1849) but for iOS.
For iOS, the CLI doesn't have to generate anything: we just need to have the same field that we have for Android.


Test Plan:
----------
CI must be green as this is just a configuration addition with no attached behavior, we are happy if validation passes.