### PR TITLE
fix: doclinks should not select a default platform

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/adb.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/adb.ts
@@ -63,10 +63,9 @@ export default {
     } catch (e) {
       return logManualInstallation({
         healthcheck: 'Adb',
-        url: link.docs('running-on-device', {
+        url: link.docs('running-on-device', 'android', {
           hash: hash,
           guide: 'native',
-          platform: 'android',
         }),
       });
     }

--- a/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
@@ -182,10 +182,9 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android SDK',
-      url: link.docs('environment-setup', {
+      url: link.docs('environment-setup', 'android', {
         hash: 'android-sdk',
         guide: 'native',
-        platform: 'android',
       }),
     });
   },

--- a/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
@@ -76,10 +76,9 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android Studio',
-      url: link.docs('environment-setup', {
+      url: link.docs('environment-setup', 'android', {
         hash: 'android-studio',
         guide: 'native',
-        platform: 'android',
       }),
     });
   },

--- a/packages/cli-doctor/src/tools/healthchecks/jdk.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/jdk.ts
@@ -61,10 +61,9 @@ export default {
     loader.fail();
     logManualInstallation({
       healthcheck: 'JDK',
-      url: link.docs('environment-setup', {
+      url: link.docs('environment-setup', 'android', {
         hash: 'jdk-studio',
         guide: 'native',
-        platform: 'android',
       }),
     });
   },

--- a/packages/cli-doctor/src/tools/healthchecks/ruby.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/ruby.ts
@@ -174,10 +174,9 @@ export default {
 
     logManualInstallation({
       healthcheck: 'Ruby',
-      url: link.docs('environment-setup', {
+      url: link.docs('environment-setup', 'ios', {
         hash: 'ruby',
         guide: 'native',
-        platform: 'ios',
       }),
     });
   },

--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -44,6 +44,8 @@ async function runPodInstall(
       throw new CLIError(
         `Looks like your iOS environment is not properly set. Please go to ${link.docs(
           'environment-setup',
+          'ios',
+          {guide: 'native'},
         )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,
       );
     }

--- a/packages/cli-doctor/src/tools/runBundleInstall.ts
+++ b/packages/cli-doctor/src/tools/runBundleInstall.ts
@@ -14,6 +14,8 @@ async function runBundleInstall(loader: Loader) {
     throw new CLIError(
       `Looks like your iOS environment is not properly set. Please go to ${link.docs(
         'environment-setup',
+        'ios',
+        {guide: 'native'},
       )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,
     );
   }

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -140,10 +140,9 @@ function createInstallError(error: Error & {stderr: string}) {
     )}."`;
   } else if (stderr.includes('requires Java')) {
     message = `Looks like your Android environment is not properly set. Please go to ${chalk.dim.underline(
-      link.docs('environment-setup', {
+      link.docs('environment-setup', 'android', {
         hash: 'jdk-studio',
         guide: 'native',
-        platform: 'android',
       }),
     )} and follow the React Native CLI QuickStart guide to install the compatible version of JDK.`;
   }

--- a/packages/cli-tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/printNewRelease.ts
@@ -21,7 +21,7 @@ export default function printNewRelease(
   logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}`);
   logger.info(
     `For more info, check out "${chalk.dim.underline(
-      link.docs('upgrading'),
+      link.docs('upgrading', 'inherit'),
     )}".`,
   );
 


### PR DESCRIPTION
Previously this would default to Android, which isn't intuitive. Also fixed some links to be more specific.

Summary:
---------
## Before
![CleanShot 2023-03-21 at 10 15 43](https://user-images.githubusercontent.com/49578/226577032-f79d2c40-62dc-4d9a-88d9-72d9d82dc10c.png)
## After
![CleanShot 2023-03-21 at 10 13 35](https://user-images.githubusercontent.com/49578/226577044-fb161861-7b4e-4086-86cd-31af271b361a.png)


Test Plan:
----------

Built and ran the cli to `init` a new project.