### PR TITLE
fix: Drop @react-native/metro-config dep for RN 0.72 config fallback

### DIFF
--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -9,13 +9,14 @@
   "dependencies": {
     "@react-native-community/cli-server-api": "12.0.0-alpha.0",
     "@react-native-community/cli-tools": "12.0.0-alpha.0",
-    "@react-native/metro-config": "^0.73.0",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
     "metro": "0.76.0",
     "metro-config": "0.76.0",
     "metro-core": "0.76.0",
+    "metro-react-native-babel-transformer": "0.76.0",
     "metro-resolver": "0.76.0",
+    "metro-runtime": "0.76.0",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/cli-plugin-metro/src/tools/getDefaultMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/getDefaultMetroConfig.ts
@@ -1,0 +1,87 @@
+import type {InputConfigT} from 'metro-config';
+import path from 'path';
+import type {ConfigLoadingContext} from './loadMetroConfig';
+
+/**
+ * This module reproduces defaults from the @react-native/metro-config package,
+ * used in ./loadMetroConfig.js to provide a soft upgrade process when upgrading
+ * to React Native 0.72.
+ *
+ * These values will be used when:
+ * - RN CLI 11.x or greater is present in a project (from React Native 0.72).
+ * - The project has not yet followed the upgrade instructions to update
+ *   metro.config.js to extend '@react-native/metro-config'.
+ *
+ * Until we remove this file in a future release, updates should be made both
+ * here and in '@react-native/metro-config'. (Note: Updates to these values are
+ * generally rare.)
+ *
+ * TODO(@huntie): Remove this file in a future React Native release.
+ */
+
+/**
+ * @deprecated (React Native 0.72.0) Defaults should be updated here and in
+ *   https://github.com/facebook/react-native/tree/main/package/metro-config/index.js
+ */
+const INTERNAL_CALLSITES_REGEX = new RegExp(
+  [
+    '/Libraries/Renderer/implementations/.+\\.js$',
+    '/Libraries/BatchedBridge/MessageQueue\\.js$',
+    '/Libraries/YellowBox/.+\\.js$',
+    '/Libraries/LogBox/.+\\.js$',
+    '/Libraries/Core/Timers/.+\\.js$',
+    '/Libraries/WebSocket/.+\\.js$',
+    '/Libraries/vendor/.+\\.js$',
+    '/node_modules/react-devtools-core/.+\\.js$',
+    '/node_modules/react-refresh/.+\\.js$',
+    '/node_modules/scheduler/.+\\.js$',
+    '/node_modules/event-target-shim/.+\\.js$',
+    '/node_modules/invariant/.+\\.js$',
+    '/node_modules/react-native/index.js$',
+    '/metro-runtime/.+\\.js$',
+    '^\\[native code\\]$',
+  ].join('|'),
+);
+
+/**
+ * Get the static Metro config defaults for a React Native project.
+ *
+ * @deprecated (React Native 0.72.0) Defaults should be updated here and in
+ *   https://github.com/facebook/react-native/tree/main/package/metro-config/index.js
+ */
+export default function getDefaultMetroConfig(
+  ctx: ConfigLoadingContext,
+): InputConfigT {
+  return {
+    resolver: {
+      resolverMainFields: ['react-native', 'browser', 'main'],
+      unstable_conditionNames: ['require', 'react-native'],
+    },
+    serializer: {
+      getPolyfills: () =>
+        require(path.join(ctx.reactNativePath, 'rn-get-polyfills'))(),
+    },
+    server: {
+      port: Number(process.env.RCT_METRO_PORT) || 8081,
+    },
+    symbolicator: {
+      customizeFrame: (frame: {file?: string}) => {
+        const collapse = Boolean(
+          frame.file && INTERNAL_CALLSITES_REGEX.test(frame.file),
+        );
+        return {collapse};
+      },
+    },
+    transformer: {
+      allowOptionalDependencies: true,
+      assetRegistryPath: 'react-native/Libraries/Image/AssetRegistry',
+      asyncRequireModulePath: require.resolve(
+        'metro-runtime/src/modules/asyncRequire',
+      ),
+      babelTransformerPath: require.resolve(
+        'metro-react-native-babel-transformer',
+      ),
+    },
+    watchFolders: [],
+  };
+}

--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -7,9 +7,9 @@ import {
   mergeConfig,
   resolveConfig,
 } from 'metro-config';
-import {getDefaultConfig} from '@react-native/metro-config';
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import type {Config} from '@react-native-community/cli-types';
+import getDefaultMetroConfig from './getDefaultMetroConfig';
 import {reactNativePlatformResolver} from './metroPlatformResolver';
 
 export type {Config};
@@ -114,8 +114,8 @@ export default async function loadMetroConfig(
 
     const loadedConfig = await loadConfig(
       {cwd: ctx.root, ...options},
-      // Provide @react-native/metro-config defaults on top of Metro defaults
-      getDefaultConfig(ctx.root),
+      // Provide React Native defaults on top of Metro defaults
+      getDefaultMetroConfig(ctx),
     );
 
     return mergeConfig(loadedConfig, overrideConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2673,21 +2673,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.1.0.tgz#e42b1bef12d2415411519fd528e64b593b1363dc"
   integrity sha512-W/J0fNYVO01tioHjvYWQ9m6RgndVtbElzYozBq1ZPrHO/iCzlqoySHl4gO/fpCl9QEFjvJfjPgtPMTMlsoq5DQ==
 
-"@react-native/js-polyfills@^0.73.0":
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.73.0.tgz#d1becae77740c705392122684a55b373e610ab63"
-  integrity sha512-3/+q+l86xvV8xjx29On9/Dn0eWjo5MHYuuALHqyOlQIs3vLk/rQB4rn4izObiurhH3utXxqVnbOk+TB9yJo4ng==
-
-"@react-native/metro-config@^0.73.0":
-  version "0.73.0"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-config/-/metro-config-0.73.0.tgz#7601d2f4ba2252a4e359f8fda21008daf5f31eb2"
-  integrity sha512-b+q8Ot6nxPE2PXEua20Q0vhXYpVtVjUaTX/hv+7mL5hLzKeIWq/bIxF04GLWT93BBjGSlL0xaZ7iGIQNN75Hog==
-  dependencies:
-    "@react-native/js-polyfills" "^0.73.0"
-    metro-config "0.76.0"
-    metro-react-native-babel-transformer "0.76.0"
-    metro-runtime "0.76.0"
-
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"


### PR DESCRIPTION
## Context

### React Native Metro config → React Native repo (https://github.com/facebook/react-native/pull/36502)

This is a follow up to https://github.com/react-native-community/cli/pull/1896.

Unfortunately the most recent CLI release was auto-consumed in React Native's CI, exposing a blocker where we could not consume the (repo-)circular dependency `react-native` → `@react-native-community/cli-plugin-metro` → `@react-native/metro-config` — I 100% jumped the gun on this setup(!).

While this is now mitigated by the new CLI release process, and possible in practice, **we're opting to remove this circular setup** as it would introduce maintenance headaches while we are working across two repos.

Changelog: Internal

---

This is an architectural simplification targeting React Native `main` (0.73). However it is also worth cherry picking this commit to RN CLI `10.x` (targeting RN 0.72), so that we can once again bump all local Metro dependencies here (and replicate those bumps in both `11.x` and `10.x`). cc @robhogan @cipolleschi 

**Open as https://github.com/react-native-community/cli/pull/1901**.

---

## Changes

- Drop `@react-native/metro-config` dependency from `cli-plugin-metro`.
- Restore reproduced `@react-native/metro-config` default config within `cli-plugin-metro` (to be used in the fallback case only).
    - This is now equivalent to the [original (abandoned) version of #1875](https://github.com/react-native-community/cli/commit/598f1a0dec7875f63e6a2a1ec677849305944357).
    - Ideally, we will only keep these values in this repo for the next 1-2 versions of React Native. Once removed, we will still have the throw-descriptive-error fallback for unmigrated projects.

Note: An alternative approach for this is `peerDependencies`, but given the recent issues and how this might affect strict internal and open source CI, I'm opting for the absolutely bulletproof solution.

## Test Plan

(Repeats test plan instructions from https://github.com/react-native-community/cli/pull/1896).

| New 0.72 config setup (project extends `@react-native/metro-config`) | Fallback 0.71 config setup (project does not extend `@react-native/metro-config`) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/2547783/230341998-8362cc27-4a5b-4419-a5ae-324c67ed86eb.png) | ![image](https://user-images.githubusercontent.com/2547783/230342054-9302486d-fe5c-438a-88b0-278a39e88a1e.png) |

✅ Identical configs are produced
*(With only path changes from `yarn link`)*

![image](https://user-images.githubusercontent.com/2547783/230342115-a92c9912-11fa-4b4f-bdf9-bb44214f9cbb.png)

