### PR TITLE
fix : Getting rid of stack traces during `run-android` by using `CLIError`

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -139,7 +139,10 @@ function createInstallError(error: Error & {stderr: string}) {
     )}."`;
   }
 
-  return new CLIError(`Failed to install the app. ${message}`, error);
+  return new CLIError(
+    `Failed to install the app. ${message}`,
+    message.length > 0 ? undefined : error,
+  );
 }
 
 export default runOnAllDevices;

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -21,6 +21,7 @@ import {getPackageName} from './getAndroidProject';
 import {findLibraryName} from './findLibraryName';
 import {findComponentDescriptors} from './findComponentDescriptors';
 import {findBuildGradle} from './findBuildGradle';
+import {CLIError} from '@react-native-community/cli-tools';
 
 /**
  * Gets android project config by analyzing given folder and taking some
@@ -53,7 +54,7 @@ export function projectConfig(
     userConfig.packageName || getPackageName(manifestPath, buildGradlePath);
 
   if (!packageName) {
-    throw new Error(
+    throw new CLIError(
       `Package name not found in neither ${manifestPath} nor ${buildGradlePath}`,
     );
   }


### PR DESCRIPTION
Summary:
---------

As highlighted in https://github.com/react-native-community/cli/issues/1766, there are useless stack traces in errors that are meant to be human-readable. Hence utilizing [CLIError](https://github.com/react-native-community/cli/blob/main/packages/cli-tools/src/errors.ts) of it's ability to strip out the stack trace in such cases.

This workflow is part of the onboarding experience of RN, there by this would improve DevX

Test Plan:
----------

BEFORE :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % react-native run-android                                  
info JS server already running.
info Launching emulator...
error Failed to launch emulator. Reason: The emulator (Pixel_5_API_33) quit before it finished opening. You can try starting the emulator manually from the terminal with: /opt/android_sdk/emulator/emulator @Pixel_5_API_33.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.

info 💡 Tip: Make sure that you have set up your development environment correctly, by running react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor 

The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.


error Failed to install the app. Command failed: ./gradlew tasks
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.
Error: Command failed: ./gradlew tasks
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.



    at makeError (/Users/arushikesarwani/cli/node_modules/execa/index.js:174:9)
    at module.exports.sync (/Users/arushikesarwani/cli/node_modules/execa/index.js:338:15)
    at getGradleTasks (/Users/arushikesarwani/cli/packages/cli-platform-android/build/commands/runAndroid/listAndroidTasks.js:53:32)
    at getTaskNames (/Users/arushikesarwani/cli/packages/cli-platform-android/build/commands/runAndroid/getTaskNames.js:21:73)
    at runOnAllDevices (/Users/arushikesarwani/cli/packages/cli-platform-android/build/commands/runAndroid/runOnAllDevices.js:61:55)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Command.handleAction (/Users/arushikesarwani/cli/packages/cli/build/index.js:111:9)
info Run CLI with --verbose flag for more details.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```

AFTER :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % react-native run-android
info JS server already running.
info Launching emulator...
error Failed to launch emulator. Reason: The emulator (Pixel_5_API_33) quit before it finished opening. You can try starting the emulator manually from the terminal with: /opt/android_sdk/emulator/emulator @Pixel_5_API_33.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.


error Failed to install the app. Command failed: ./gradlew tasks
The operation couldn’t be completed. Unable to locate a Java Runtime.
Please visit http://www.java.com for information on installing Java.
info Run CLI with --verbose flag for more details.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```


