### PR TITLE
Bump execa from 1.x to 5.x

### DIFF
--- a/__e2e__/__snapshots__/default.test.ts.snap
+++ b/__e2e__/__snapshots__/default.test.ts.snap
@@ -13,6 +13,5 @@ Commands:
                                 <projectName> in a directory of the same name.
   doctor [options]              Diagnose and fix common Node.js, iOS, Android &
                                 React Native issues.
-  help [command]                display help for command
-"
+  help [command]                display help for command"
 `;

--- a/__e2e__/unknown.test.ts
+++ b/__e2e__/unknown.test.ts
@@ -16,14 +16,14 @@ afterEach(() => {
 });
 
 test('warn for passing in unknown commands', () => {
-  const {code, stderr} = runCLI(DIR, ['unknown'], {expectedFailure: true});
-  expect(code).toBe(1);
+  const {exitCode, stderr} = runCLI(DIR, ['unknown'], {expectedFailure: true});
+  expect(exitCode).toBe(1);
   expect(stderr).toContain("error: unknown command 'unknown'");
 });
 
 test('suggest matching command', () => {
-  const {code, stderr} = runCLI(DIR, ['ini'], {expectedFailure: true});
-  expect(code).toBe(1);
+  const {exitCode, stderr} = runCLI(DIR, ['ini'], {expectedFailure: true});
+  expect(exitCode).toBe(1);
   expect(stderr).toContain(
     `error: unknown command 'ini'
 (Did you mean init?)`,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.3",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "glob": "^7.1.3",
     "husky": "^8.0.2",
     "jest": "^26.6.2",

--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@react-native-community/cli-tools": "^11.0.0",
     "chalk": "^4.1.2",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "prompts": "^2.4.0"
   },
   "files": [
@@ -20,7 +20,6 @@
   ],
   "devDependencies": {
     "@react-native-community/cli-types": "^11.0.0",
-    "@types/execa": "^0.9.0",
     "@types/prompts": "^2.0.9"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-clean",

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -15,7 +15,7 @@
     "chalk": "^4.1.2",
     "command-exists": "^1.2.8",
     "envinfo": "^7.7.2",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "hermes-profile-transformer": "^0.0.6",
     "ip": "^1.1.5",
     "node-stream-zip": "^1.9.1",

--- a/packages/cli-platform-android/package.json
+++ b/packages/cli-platform-android/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@react-native-community/cli-tools": "^11.0.0",
     "chalk": "^4.1.2",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "glob": "^7.1.3",
     "logkitty": "^0.7.1"
   },
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@react-native-community/cli-plugin-metro": "^11.0.0",
     "@react-native-community/cli-types": "^11.0.0",
-    "@types/execa": "^0.9.0",
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1"
   },

--- a/packages/cli-platform-ios/package.json
+++ b/packages/cli-platform-ios/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@react-native-community/cli-tools": "^11.0.0",
     "chalk": "^4.1.2",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "fast-xml-parser": "^4.0.12",
     "glob": "^7.1.3",
     "ora": "^5.4.1"

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -10,7 +10,7 @@
     "@react-native-community/cli-server-api": "^11.0.0",
     "@react-native-community/cli-tools": "^11.0.0",
     "chalk": "^4.1.2",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "metro": "0.76.0",
     "metro-config": "0.76.0",
     "metro-core": "0.76.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
     "@react-native-community/cli-types": "^11.0.0",
     "chalk": "^4.1.2",
     "commander": "^9.4.1",
-    "execa": "^1.0.0",
+    "execa": "^5.0.0",
     "find-up": "^4.1.0",
     "fs-extra": "^8.1.0",
     "graceful-fs": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2786,13 +2786,6 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/execa@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@types/execa/-/execa-0.9.0.tgz#9b025d2755f17e80beaf9368c3f4f319d8b0fb93"
-  integrity sha512-mgfd93RhzjYBUHHV532turHC2j4l/qxsF/PbfDmprHDEUHmNZGlDn1CEsulGK3AfsPdhkWzZQT/S/k0UGhLGsA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.33"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz#de35d30a9d637dc1450ad18dd583d75d5733d543"


### PR DESCRIPTION
Summary:
---------

https://github.com/sindresorhus/execa/releases

5.x is the last version before the package is being rewritten to ESM.

execa now ships with typescript types embedded.

I see a previous attempt here was aborted:
https://github.com/react-native-community/cli/pull/1514/

#### Relevant breaking changes:
error.code is deprecated in favor of error.exitCode
https://github.com/sindresorhus/execa/pull/250
Some changes to stripping the final newline:
https://github.com/sindresorhus/execa/commit/f8397ba9504b5fbba6cb6275b617fc5da6ced199

Test Plan:
----------

There should be no expected changes. From reading the Changelog I could not find any usage of deprecated APIs.