### PR TITLE
fix : Getting rid of stack traces during `run-ios` by using `CLIError`

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -217,7 +217,6 @@ const getSimulators = () => {
   } catch (error) {
     throw new CLIError(
       'Could not get the simulator list from Xcode. Please open Xcode and try running project directly from there to resolve the remaining issues.',
-      error as Error,
     );
   }
   return simulators;


### PR DESCRIPTION
Summary:
---------

As highlighted in https://github.com/react-native-community/cli/issues/1766, there are useless stack traces in errors during `run-ios` that are meant to be human-readable. Hence utilizing [CLIError](https://github.com/react-native-community/cli/blob/main/packages/cli-tools/src/errors.ts) of it's ability to strip out the stack trace in such cases.

In case we are not able to find the simulators in Xcode, the error is direct and message is sufficient, hence removing the stack trace in such case to improve error reporting. This workflow is part of the onboarding experience of RN, there by this would improve DevX

Test Plan:
----------

1. Build cli codebase using : `node ./scripts/build.js && yarn build:debugger`.
2. `cd packages/cli-platform-ios`
3. Link packages using : `yarn link`
4. In RN app `AwesomeProject`, run `yarn link "@react-native-community/cli-platform-ios"` to see successful linking :
```
arushikesarwani@arushikesarwani-mbp AwesomeProject % yarn link "@react-native-community/cli-platform-ios"
yarn link v1.22.19
warning ../package.json: No license field
success Using linked package for "@react-native-community/cli-platform-ios".
✨  Done in 0.05s.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```
5. `react-native run-ios`
