### PR TITLE
fix: link inside `printRunDoctorTip.ts`

### DIFF
--- a/packages/cli-tools/src/printRunDoctorTip.ts
+++ b/packages/cli-tools/src/printRunDoctorTip.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 
 const printRunDoctorTip = () => {
   const linkToDocs =
-    'https://github.com/react-native-community/cli/blob/main/docs/commands.md#doctor';
+    'https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor';
 
   logger.log('');
   logger.info(


### PR DESCRIPTION
Summary:
---------
Recently I updated docs, and this PR fixes link which is pointing to header which doesn't exist.

Test Plan:
----------
