### PR TITLE
Adding RN docs link for JDK install error

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -145,7 +145,7 @@ function createInstallError(error: Error & {stderr: string}) {
         guide: 'native',
         platform: 'android',
       }),
-    )} and follow the React Native CLI QuickStart guide to install the compatible version of jdk `;
+    )} and follow the React Native CLI QuickStart guide to install the compatible version of JDK.`;
   }
 
   return new CLIError(

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -10,6 +10,7 @@ import chalk from 'chalk';
 import execa from 'execa';
 import {Config} from '@react-native-community/cli-types';
 import {
+  link,
   logger,
   CLIError,
   printRunDoctorTip,
@@ -137,6 +138,14 @@ function createInstallError(error: Error & {stderr: string}) {
     message = `Please accept all necessary Android SDK licenses using Android SDK Manager: "${chalk.bold(
       '$ANDROID_HOME/tools/bin/sdkmanager --licenses',
     )}."`;
+  } else if (stderr.includes('requires Java')) {
+    message = `Looks like your Android environment is not properly set. Please go to ${chalk.dim.underline(
+      link.docs('environment-setup', {
+        hash: 'jdk-studio',
+        guide: 'native',
+        platform: 'android',
+      }),
+    )} and follow the React Native CLI QuickStart guide to install the compatible version of jdk `;
   }
 
   return new CLIError(


### PR DESCRIPTION
Summary:
---------
Upon getting gradle errors about JDK like this : 

https://gist.github.com/lunaleaps/21f9b72f4a1e617a8fb04a27c00e527b#file-gistfile1-txt-L16

It was unclear how to install the right JDK. There is no link to RN docs for our recommendation to install the right jdk?

Hence, in case we are sure about the error to be pertaining to JDK install, we can handle this common failure and make the errors more helpful. Also seen in : https://github.com/facebook/react-native/issues/33416

NOTE : The print Doctor Tip is part of both errors reported which is also helpful to fix your current state.

Test Plan:
----------

1. Build cli codebase using : `node ./scripts/build.js && yarn build:debugger`
2. `cd packages/cli-platform-android`
3. Link packages using : `yarn link`
4. In RN app AwesomeProject, run `yarn link "@react-native-community/cli-platform-android"` to see successful linking :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % yarn link "@react-native-community/cli-platform-android"
yarn link v1.22.19
warning ../package.json: No license field
success Using linked package for "@react-native-community/cli-platform-android".
✨  Done in 0.02s.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```

BEFORE :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % npx react-native run-android
info Starting JS server...
info Launching emulator...
error Failed to launch emulator. Reason: The emulator (Pixel_5_API_33) quit before it finished opening. You can try starting the emulator manually from the terminal with: /opt/android_sdk/emulator/emulator @Pixel_5_API_33.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.

info 💡 Tip: Make sure that you have set up your development environment correctly, by running react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor 


FAILURE: Build failed with an exception.

* Where:
Build file '/Users/arushikesarwani/AwesomeProject/android/app/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin 'com.android.internal.application'.
   > Android Gradle plugin requires Java 11 to run. You are currently using Java 1.10.
      Your current JDK is located in /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1m 15s

error Failed to install the app. Command failed: ./gradlew tasks FAILURE: Build failed with an exception. * Where:
Build file '/Users/arushikesarwani/AwesomeProject/android/app/build.gradle' line: 1 * What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin 'com.android.internal.application'. > Android Gradle plugin requires Java 11 to run. You are currently using Java 1.10. Your current JDK is located in /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home You can try some of the following options: - changing the IDE settings. - changing the JAVA_HOME environment variable. - changing `org.gradle.java.home` in `gradle.properties`. * Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights. * Get more help at https://help.gradle.org BUILD FAILED in 1m 15s > Task :react-native-gradle-plugin:compileKotlin
> Task :react-native-gradle-plugin:compileJava NO-SOURCE
> Task :react-native-gradle-plugin:pluginDescriptors
> Task :react-native-gradle-plugin:processResources
> Task :react-native-gradle-plugin:classes
> Task :react-native-gradle-plugin:inspectClassesForKotlinIC
> Task :react-native-gradle-plugin:jar
arushikesarwani@arushikesarwani-mbp AwesomeProject %
```

AFTER :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % react-native run-android
info Starting JS server...
info Launching emulator...
error Failed to launch emulator. Reason: The emulator (Pixel_5_API_33) quit before it finished opening. You can try starting the emulator manually from the terminal with: /opt/android_sdk/emulator/emulator @Pixel_5_API_33.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.

info 💡 Tip: Make sure that you have set up your development environment correctly, by running react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor 


FAILURE: Build failed with an exception.

* Where:
Build file '/Users/arushikesarwani/AwesomeProject/android/app/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':app'.
> Failed to apply plugin 'com.android.internal.application'.
   > Android Gradle plugin requires Java 11 to run. You are currently using Java 1.10.
      Your current JDK is located in /Library/Java/JavaVirtualMachines/jdk-10.0.1.jdk/Contents/Home
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s

error Failed to install the app. Looks like your Android environment is not properly set. Please go to https://reactnative.dev/docs/0.71/environment-setup?os=macos&platform=android&guide=native#jdk-studio and follow the React Native CLI QuickStart guide to install the compatible version of JDK..
info Run CLI with --verbose flag for more details.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```
