### PR TITLE
fix: `log-ios` command

### DIFF
--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -9,7 +9,10 @@ exports[`shows up current config without unnecessary output 1`] = `
   "commands": [
     {
       "name": "log-ios",
-      "description": "starts iOS device syslog tail"
+      "description": "starts iOS device syslog tail",
+      "options": [
+        "<<REPLACED>>"
+      ]
     },
     {
       "name": "run-ios",

--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -192,6 +192,12 @@ react-native log-ios
 
 Starts iOS device syslog tail.
 
+#### Options
+
+#### `--interactive`
+
+Explicitly select simulator to tail logs from. By default it will tail logs from the first booted and available simulator.
+
 ## License
 
 Everything inside this repository is [MIT licensed](./LICENSE).

--- a/packages/cli-platform-ios/src/commands/logIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/logIOS/index.ts
@@ -6,44 +6,42 @@
  *
  */
 
-import {execFileSync, spawnSync} from 'child_process';
+import {spawnSync} from 'child_process';
 import os from 'os';
 import path from 'path';
 import {logger} from '@react-native-community/cli-tools';
-import {Device} from '../../types';
-
-function findAvailableDevice(devices: {[index: string]: Array<Device>}) {
-  for (const key of Object.keys(devices)) {
-    for (const device of devices[key]) {
-      if (device.availability === '(available)' && device.state === 'Booted') {
-        return device;
-      }
-    }
-  }
-  return null;
-}
+import listIOSDevices from '../../tools/listIOSDevices';
+import {getSimulators} from '../runIOS';
 
 /**
  * Starts iOS device syslog tail
  */
 async function logIOS() {
-  const rawDevices = execFileSync(
-    'xcrun',
-    ['simctl', 'list', 'devices', '--json'],
-    {encoding: 'utf8'},
+  // Here we're using two command because first command `xcrun simctl list --json devices` outputs `state` but doesn't return `available`. But second command `xcrun xcdevice list` outputs `available` but doesn't output `state`. So we need to connect outputs of both commands.
+  const simulators = getSimulators();
+  const bootedSimulators = Object.keys(simulators.devices)
+    .map((key) => simulators.devices[key])
+    .reduce((acc, val) => acc.concat(val), [])
+    .filter(({state}) => state === 'Booted');
+
+  const devices = await listIOSDevices();
+  const availableSimulators = devices.filter(
+    ({type, isAvailable}) => type === 'simulator' && isAvailable,
   );
 
-  const {devices} = JSON.parse(rawDevices) as {
-    devices: {[index: string]: Array<Device>};
-  };
+  const bootedAndAvailableSimulators = bootedSimulators.map((booted) => {
+    const available = availableSimulators.find(
+      ({udid}) => udid === booted.udid,
+    );
+    return {...available, ...booted};
+  });
 
-  const device = findAvailableDevice(devices);
-  if (device === null) {
+  if (bootedAndAvailableSimulators.length === 0) {
     logger.error('No active iOS device found');
     return;
   }
 
-  tailDeviceLogs(device.udid);
+  tailDeviceLogs(bootedAndAvailableSimulators[0].udid);
 }
 
 function tailDeviceLogs(udid: string) {

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -203,7 +203,7 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 }
 
-const getSimulators = () => {
+export const getSimulators = () => {
   let simulators: {devices: {[index: string]: Array<Device>}};
 
   try {

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -22,6 +22,7 @@ import {getProjectInfo} from '../../tools/getProjectInfo';
 import {getConfigurationScheme} from '../../tools/getConfigurationScheme';
 import {selectFromInteractiveMode} from '../../tools/selectFromInteractiveMode';
 import {promptForDeviceSelection} from '../../tools/prompts';
+import getSimulators from '../../tools/getSimulators';
 
 export interface FlagsT extends BuildFlags {
   simulator?: string;
@@ -202,25 +203,6 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     runOnSimulator(xcodeProject, scheme, modifiedArgs);
   }
 }
-
-export const getSimulators = () => {
-  let simulators: {devices: {[index: string]: Array<Device>}};
-
-  try {
-    simulators = JSON.parse(
-      child_process.execFileSync(
-        'xcrun',
-        ['simctl', 'list', '--json', 'devices'],
-        {encoding: 'utf8'},
-      ),
-    );
-  } catch (error) {
-    throw new CLIError(
-      'Could not get the simulator list from Xcode. Please open Xcode and try running project directly from there to resolve the remaining issues.',
-    );
-  }
-  return simulators;
-};
 
 async function runOnBootedDevicesSimulators(
   scheme: string,

--- a/packages/cli-platform-ios/src/tools/getSimulators.ts
+++ b/packages/cli-platform-ios/src/tools/getSimulators.ts
@@ -1,0 +1,24 @@
+import {CLIError} from '@react-native-community/cli-tools';
+import child_process from 'child_process';
+import {Device} from '../types';
+
+const getSimulators = () => {
+  let simulators: {devices: {[index: string]: Array<Device>}};
+
+  try {
+    simulators = JSON.parse(
+      child_process.execFileSync(
+        'xcrun',
+        ['simctl', 'list', '--json', 'devices'],
+        {encoding: 'utf8'},
+      ),
+    );
+  } catch (error) {
+    throw new CLIError(
+      'Could not get the simulator list from Xcode. Please open Xcode and try running project directly from there to resolve the remaining issues.',
+    );
+  }
+  return simulators;
+};
+
+export default getSimulators;


### PR DESCRIPTION
Summary:
---------

Closes  #1675

This PR connects output of two commands`xcrun simctl list --json devices` and `xcrun xcdevice list`. One command outputs `state`, but doesn't return `available`. But second command `xcrun xcdevice list` outputs `available` but doesn't output `state`. So I connected outputs from both commands.


Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:
```
node /path/to/react-native-cli/packages/cli/build/bin.js log-ios
```