### PR TITLE
feat: add `newArchEnabled` and `hermesEnabled` to `info` command

### DIFF
--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -24,7 +24,8 @@
     "semver": "^6.3.0",
     "strip-ansi": "^5.2.0",
     "sudo-prompt": "^9.0.0",
-    "wcwidth": "^1.0.1"
+    "wcwidth": "^1.0.1",
+    "yaml": "^2.2.1"
   },
   "files": [
     "build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13307,6 +13307,11 @@ yaml@^2.1.3:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.3.tgz#9b3a4c8aff9821b696275c79a8bee8399d945207"
   integrity sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==
 
+yaml@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.2.1.tgz#3014bf0482dcd15147aa8e56109ce8632cd60ce4"
+  integrity sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==
+
 yargs-parser@20.2.4:
   version "20.2.4"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.4.tgz#b42890f14566796f85ae8e3a25290d205f154a54"


### PR DESCRIPTION
Summary:
---------
Closes #1809

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:
```
node /path/to/react-native-cli/packages/cli/build/bin.js info
```

In the output you should see `Android` & `iOS` fields:
```
Android:
  hermesEnabled: true
  newArchEnabled: false
iOS:
  hermesEnabled: true
  newArchEnabled: false
```