### PR TITLE
chore: add --force-publish to lerna to sync releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint": "eslint --ext .js,.ts . --cache --report-unused-disable-directives",
     "postinstall": "yarn build",
     "link-packages": "node ./scripts/linkPackages.js",
-    "publish": "yarn build-clean-all && yarn install && lerna publish",
-    "publish:next": "yarn build-clean-all && yarn install && lerna publish --dist-tag next",
+    "publish": "yarn build-clean-all && yarn install && lerna publish --force-publish",
+    "publish:next": "yarn build-clean-all && yarn install && lerna publish --force-publish --dist-tag next",
     "prepare": "husky install"
   },
   "devDependencies": {


### PR DESCRIPTION
Summary:
---------

By default Lerna will only upgrade and publish the packages that were affected by recent changes. However this proves to be tricky, with different CLI sub-packages following different release schedule. To make it less confusing for anyone consuming the packages, this PR adds `--force-publish` flag to the `lerna publish` command, so that all packages are synced even when only one was upgraded.

This goes in line with the recently added `exact` setting to the `lerna.json`, which plays better with the way this CLI is consumed by React Native—through exact versions.

Test Plan:
----------

Doing it locally and now want to upstream it to the command.