### PR TITLE
refactor: remove useless parameter

### DIFF
--- a/packages/cli-doctor/src/tools/installPods.ts
+++ b/packages/cli-doctor/src/tools/installPods.ts
@@ -13,7 +13,6 @@ import {Loader} from '../types';
 
 async function runPodInstall(
   loader: Loader,
-  directory: string,
   shouldHandleRepoUpdate: boolean = true,
 ) {
   try {
@@ -37,7 +36,7 @@ async function runPodInstall(
      */
     if (stderr.includes('pod repo update') && shouldHandleRepoUpdate) {
       await runPodUpdate(loader);
-      await runPodInstall(loader, directory, false);
+      await runPodInstall(loader, false);
     } else {
       loader.fail();
       logger.error(stderr);
@@ -117,13 +116,7 @@ async function installCocoaPods(loader: Loader) {
   }
 }
 
-async function installPods({
-  directory,
-  loader,
-}: {
-  directory: string;
-  loader?: Loader;
-}) {
+async function installPods(loader?: Loader) {
   loader = loader || new NoopLoader();
   try {
     if (!fs.existsSync('ios')) {
@@ -152,7 +145,7 @@ async function installPods({
       await installCocoaPods(loader);
     }
 
-    await runPodInstall(loader, directory);
+    await runPodInstall(loader);
   } finally {
     process.chdir('..');
   }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -140,7 +140,6 @@ async function createFromTemplate({
         npm,
         loader,
         root: projectDirectory,
-        directory,
       });
     } else {
       loader.succeed('Dependencies installation skipped');
@@ -154,12 +153,10 @@ async function createFromTemplate({
 }
 
 async function installDependencies({
-  directory,
   npm,
   loader,
   root,
 }: {
-  directory: string;
   npm?: boolean;
   loader: Loader;
   root: string;
@@ -173,7 +170,7 @@ async function installDependencies({
   });
 
   if (process.platform === 'darwin') {
-    await installPods({directory, loader});
+    await installPods(loader);
   }
 
   loader.succeed();

--- a/packages/cli/src/commands/upgrade/upgrade.ts
+++ b/packages/cli/src/commands/upgrade/upgrade.ts
@@ -216,7 +216,7 @@ const installDeps = async (
   }
 };
 
-const installCocoaPodsDeps = async (projectDir: string) => {
+const installCocoaPodsDeps = async () => {
   if (process.platform === 'darwin') {
     try {
       logger.info(
@@ -224,9 +224,7 @@ const installCocoaPodsDeps = async (projectDir: string) => {
           '(this may take a few minutes)',
         )}`,
       );
-      await installPods({
-        directory: projectDir.split('/').pop() || '',
-      });
+      await installPods();
     } catch (error) {
       if ((error as UpgradeError).stderr) {
         logger.debug(
@@ -372,7 +370,7 @@ async function upgrade(argv: Array<string>, ctx: Config) {
   if (patch === '') {
     logger.info('Diff has no changes to apply, proceeding further');
     await installDeps(projectDir, newVersion, repoName);
-    await installCocoaPodsDeps(projectDir);
+    await installCocoaPodsDeps();
 
     logger.success(
       `Upgraded React Native to v${newVersion} 🎉. Now you can review and commit the changes`,
@@ -413,7 +411,7 @@ async function upgrade(argv: Array<string>, ctx: Config) {
       }
     } else {
       await installDeps(projectDir, newVersion, repoName);
-      await installCocoaPodsDeps(projectDir);
+      await installCocoaPodsDeps();
       logger.info('Running "git status" to check what changed...');
       await execa('git', ['status'], {stdio: 'inherit'});
     }


### PR DESCRIPTION
Summary:
---------
- since this [change](https://github.com/react-native-community/cli/pull/1708/files#diff-40d53f615b04d356709049813d8b41a91dc15a6be511a0351cf163a97a4de007R49) was merged, the parameter `directory` of function `installPods` is useless. So I removed.
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
 - use init command, still work fine.
 - ![image](https://user-images.githubusercontent.com/39456032/231129568-f3a75f6b-9e4e-4292-b6ae-016bde0491c7.png)


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
