### PR TITLE
feat: add deeplinks to our documentation

### DIFF
--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -4,6 +4,7 @@ exports[`shows up current config without unnecessary output 1`] = `
 {
   "root": "<<REPLACED_ROOT>>/TestProject",
   "reactNativePath": "<<REPLACED_ROOT>>/TestProject/node_modules/react-native",
+  "reactNativeVersion": "0.71",
   "dependencies": {},
   "commands": [
     {

--- a/babel.config.js
+++ b/babel.config.js
@@ -18,6 +18,7 @@ module.exports = {
   ],
   plugins: [
     [require.resolve('@babel/plugin-transform-modules-commonjs'), {lazy: true}],
+    '@babel/plugin-proposal-export-namespace-from',
   ],
   sourceMaps: true,
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/plugin-transform-modules-commonjs": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.0.0",

--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -25,6 +25,7 @@ Object {
   "platforms": Object {},
   "project": Object {},
   "reactNativePath": "<<REPLACED>>",
+  "reactNativeVersion": "unknown",
   "root": "<<REPLACED>>",
 }
 `;

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -162,6 +162,7 @@ test('should merge project configuration with default values', () => {
 test('should load commands from "react-native-foo" and "react-native-bar" packages', () => {
   DIR = getTempDirectory('config_test_packages');
   writeFiles(DIR, {
+    'react-native.config.js': 'module.exports = { reactNativePath: "." }',
     'node_modules/react-native-foo/package.json': '{}',
     'node_modules/react-native-foo/react-native.config.js': `module.exports = {
       commands: [
@@ -220,6 +221,7 @@ test('does not use restricted "react-native" key to resolve config from package.
     'node_modules/react-native-netinfo/package.json': `{
       "react-native": "src/index.js"
     }`,
+    'react-native.config.js': 'module.exports = { reactNativePath: "." }',
     'package.json': `{
       "dependencies": {
         "react-native-netinfo": "0.0.1"

--- a/packages/cli-doctor/src/commands/info.ts
+++ b/packages/cli-doctor/src/commands/info.ts
@@ -6,7 +6,7 @@
  */
 
 import getEnvironmentInfo from '../tools/envinfo';
-import {logger, releaseChecker} from '@react-native-community/cli-tools';
+import {logger, version} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
 
 const info = async function getInfo(_argv: Array<string>, ctx: Config) {
@@ -17,7 +17,7 @@ const info = async function getInfo(_argv: Array<string>, ctx: Config) {
   } catch (err) {
     logger.error(`Unable to print environment info.\n${err}`);
   } finally {
-    await releaseChecker(ctx.root);
+    await version.logIfUpdateAvailable(ctx.root);
   }
 };
 

--- a/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
@@ -1,4 +1,4 @@
-import {findProjectRoot, logger} from '@react-native-community/cli-tools';
+import {findProjectRoot, logger, link} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
@@ -182,7 +182,11 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android SDK',
-      url: 'https://reactnative.dev/docs/environment-setup',
+      url: link.docs('environment-setup', {
+        hash: 'android-sdk',
+        guide: 'native',
+        platform: 'android',
+      }),
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
@@ -1,5 +1,7 @@
 import {join} from 'path';
 
+import {link} from '@react-native-community/cli-tools';
+
 import {HealthCheckInterface} from '../../types';
 
 import {downloadAndUnzip} from '../downloadAndUnzip';
@@ -74,7 +76,11 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android Studio',
-      url: 'https://reactnative.dev/docs/environment-setup',
+      url: link.docs('environment-setup', {
+        hash: 'android-studio',
+        guide: 'native',
+        platform: 'android',
+      }),
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/healthchecks/jdk.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/jdk.ts
@@ -1,4 +1,7 @@
 import {join} from 'path';
+
+import {link} from '@react-native-community/cli-tools';
+
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
 import {HealthCheckInterface} from '../../types';
@@ -58,7 +61,11 @@ export default {
     loader.fail();
     logManualInstallation({
       healthcheck: 'JDK',
-      url: 'https://reactnative.dev/docs/environment-setup',
+      url: link.docs('environment-setup', {
+        hash: 'jdk-studio',
+        guide: 'native',
+        platform: 'android',
+      }),
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/healthchecks/ruby.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/ruby.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import chalk from 'chalk';
 
-import {logger, findProjectRoot} from '@react-native-community/cli-tools';
+import {logger, findProjectRoot, link} from '@react-native-community/cli-tools';
 
 import versionRanges from '../versionRanges';
 import {doesSoftwareNeedToBeFixed} from '../checkInstallation';
@@ -174,7 +174,11 @@ export default {
 
     logManualInstallation({
       healthcheck: 'Ruby',
-      url: 'https://reactnative.dev/docs/environment-setup#ruby',
+      url: link.docs('environment-setup', {
+        hash: 'ruby',
+        guide: 'native',
+        platform: 'ios',
+      }),
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import execa from 'execa';
 import chalk from 'chalk';
-import {logger, NoopLoader} from '@react-native-community/cli-tools';
+import {logger, NoopLoader, link} from '@react-native-community/cli-tools';
 import sudo from 'sudo-prompt';
 import runBundleInstall from './runBundleInstall';
 import {Loader} from '../types';
@@ -38,7 +38,9 @@ async function runPodInstall(
       logger.error(stderr);
 
       throw new Error(
-        'Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.',
+        `Looks like your iOS environment is not properly set. Please go to ${link.docs(
+          'environment-setup',
+        )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,
       );
     }
   }

--- a/packages/cli-doctor/src/tools/runBundleInstall.ts
+++ b/packages/cli-doctor/src/tools/runBundleInstall.ts
@@ -1,5 +1,5 @@
 import execa from 'execa';
-import {CLIError, logger} from '@react-native-community/cli-tools';
+import {CLIError, logger, link} from '@react-native-community/cli-tools';
 
 import {Loader} from '../types';
 
@@ -12,7 +12,9 @@ async function runBundleInstall(loader: Loader) {
     loader.fail();
     logger.error((error as any).stderr || (error as any).stdout);
     throw new CLIError(
-      'Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.',
+      `Looks like your iOS environment is not properly set. Please go to ${link.docs(
+        'environment-setup',
+      )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,
     );
   }
 

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -13,7 +13,7 @@ import tryRunAdbReverse from './tryRunAdbReverse';
 import tryLaunchAppOnDevice from './tryLaunchAppOnDevice';
 import tryInstallAppOnDevice from './tryInstallAppOnDevice';
 import getAdbPath from './getAdbPath';
-import {logger, CLIError} from '@react-native-community/cli-tools';
+import {logger, CLIError, link} from '@react-native-community/cli-tools';
 import {getAndroidProject} from '../../config/getAndroidProject';
 import listAndroidDevices from './listAndroidDevices';
 import tryLaunchEmulator from './tryLaunchEmulator';
@@ -38,6 +38,12 @@ export type AndroidProject = NonNullable<Config['project']['android']>;
  * Starts the app on a connected Android emulator or device.
  */
 async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
+  link.setPlatform('android');
+
+  if (config.reactNativeVersion !== 'unknown') {
+    link.setVersion(config.reactNativeVersion);
+  }
+
   if (args.binaryPath) {
     if (args.tasks) {
       throw new CLIError(

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -12,7 +12,7 @@ import fs from 'fs';
 import chalk from 'chalk';
 import {Config, IOSProjectInfo} from '@react-native-community/cli-types';
 import {getDestinationSimulator} from '../../tools/getDestinationSimulator';
-import {logger, CLIError} from '@react-native-community/cli-tools';
+import {logger, CLIError, link} from '@react-native-community/cli-tools';
 import {BuildFlags, buildProject} from '../buildIOS/buildProject';
 import {iosBuildOptions} from '../buildIOS';
 import {Device} from '../../types';
@@ -35,6 +35,12 @@ export interface FlagsT extends BuildFlags {
 }
 
 async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
+  link.setPlatform('ios');
+
+  if (ctx.reactNativeVersion !== 'unknown') {
+    link.setVersion(ctx.reactNativeVersion);
+  }
+
   if (!ctx.project.ios) {
     throw new CLIError(
       'iOS project folder not found. Are you sure this is a React Native project?',

--- a/packages/cli-plugin-metro/src/commands/start/runServer.ts
+++ b/packages/cli-plugin-metro/src/commands/start/runServer.ts
@@ -18,7 +18,7 @@ import {
 import {Config} from '@react-native-community/cli-types';
 
 import loadMetroConfig from '../../tools/loadMetroConfig';
-import {releaseChecker} from '@react-native-community/cli-tools';
+import {version} from '@react-native-community/cli-tools';
 import enableWatchMode from './watchMode';
 
 export type Args = {
@@ -124,7 +124,7 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
   //
   serverInstance.keepAliveTimeout = 30000;
 
-  await releaseChecker(ctx.root);
+  await version.logIfUpdateAvailable(ctx.root);
 }
 
 function getReporterImpl(customLogReporterPath: string | undefined) {

--- a/packages/cli-tools/src/__tests__/doclink.test.ts
+++ b/packages/cli-tools/src/__tests__/doclink.test.ts
@@ -1,0 +1,56 @@
+import * as link from '../doclink';
+
+const mockPlatform = jest.fn().mockReturnValue('darwin');
+jest.mock('os', () => ({
+  platform: mockPlatform,
+}));
+
+describe('link', () => {
+  it('builds a link with the platform and os defined', () => {
+    mockPlatform.mockReturnValueOnce('darwin');
+    link.setPlatform('android');
+
+    const url = new URL(link.docs('environment-setup')).toString();
+    expect(url).toMatch(/os=macos/);
+    expect(url).toMatch(/platform=android/);
+    expect(url).toEqual(
+      expect.stringContaining('https://reactnative.dev/docs/environment-setup'),
+    );
+
+    // Handles a change of os
+    mockPlatform.mockReturnValueOnce('win32');
+    expect(link.docs('environment-setup')).toMatch(/os=windows/);
+
+    // Handles a change of platform
+    link.setPlatform('ios');
+    expect(link.docs('environment-setup')).toMatch(/platform=ios/);
+  });
+
+  it('preserves anchor-links', () => {
+    expect(link.docs('environment-setup', 'ruby')).toMatch(/#ruby/);
+  });
+
+  describe('overrides', () => {
+    afterAll(() => link.setVersion(null));
+    it.each([
+      [{hash: 'ruby'}, /#ruby/],
+      [{hash: 'ruby', os: 'linux'}, /os=linux/],
+      [{platform: 'ios'}, /platform=ios/],
+      [{'extra stuff': 'here?ok'}, /extra\+stuff=here%3Fok/],
+    ])("link.doc('environment-setup, %o) -> %o", (param, re) => {
+      expect(link.docs('environment-setup', param)).toMatch(re);
+    });
+  });
+
+  describe('versions', () => {
+    afterAll(() => link.setVersion(null));
+    it('supports linking to a specific version of React Native', () => {
+      link.setVersion('0.71');
+      expect(link.docs('environment-setup', 'ruby')).toEqual(
+        expect.stringContaining(
+          'https://reactnative.dev/docs/0.71/environment-setup',
+        ),
+      );
+    });
+  });
+});

--- a/packages/cli-tools/src/doclink.ts
+++ b/packages/cli-tools/src/doclink.ts
@@ -1,0 +1,106 @@
+import os from 'os';
+import assert from 'assert';
+
+type Platforms = 'android' | 'ios';
+
+function getOS(): string {
+  // Using os.platform instead of process.platform so we can test more easily. Once jest upgrades
+  // to ^29.4 we could use process.platforms and jest.replaceProperty(process, 'platforms', 'someplatform');
+  switch (os.platform()) {
+    case 'aix':
+    case 'freebsd':
+    case 'linux':
+    case 'openbsd':
+    case 'sunos':
+      // King of controversy, right here.
+      return 'linux';
+    case 'darwin':
+      return 'macos';
+    case 'win32':
+      return 'windows';
+    default:
+      return '';
+  }
+}
+
+let _platform: Platforms = 'android';
+let _version: string | undefined;
+
+interface Overrides {
+  os?: string;
+  platform?: string;
+  hash?: string;
+  version?: string;
+}
+
+interface Other {
+  [key: string]: string;
+}
+
+/**
+ * Create a deeplink to our documentation based on the user's OS and the Platform they're trying to build.
+ */
+function doclink(
+  section: string,
+  path: string,
+  hashOrOverrides?: string | (Overrides & Other),
+): string {
+  const url = new URL('https://reactnative.dev/');
+
+  // Overrides
+  const isObj = typeof hashOrOverrides === 'object';
+
+  const hash = isObj ? hashOrOverrides.hash : hashOrOverrides;
+  const version =
+    isObj && hashOrOverrides.version ? hashOrOverrides.version : _version;
+  const OS = isObj && hashOrOverrides.os ? hashOrOverrides.os : getOS();
+  const platform =
+    isObj && hashOrOverrides.platform ? hashOrOverrides.platform : _platform;
+
+  url.pathname = _version
+    ? `${section}/${version}/${path}`
+    : `${section}/${path}`;
+
+  url.searchParams.set('os', OS);
+  url.searchParams.set('platform', platform);
+
+  if (isObj) {
+    const otherKeys = Object.keys(hashOrOverrides).filter(
+      (key) => !['hash', 'version', 'os', 'platform'].includes(key),
+    );
+    for (let key of otherKeys) {
+      url.searchParams.set(key, hashOrOverrides[key]);
+    }
+  }
+
+  if (hash) {
+    assert.doesNotMatch(
+      hash,
+      /#/,
+      "Anchor links should be written withou a '#'",
+    );
+    url.hash = hash;
+  }
+
+  return url.toString();
+}
+
+export const docs = doclink.bind(null, 'docs');
+export const contributing = doclink.bind(null, 'contributing');
+export const community = doclink.bind(null, 'community');
+export const showcase = doclink.bind(null, 'showcase');
+export const blog = doclink.bind(null, 'blog');
+
+/**
+ * When the user builds, we should define the target platform globally.
+ */
+export function setPlatform(target: Platforms): void {
+  _platform = target;
+}
+
+/**
+ * Can we figure out what version of react native they're using?
+ */
+export function setVersion(reactNativeVersion: string): void {
+  _version = reactNativeVersion;
+}

--- a/packages/cli-tools/src/errors.ts
+++ b/packages/cli-tools/src/errors.ts
@@ -19,5 +19,10 @@ export class CLIError extends Error {
   }
 }
 
+/**
+ * Raised when we're unable to find a package.json
+ */
+export class UnknownProjectError extends Error {}
+
 export const inlineString = (str: string) =>
   str.replace(/(\s{2,})/gm, ' ').trim();

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -11,5 +11,6 @@ export {default as hookStdout} from './hookStdout';
 export {getLoader, NoopLoader, Loader} from './loader';
 export {default as findProjectRoot} from './findProjectRoot';
 export {default as printRunDoctorTip} from './printRunDoctorTip';
+export * as link from './doclink';
 
 export * from './errors';

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -5,7 +5,7 @@ export {fetch, fetchToTemp} from './fetch';
 export {default as launchDefaultBrowser} from './launchDefaultBrowser';
 export {default as launchDebugger} from './launchDebugger';
 export {default as launchEditor} from './launchEditor';
-export {default as releaseChecker} from './releaseChecker';
+export * as version from './releaseChecker';
 export {default as resolveNodeModuleDir} from './resolveNodeModuleDir';
 export {default as hookStdout} from './hookStdout';
 export {getLoader, NoopLoader, Loader} from './loader';

--- a/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
@@ -19,7 +19,7 @@ export type Release = {
 export default async function getLatestRelease(
   name: string,
   currentVersion: string,
-): Promise<Release | void> {
+): Promise<Release | undefined> {
   logger.debug('Checking for a newer version of React Native');
   try {
     logger.debug(`Current version: ${currentVersion}`);
@@ -68,6 +68,7 @@ export default async function getLatestRelease(
     );
     logger.debug(e as any);
   }
+  return undefined;
 }
 
 function buildChangelogUrl(version: string) {

--- a/packages/cli-tools/src/releaseChecker/index.ts
+++ b/packages/cli-tools/src/releaseChecker/index.ts
@@ -1,21 +1,52 @@
 import path from 'path';
+import semver, {SemVer} from 'semver';
+
+import {UnknownProjectError} from '../errors';
 import logger from '../logger';
-// @ts-ignore - JS file
 import resolveNodeModuleDir from '../resolveNodeModuleDir';
-import getLatestRelease from './getLatestRelease';
+import getLatestRelease, {Release} from './getLatestRelease';
 import printNewRelease from './printNewRelease';
 
-export default async function releaseChecker(root: string) {
+const getReactNativeVersion = (projectRoot: string): string | undefined =>
+  require(path.join(
+    resolveNodeModuleDir(projectRoot, 'react-native'),
+    'package.json',
+  ))?.version;
+
+/**
+ * Logs out a message if the user's version is behind a stable version of React Native
+ */
+export async function logIfUpdateAvailable(projectRoot: string): Promise<void> {
+  const hasUpdate = await latest(projectRoot);
+  if (hasUpdate) {
+    printNewRelease(hasUpdate.name, hasUpdate.upgrade, hasUpdate.current);
+  }
+}
+
+type Update = {
+  upgrade: Release;
+  current: string;
+  name: string;
+};
+
+/**
+ * Finds the latest stables version of React Native > current version
+ */
+export async function latest(projectRoot: string): Promise<Update | undefined> {
   try {
-    const {version: currentVersion} = require(path.join(
-      resolveNodeModuleDir(root, 'react-native'),
-      'package.json',
-    ));
-    const {name} = require(path.join(root, 'package.json'));
+    const currentVersion = getReactNativeVersion(projectRoot);
+    if (!currentVersion) {
+      return;
+    }
+    const {name} = require(path.join(projectRoot, 'package.json'));
     const latestRelease = await getLatestRelease(name, currentVersion);
 
     if (latestRelease) {
-      printNewRelease(name, latestRelease, currentVersion);
+      return {
+        name,
+        current: currentVersion,
+        upgrade: latestRelease,
+      };
     }
   } catch (e) {
     // We let the flow continue as this component is not vital for the rest of
@@ -26,4 +57,20 @@ export default async function releaseChecker(root: string) {
     );
     logger.debug(e as any);
   }
+  return undefined;
+}
+
+/**
+ * Gets the current project's version parsed as Semver
+ */
+export function current(projectRoot: string): SemVer | undefined {
+  try {
+    const found = semver.parse(getReactNativeVersion(projectRoot));
+    if (found) {
+      return found;
+    }
+  } catch (_) {
+    throw new UnknownProjectError(projectRoot);
+  }
+  return undefined;
 }

--- a/packages/cli-tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/printNewRelease.ts
@@ -1,4 +1,7 @@
 import chalk from 'chalk';
+
+import * as link from '../doclink';
+
 import logger from '../logger';
 import {Release} from './getLatestRelease';
 import cacheManager from './releaseCacheManager';
@@ -18,7 +21,7 @@ export default function printNewRelease(
   logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}`);
   logger.info(
     `For more info, check out "${chalk.dim.underline(
-      'https://reactnative.dev/docs/upgrading',
+      link.docs('upgrading'),
     )}".`,
   );
 

--- a/packages/cli-types/src/index.ts
+++ b/packages/cli-types/src/index.ts
@@ -112,6 +112,7 @@ export interface DependencyConfig {
 export interface Config {
   root: string;
   reactNativePath: string;
+  reactNativeVersion: string;
   project: ProjectConfig;
   dependencies: {
     [key: string]: DependencyConfig;

--- a/yarn.lock
+++ b/yarn.lock
@@ -429,6 +429,14 @@
     "@babel/helper-plugin-utils" "^7.18.9"
     "@babel/plugin-syntax-export-default-from" "^7.18.6"
 
+"@babel/plugin-proposal-export-namespace-from@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz#5f7313ab348cdb19d590145f9247540e94761203"
+  integrity sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+
 "@babel/plugin-proposal-json-strings@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz#da5216b238a98b58a1e05d6852104b10f9a70d6b"
@@ -570,6 +578,13 @@
   integrity sha512-Kr//z3ujSVNx6E9z9ih5xXXMqK07VVTuqPmqGe6Mss/zW5XPeLZeSDZoP9ab/hT4wPKqAgjl2PnhPrcpk8Seew==
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
+
+"@babel/plugin-syntax-export-namespace-from@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz#028964a9ba80dbc094c915c487ad7c4e7a66465a"
+  integrity sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
 
 "@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.12.1", "@babel/plugin-syntax-flow@^7.18.0", "@babel/plugin-syntax-flow@^7.18.6", "@babel/plugin-syntax-flow@^7.8.3":
   version "7.18.6"


### PR DESCRIPTION
Summary:
---------

Everything is in, so this should be good to tests against.
~~These changes will only start to work once our documentation is updated to support this feature:~~
- [X] facebook/react-native-website#3618 
- [X]  facebook/react-native-website#3619
- [X]  facebook/react-native-website#3620
- [X]  facebook/react-native-website/pull/3626

The outcome is that we now write links like this:

```typescript
import {findProjectRoot, logger, link} from '@react-native-community/cli-tools';
link.docs('environment-setup', 'ruby');
```
And get links this:

> https://reactnative.dev/docs/environment-setup#ruby?platform=ios&os=macos

For more complicated examples you'd write this:

```typescript
link.setVersion('0.69');
link.docs('environment-setup', {hash:'ruby', platform: 'ios', guide: 'native', very: 'extensible'})
```
> https://reactnative.dev/docs/0.69/environment-setup#ruby?platform=ios&os=macos&guide=native&very=extensible

Depending on how the user has run the project.  With this result if clicked on:

![CleanShot 2023-03-10 at 18 49 43](https://user-images.githubusercontent.com/49578/224400656-f2001c52-2058-4080-9161-be0f3b33e0a1.png)



Test Plan:
----------

I've run this against a locally generated project from `init`.  I'll do something more comprehensive, but wanted to get some direction feedback before.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
