### PR TITLE
fix : Getting rid of stack traces during `installPods` by using `CLIError`

### DIFF
--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import execa from 'execa';
 import chalk from 'chalk';
-import {logger, NoopLoader, link} from '@react-native-community/cli-tools';
+import {
+  logger,
+  NoopLoader,
+  link,
+  CLIError,
+} from '@react-native-community/cli-tools';
 import sudo from 'sudo-prompt';
 import runBundleInstall from './runBundleInstall';
 import {Loader} from '../types';
@@ -37,7 +42,7 @@ async function runPodInstall(
       loader.fail();
       logger.error(stderr);
 
-      throw new Error(
+      throw new CLIError(
         `Looks like your iOS environment is not properly set. Please go to ${link.docs(
           'environment-setup',
         )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,
@@ -59,7 +64,7 @@ async function runPodUpdate(loader: Loader) {
     logger.log((error as any).stderr || (error as any).stdout);
     loader.fail();
 
-    throw new Error(
+    throw new CLIError(
       `Failed to update CocoaPods repositories for iOS project.\nPlease try again manually: "pod repo update".\nCocoaPods documentation: ${chalk.dim.underline(
         'https://cocoapods.org/',
       )}`,
@@ -104,7 +109,7 @@ async function installCocoaPods(loader: Loader) {
     loader.fail();
     logger.error((error as any).stderr);
 
-    throw new Error(
+    throw new CLIError(
       `An error occured while trying to install CocoaPods, which is required by this template.\nPlease try again manually: sudo gem install cocoapods.\nCocoaPods documentation: ${chalk.dim.underline(
         'https://cocoapods.org/',
       )}`,


### PR DESCRIPTION
Summary:
---------

As highlighted in https://github.com/react-native-community/cli/issues/1766, there are useless stack traces in errors that are meant to be human-readable. Hence utilizing [CLIError](https://github.com/react-native-community/cli/blob/main/packages/cli-tools/src/errors.ts) of it's ability to strip out the stack trace in such cases.


Test Plan:
----------

1. Build cli codebase using : `node ./scripts/build.js && yarn build:debugger`
2. Init a new RN app using local built CLI : `node /Users/arushikesarwani/cli/packages/cli/build/bin.js init tests`
