### PR TITLE
fix: Fix merge of CLI Metro config overrides, add soft fallback to RN defaults

### DIFF
--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@react-native-community/cli-server-api": "^11.0.1",
     "@react-native-community/cli-tools": "^11.0.1",
+    "@react-native/metro-config": "^0.72.1",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
     "metro": "0.76.0",

--- a/packages/cli-plugin-metro/types/@react-native/metro-config/index.d.ts
+++ b/packages/cli-plugin-metro/types/@react-native/metro-config/index.d.ts
@@ -1,0 +1,5 @@
+declare module '@react-native/metro-config' {
+  import type {ConfigT} from 'metro-config';
+
+  export function getDefaultConfig(projectRoot: string): ConfigT;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,6 +2673,21 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz#e42b1bef12d2415411519fd528e64b593b1363dc"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
 
+"@react-native/js-polyfills@^0.72.1":
+  version "0.72.1"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.72.1.tgz#905343ef0c51256f128256330fccbdb35b922291"
+  integrity sha512-cRPZh2rBswFnGt5X5EUEPs0r+pAsXxYsifv/fgy9ZLQokuT52bPH+9xjDR+7TafRua5CttGW83wP4TntRcWNDA==
+
+"@react-native/metro-config@^0.72.1":
+  version "0.72.1"
+  resolved "https://registry.yarnpkg.com/@react-native/metro-config/-/metro-config-0.72.1.tgz#57f212700db2d160e8beff6163558310c2c82220"
+  integrity sha512-BxGfuMK/cXwJxChE4/T6nE4qOdwGLM9iUFFKpcyh9Nks0702qTTvwpjkFbJvlkpe4yulAZh8CKLJrRDVzGGbfQ==
+  dependencies:
+    "@react-native/js-polyfills" "^0.72.1"
+    metro-config "0.76.0"
+    metro-react-native-babel-transformer "0.76.0"
+    metro-runtime "0.76.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -8915,6 +8930,19 @@ metro-react-native-babel-preset@0.76.0:
     "@babel/template" "^7.0.0"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.4.0"
+
+metro-react-native-babel-transformer@0.76.0:
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.0.tgz#8c8872f0d3a0ec9dad2480df53c92c10eac92c79"
+  integrity sha512-mLyUiGq2qPoEwV3oncD82HOtM4wAl8YmXtGY17D4iqH6/5pE32lRnDDYt0WnJYACZDs3RB3MhTjGCM7rJNwn/A==
+  dependencies:
+    "@babel/core" "^7.20.0"
+    babel-preset-fbjs "^3.4.0"
+    hermes-parser "0.8.0"
+    metro-babel-transformer "0.76.0"
+    metro-react-native-babel-preset "0.76.0"
+    metro-source-map "0.76.0"
+    nullthrows "^1.1.1"
 
 metro-resolver@0.76.0:
   version "0.76.0"


### PR DESCRIPTION
## Context

### React Native Metro config → React Native repo (https://github.com/facebook/react-native/pull/36502)

Follow ups to https://github.com/react-native-community/cli/pull/1875.

## Changes

**Fixes**

- Fix a subtle bug where `loadConfig({cwd: ctx.root, ...options}, overrideConfig);` ([see original file diff](https://github.com/react-native-community/cli/pull/1875/files#diff-3eb3e1e81b924a57b22a630c633912f2f8777b5a201992591c8a3517fb63f525L128)) did not correctly merge `overrideConfig` (the extra config applied by RN CLI) over the newly migrated defaults (which were promoted into the project-level config file).
    - After changes, `overrideConfig` will now be merged after all config, _including any user-set config_. This makes sense (as before), given the CLI applies very sparse override options based on required CLI inputs.
    - **See test plan for E2E bugs fixed.**

**Upgrade improvements**

Provide a soft upgrade path for users on React Native 0.72 to migrate to the new `metro.config.js` setup in 0.73.

- Update the CLI's `loadMetroConfig` implementation to conditionally fall back to internal defaults. The intent is to remove this behaviour (and dependency in CLI) for React Native 0.73.
    - This conceptually brings the implementation back to the [first version](https://github.com/react-native-community/cli/commit/598f1a0dec7875f63e6a2a1ec677849305944357) of the original PR where we had "getDefaultConfigPre72". Instead, this now depends on the common `@react-native/metro-config` source.
- Improve warning guidance to reference template `metro.config.js` source.
    - Note: This may be later replaced with a React Native changelog deep link, once published.

Changelog: Fix bug where CLI-overridden Metro config might not have been applied

---

**📦 Please publish!**: We'd like to integrate this change into the 0.72 RC1 early next week. Apologies for the churn 🙏🏻.

---

## Test Plan

Using `rn-tester` configured with a locally `yarn link`ed copy of RN CLI.

✅ In all test cases, I added temporary debug logs for the entire final config object, which were compared and produce no diff between either config setup.

### New 0.72 config setup (project extends `@react-native/metro-config`)

**✅  App (rn-tester) runs with no CLI warnings**

<img width="2107" alt="image" src="https://user-images.githubusercontent.com/2547783/229482599-6663b31d-284f-4aa7-810a-ecfd8c473f06.png">

**✅ Correctly merged `overrideConfig`**

In the new config setup, the CLI `overrideConfig` was previously clobbered by the project-level `metro.config.js` which broke new template apps. This is now fixed.

**FIXED**: `serializer.getModulesRunBeforeMainModule` now overrides [the default value in `metro-config` (metro)](https://github.com/facebook/metro/blob/1e47cb5b3cc289530fb18e402891f9d2816611dd/packages/metro-config/src/defaults/index.js#L66), cc @cipolleschi 

<img width="929" alt="image" src="https://user-images.githubusercontent.com/2547783/229186956-2e69c9df-3d9c-483f-9b5b-5ed9b51e09c3.png">

**FIXED**: `resolver.platforms` now overrides [the default value in `@react-native/metro-config`](https://github.com/facebook/react-native/blob/950472018d137f266358e439ffd17e374ec3686b/packages/metro-config/index.js#L44).

Final config in RN CLI compared to before this PR:

```diff
- platforms: [ 'android', 'ios' ],
+ platforms: [ 'ios', 'android', 'native' ],
```

(`@react-native/metro-config` uses an intentionally simpler default for this option. The former value will be read by standalone Metro CLI, and the latter is overridden by RN CLI based on `ctx.platforms`).

### Fallback 0.71 config setup (project does not extend `@react-native/metro-config`)

**✅ Warning and fallback config behaviour are present**

<img width="2099" alt="image" src="https://user-images.githubusercontent.com/2547783/229482163-b4e2d9da-9bcd-4dcf-9077-5424a18f2375.png">

