### PR TITLE
feat: Set "react-native" condition when using Package Exports

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -44,6 +44,7 @@ export interface MetroConfig {
     ) => any;
     resolverMainFields: string[];
     platforms: string[];
+    unstable_conditionNames: string[];
   };
   serializer: {
     getModulesRunBeforeMainModule: () => string[];
@@ -91,6 +92,7 @@ export const getDefaultConfig = (ctx: ConfigLoadingContext): MetroConfig => {
             ),
       resolverMainFields: ['react-native', 'browser', 'main'],
       platforms: [...Object.keys(ctx.platforms), 'native'],
+      unstable_conditionNames: ['import', 'require', 'react-native'],
     },
     serializer: {
       // We can include multiple copies of InitializeCore here because metro will


### PR DESCRIPTION
Summary:
---------

Provide a default value for the [`resolver.unstable_conditionNames`](https://facebook.github.io/metro/docs/configuration#unstable_conditionnames-experimental) option when running Metro via React Native CLI (applicable to Metro >0.75.1, merged in https://github.com/react-native-community/cli/pull/1846), **enabling the `"react-native"` conditional export** (see [RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0534-metro-package-exports-support.md#conditional-exports-user-conditions-and-configuration)).

Note: This does not set `unstable_enablePackageExports` by default, as we want this to be an opt-in by the user (which will be documented in an upcoming React Native blog post). However when users have enabled Package Exports, we want the default conditions to be set appropriately.

Screenshot: The intended Metro docs wording for this config merge. This is intentionally equivalent to today's [`resolverMainFields`](https://facebook.github.io/metro/docs/configuration/#resolvermainfields) behaviour.

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/2547783/223488782-6db4cbfd-917f-422f-a6fc-98fcd8ac7c34.png">


Test Plan:
----------

Manual review