### PR TITLE
fix: Add runtime error when Metro config cannot be resolved

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -96,8 +96,8 @@ export default async function loadMetroConfig(
   } catch (e) {
     console.warn(
       'warning: From React Native 0.72, your metro.config.js file should ' +
-        "extend '@react-native/metro-config', however this is not in your " +
-        "project's devDependencies.",
+        "extend '@react-native/metro-config', however it's not present in your " +
+        "project's devDependencies. Please install '@react-native/metro-config'.",
     );
   }
 

--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -94,8 +94,8 @@ export default async function loadMetroConfig(
       paths: [ctx.root],
     });
   } catch (e) {
-    console.warn(
-      'warning: From React Native 0.72, your metro.config.js file should ' +
+    logger.warn(
+      "From React Native 0.72, your 'metro.config.js' file should " +
         "extend '@react-native/metro-config', however it's not present in your " +
         "project's devDependencies. Please install '@react-native/metro-config'.",
     );


### PR DESCRIPTION
Summary:
---------

Relates to:
- https://github.com/react-native-community/cli/pull/1875
- https://github.com/facebook/react-native/pull/36502
- https://github.com/facebook/react-native/pull/36623

While preparing https://github.com/facebook/react-native/pull/36623, we discovered that (post monorepo) a few scripts in the React Native repo were starting RN CLI in directories outside of the project dir and weren't reading `metro.config.js` as expected — printing obscure errors due to missing config items.

This PR updates the CLI to throw a runtime error when `resolveConfig` fails for the target working directory (`ctx.root`). This is an important DevX enhancement, since a complete `metro.config.js` file will be required from React Native 0.72.

Test Plan:
----------

Pre-steps:
- Run `yarn link` in local clone of RN CLI.
- Run `yarn link @react-native-community/cli-plugin-metro` inside `packages/rn-tester` (local `facebook/react-native` repo clone).

✅ Now throws for `yarn start` in `packages/rn-tester`.
- Previously, this would start Metro and throw harder-to-understand errors due to missing config items.

![image](https://user-images.githubusercontent.com/2547783/227917705-99792a82-179d-4e88-9885-9c1b86e3001a.png)

(Note: I'm open to suggestions for an improved error message/method of erroring to improve the CLI output.)

✅ Does not throw when `yarn start` command is fixed
- (I've added a local `console.log()` to print the config file name)

<img width="1807" alt="image" src="https://user-images.githubusercontent.com/2547783/227918396-383cfcf4-4feb-48b7-b39e-854bbe88f9e3.png">


