### PR TITLE
fix: Getting rid of stack trace for `Installing Bundler` errors

### DIFF
--- a/packages/cli-doctor/src/tools/runBundleInstall.ts
+++ b/packages/cli-doctor/src/tools/runBundleInstall.ts
@@ -13,7 +13,6 @@ async function runBundleInstall(loader: Loader) {
     logger.error((error as any).stderr || (error as any).stdout);
     throw new CLIError(
       'Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.',
-      error as Error,
     );
   }
 


### PR DESCRIPTION
Summary:
---------

As a follow-up to https://github.com/react-native-community/cli/pull/1873, the stack trace is irrelevant and not useful/actionable since we already know what went wrong with the `npx react-native@latest init AwesomeProject` step. Hence removing it in order to make the error more clear, concise and accurate.

Hence utilizing [CLIError](https://github.com/react-native-community/cli/blob/main/packages/cli-tools/src/errors.ts)  of it's ability to strip out the stack trace in this case.

Resolves https://github.com/react-native-community/cli/issues/1766


Test Plan:
----------

1. Build cli codebase using : `node ./scripts/build.js && yarn build:debugger`
2. Init a new RN app using local built CLI : `node /Users/arushikesarwani/cli/packages/cli/build/bin.js init tests`

**BEFORE :**

```
arushikesarwani@arushikesarwani-mbp ~ % node /Users/arushikesarwani/cli/packages/cli/build/bin.js init tests
                                                          
               ######                ######               
             ###     ####        ####     ###             
            ##          ###    ###          ##            
            ##             ####             ##            
            ##             ####             ##            
            ##           ##    ##           ##            
            ##         ###      ###         ##            
             ##  ########################  ##             
          ######    ###            ###    ######          
      ###     ##    ##              ##    ##     ###      
   ###         ## ###      ####      ### ##         ###   
  ##           ####      ########      ####           ##  
 ##             ###     ##########     ###             ## 
  ##           ####      ########      ####           ##  
   ###         ## ###      ####      ### ##         ###   
      ###     ##    ##              ##    ##     ###      
          ######    ###            ###    ######          
             ##  ########################  ##             
            ##         ###      ###         ##            
            ##           ##    ##           ##            
            ##             ####             ##            
            ##             ####             ##            
            ##          ###    ###          ##            
             ###     ####        ####     ###             
               ######                ######               
                                                          

                  Welcome to React Native!                
                 Learn once, write anywhere               

✔ Downloading template
✔ Copying template
✔ Processing template
✖ Installing Bundler
error Your Ruby version is 2.6.10, but your Gemfile specified 2.7.6

✖ Installing Bundler
error Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.
Error: Command failed: bundle install

Your Ruby version is 2.6.10, but your Gemfile specified 2.7.6

    at makeError (/Users/arushikesarwani/cli/node_modules/execa/index.js:174:9)
    at /Users/arushikesarwani/cli/node_modules/execa/index.js:278:16
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async runBundleInstall (/Users/arushikesarwani/cli/packages/cli-doctor/build/tools/runBundleInstall.js:25:5)
    at async installPods (/Users/arushikesarwani/cli/packages/cli-doctor/build/tools/installPods.js:131:7)
    at async installDependencies (/Users/arushikesarwani/cli/packages/cli/build/commands/init/init.js:149:5)
    at async createFromTemplate (/Users/arushikesarwani/cli/packages/cli/build/commands/init/init.js:120:7)
    at async Object.initialize [as func] (/Users/arushikesarwani/cli/packages/cli/build/commands/init/init.js:184:3)
    at async Command.handleAction (/Users/arushikesarwani/cli/packages/cli/build/index.js:109:9)
info Run CLI with --verbose flag for more details.
arushikesarwani@arushikesarwani-mbp ~ % 
```

**AFTER :**

```
arushikesarwani@arushikesarwani-mbp ~ % node /Users/arushikesarwani/cli/packages/cli/build/bin.js init tests
                                                          
               ######                ######               
             ###     ####        ####     ###             
            ##          ###    ###          ##            
            ##             ####             ##            
            ##             ####             ##            
            ##           ##    ##           ##            
            ##         ###      ###         ##            
             ##  ########################  ##             
          ######    ###            ###    ######          
      ###     ##    ##              ##    ##     ###      
   ###         ## ###      ####      ### ##         ###   
  ##           ####      ########      ####           ##  
 ##             ###     ##########     ###             ## 
  ##           ####      ########      ####           ##  
   ###         ## ###      ####      ### ##         ###   
      ###     ##    ##              ##    ##     ###      
          ######    ###            ###    ######          
             ##  ########################  ##             
            ##         ###      ###         ##            
            ##           ##    ##           ##            
            ##             ####             ##            
            ##             ####             ##            
            ##          ###    ###          ##            
             ###     ####        ####     ###             
               ######                ######               
                                                          
                  Welcome to React Native!                
                 Learn once, write anywhere               
✔ Downloading template
✔ Copying template
✔ Processing template
✖ Installing Bundler
error Your Ruby version is 2.6.10, but your Gemfile specified 2.7.6
✖ Installing Bundler
error Looks like your iOS environment is not properly set. Please go to https://reactnative.dev/docs/next/environment-setup and follow the React Native CLI QuickStart guide for macOS and iOS.
info Run CLI with --verbose flag for more details.
arushikesarwani@arushikesarwani-mbp ~ %
```

