### PR TITLE
fix: str.replace not a function issue

### DIFF
--- a/packages/cli-platform-ios/src/tools/getProjectInfo.ts
+++ b/packages/cli-platform-ios/src/tools/getProjectInfo.ts
@@ -1,15 +1,20 @@
-import {CLIError} from '@react-native-community/cli-tools';
 import execa from 'execa';
 import {IosProjectInfo} from '../types';
 
 export function getProjectInfo(): IosProjectInfo {
   try {
-    const {project} = JSON.parse(
-      execa.sync('xcodebuild', ['-list', '-json']).stdout,
-    );
-
+    const out = execa.sync('xcodebuild', ['-list', '-json']).stdout;
+    const {project} = JSON.parse(out);
     return project;
   } catch (error) {
-    throw new CLIError(error as any);
+    if (
+      (error as Error)?.message &&
+      (error as Error).message.includes('xcodebuild: error:')
+    ) {
+      const match = (error as Error).message.match(/xcodebuild: error: (.*)/);
+      const err = match ? match[0] : error;
+      throw new Error(err as any);
+    }
+    throw new Error(error as any);
   }
 }

--- a/packages/cli-tools/src/errors.ts
+++ b/packages/cli-tools/src/errors.ts
@@ -24,5 +24,5 @@ export class CLIError extends Error {
  */
 export class UnknownProjectError extends Error {}
 
-export const inlineString = (str: string) =>
+export const inlineString = (str: string = '') =>
   str.replace(/(\s{2,})/gm, ' ').trim();


### PR DESCRIPTION
Summary:
---------

`xcodebuild` can throw but when it does inside `JSON.parse` we won't get any error in `catch` block which in turn will cause another error `Error: str.replace is not a function` in CLIError's constructor. 

Partially related to #1883 and #1908  -not a real fix for those issues but at least it will make debugging bit better :)







