### PR TITLE
fix: replace `launchPackager.sh` with `launchPackager.command`

### DIFF
--- a/packages/cli-platform-android/src/commands/buildAndroid/startServerInNewWindow.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/startServerInNewWindow.ts
@@ -17,7 +17,9 @@ export function startServerInNewWindow(
    * Set up OS-specific filenames and commands
    */
   const isWindows = /^win/.test(process.platform);
-  const scriptFile = isWindows ? 'launchPackager.bat' : 'launchPackager.sh';
+  const scriptFile = isWindows
+    ? 'launchPackager.bat'
+    : 'launchPackager.command';
   const packagerEnvFilename = isWindows ? '.packager.bat' : '.packager.env';
   const packagerEnvFileExportContent = isWindows
     ? `set RCT_METRO_PORT=${port}\nset PROJECT_ROOT=${projectRoot}\nset REACT_NATIVE_PATH=${reactNativePath}`
@@ -59,8 +61,8 @@ export function startServerInNewWindow(
       );
     } else {
       fs.copyFileSync(
-        path.join(cliPluginMetroPath, 'launchPackager.sh'),
-        path.join(nodeModulesPath, 'launchPackager.sh'),
+        path.join(cliPluginMetroPath, 'launchPackager.command'),
+        path.join(nodeModulesPath, 'launchPackager.command'),
       );
     }
   } catch (error) {

--- a/packages/cli-plugin-metro/launchPackager.command
+++ b/packages/cli-plugin-metro/launchPackager.command
@@ -1,4 +1,5 @@
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
+
 source "$THIS_DIR/.packager.env"
 cd $PROJECT_ROOT
 $REACT_NATIVE_PATH/cli.js start


### PR DESCRIPTION
Summary:
---------
This PR replaces `launchPackager.sh` with `launchPackager.command`, we though that we can use `launchPackager.sh`, but actually it doesn't work. Because in same cases when we ran `open -a Terminal.app /path/to/launchPackager.sh` it doesn't opens the Terminal.app with the script but the Code Editor with this file.



Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:
```
node /path/to/react-native-cli/packages/cli/build/bin.js run-android
```
Metro bundler should be opened in right place in new terminal window.