### PR TITLE
chore: Upgrade metro dependencies to 0.76.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^4.0.0",
     "lint-staged": "^13.1.0",
-    "metro-memory-fs": "0.76.0",
+    "metro-memory-fs": "0.76.2",
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "slash": "^3.0.0",

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -11,20 +11,16 @@
     "@react-native-community/cli-tools": "12.0.0-alpha.2",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
-    "metro": "0.76.0",
-    "metro-config": "0.76.0",
-    "metro-core": "0.76.0",
-    "metro-react-native-babel-transformer": "0.76.0",
-    "metro-resolver": "0.76.0",
-    "metro-runtime": "0.76.0",
+    "metro": "0.76.2",
+    "metro-config": "0.76.2",
+    "metro-core": "0.76.2",
+    "metro-react-native-babel-transformer": "0.76.2",
+    "metro-resolver": "0.76.2",
+    "metro-runtime": "0.76.2",
     "readline": "^1.3.0"
   },
   "devDependencies": {
-    "@react-native-community/cli-types": "12.0.0-alpha.2",
-    "@types/metro": "^0.76.0",
-    "@types/metro-config": "^0.76.1",
-    "@types/metro-core": "^0.76.0",
-    "@types/metro-resolver": "^0.76.1"
+    "@react-native-community/cli-types": "12.0.0-alpha.2"
   },
   "files": [
     "build",

--- a/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
@@ -9,7 +9,7 @@
 import Server from 'metro/src/Server';
 // @ts-ignore - no typed definition for the package
 const outputBundle = require('metro/src/shared/output/bundle');
-import type {BundleOptions} from 'metro/shared/types';
+import type {BundleOptions} from 'metro/src/shared/types';
 import type {ConfigT} from 'metro-config';
 import path from 'path';
 import chalk from 'chalk';

--- a/packages/cli-plugin-metro/src/commands/start/runServer.ts
+++ b/packages/cli-plugin-metro/src/commands/start/runServer.ts
@@ -7,7 +7,7 @@
 
 // @ts-ignore untyped metro
 import Metro from 'metro';
-import type {Server} from 'metro';
+import type Server from 'metro/src/Server';
 import type {Middleware} from 'metro-config';
 import {Terminal} from 'metro-core';
 import path from 'path';
@@ -101,7 +101,6 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
     secure: args.https,
     secureCert: args.cert,
     secureKey: args.key,
-    hmrEnabled: true,
     // @ts-ignore - ws.Server types are incompatible
     websocketEndpoints,
   });

--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -89,19 +89,15 @@ export default async function loadMetroConfig(
 
   const projectConfig = await resolveConfig(undefined, ctx.root);
 
-  // @ts-ignore resolveConfig return value is mistyped
   if (projectConfig.isEmpty) {
     throw new CLIError(`No metro config found in ${ctx.root}`);
   }
 
-  // @ts-ignore resolveConfig return value is mistyped
   logger.debug(`Reading Metro config from ${projectConfig.filepath}`);
 
   if (
     !/['"']@react-native\/metro-config['"']/.test(
-      fs
-        // @ts-ignore resolveConfig return value is mistyped
-        .readFileSync(projectConfig.filepath, 'utf8'),
+      fs.readFileSync(projectConfig.filepath, 'utf8'),
     )
   ) {
     logger.warn(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2692,11 +2692,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/babel__code-frame@*":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/babel__code-frame/-/babel__code-frame-7.0.3.tgz#eda94e1b7c9326700a4b69c485ebbc9498a0b63f"
-  integrity sha512-2TN6oiwtNjOezilFVl77zwdNPwQWaDBBCCWWxyo1ctiO3vAtd7H/aB/CBJdw9+kqq3+latD0SXoedIuHySSZWw==
-
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.9"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.9.tgz#77e59d438522a6fb898fa43dc3455c6e72f3963d"
@@ -2903,79 +2898,6 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
-"@types/metro-babel-transformer@*":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro-babel-transformer/-/metro-babel-transformer-0.76.0.tgz#59ecb66e4168db5fbe712c0636eefdeee4ffde95"
-  integrity sha512-ctZPAeNrR9HOvH968gCMPa2YAFDkGhqhoceYlXB+Tp/eQu/crzUR3I7j9UKv8t9enuvd5OWLAQm3hJz+QCtPZg==
-  dependencies:
-    "@types/metro-source-map" "*"
-
-"@types/metro-cache@*":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro-cache/-/metro-cache-0.76.0.tgz#7762fde7172bba2779ec7355fa4f31a511abf2ee"
-  integrity sha512-5YsoNnEWQ3X2OI1whVItKeL7iMLHIQg3aWKHGsK3Idau6MTTSQMjw/oh2SbTiiHdzrBaXJfQ25ApMPCMMdurDg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/metro-config@*", "@types/metro-config@^0.76.1":
-  version "0.76.1"
-  resolved "https://registry.yarnpkg.com/@types/metro-config/-/metro-config-0.76.1.tgz#7deab1b73132f84c04478610ac840bf92e0851e1"
-  integrity sha512-xA82orx+zGHTl3Tky4pUDfFvWXAm+NtGR71Ux45KzJrX/ooppYPZGy/wez4L78pUcHEt4KQoIefoONvNeb4F3A==
-  dependencies:
-    "@types/metro" "*"
-    "@types/metro-cache" "*"
-    "@types/metro-resolver" "*"
-    "@types/metro-transform-worker" "*"
-
-"@types/metro-core@*", "@types/metro-core@^0.76.0":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro-core/-/metro-core-0.76.0.tgz#ce9f425abd48431681922ac4f13a3efc9fd1d0e3"
-  integrity sha512-7iBXd1CiBNHVBPrVbjG2xy8KJq1l6aohQftyqH89FZL/h1cwxxgxt3QtdeYGN7ATOgqAl7iI3BkRd2th4diBvA==
-  dependencies:
-    "@types/node" "*"
-
-"@types/metro-file-map@*":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro-file-map/-/metro-file-map-0.76.0.tgz#feb5573c57ee5c7d53268c1bf69c00f1c3bfccde"
-  integrity sha512-61sPxJZG5zEn/8grZfapDOBN517Z4ejHjXrcnMkudBxLrtCxLOcC495JRIfEn7mvV776Z488mNYGMfoPApht2A==
-  dependencies:
-    "@types/metro-config" "*"
-
-"@types/metro-resolver@*", "@types/metro-resolver@^0.76.1":
-  version "0.76.1"
-  resolved "https://registry.yarnpkg.com/@types/metro-resolver/-/metro-resolver-0.76.1.tgz#bf0f6f7224fd5b22571abc4b8cbe9f0eed6104d3"
-  integrity sha512-GAzz8yV7azX1RWmRSLsdPe1ml2vOmaJftirLR/7lSMmDOPJ8G/n8VdnjuoI0uOvth7EmFRwyGBBzF7nceenvOQ==
-
-"@types/metro-source-map@*":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro-source-map/-/metro-source-map-0.76.0.tgz#c3b4bdd7c401b890165cf3274ffa3acc839cf191"
-  integrity sha512-nxx7MjnQJKzftTMDp6voMqdHjy4rL0gHeJHG2LYLcqdl9gs3sxeoAC1wx39SoeSYgsadWUvnj7GrJWMhP4oGvg==
-
-"@types/metro-transform-worker@*":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro-transform-worker/-/metro-transform-worker-0.76.0.tgz#8b799647cabfa161ab0c13193b9c88fed2951668"
-  integrity sha512-jCpU73gb49YKKK8qtGzjMSh86HWG0IQiBgbUYU3WhXtReCVuA2Sy9sXXCiF9kZvnsqtRNbg2MR4ww8i1XEg/nw==
-  dependencies:
-    "@types/metro" "*"
-    "@types/metro-babel-transformer" "*"
-    "@types/metro-source-map" "*"
-
-"@types/metro@*", "@types/metro@^0.76.0":
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/@types/metro/-/metro-0.76.0.tgz#fe6eadcab1444b3a0398aa1a9a87d09643d37879"
-  integrity sha512-3WIyw3e0QxF7XBvFuQIpBqui/7lYtFE8xpFIMKY+i+U9ERdbktBOEGXcN6gqG56BHq89502Ts5fxpOSrLEH3fQ==
-  dependencies:
-    "@types/babel__code-frame" "*"
-    "@types/metro-babel-transformer" "*"
-    "@types/metro-config" "*"
-    "@types/metro-core" "*"
-    "@types/metro-file-map" "*"
-    "@types/metro-resolver" "*"
-    "@types/metro-source-map" "*"
-    "@types/metro-transform-worker" "*"
-    "@types/ws" "*"
-    "@types/yargs" "*"
-
 "@types/mime@*", "@types/mime@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.1.tgz#dc488842312a7f075149312905b5e3c0b054c79d"
@@ -3095,13 +3017,6 @@
   resolved "https://registry.yarnpkg.com/@types/wcwidth/-/wcwidth-1.0.0.tgz#a58f4673050f98c46ae8f852340889343b21a1f5"
   integrity sha512-X/WFfwGCIisEnd9EOSsX/jt7BHPDkcvQVYwVzc1nsE2K5bC56mWKnmNs0wyjcGcQsP7Wxq2zWSmhDDbF5Z7dDg==
 
-"@types/ws@*":
-  version "8.5.4"
-  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.4.tgz#bb10e36116d6e570dd943735f86c933c1587b8a5"
-  integrity sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ws@^7.4.7":
   version "7.4.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
@@ -3113,13 +3028,6 @@
   version "21.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.0.tgz#0c60e537fa790f5f9472ed2776c2b71ec117351b"
   integrity sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==
-
-"@types/yargs@*":
-  version "17.0.22"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-17.0.22.tgz#7dd37697691b5f17d020f3c63e7a45971ff71e9a"
-  integrity sha512-pet5WJ9U8yPVRhkwuEIp5ktAeAqRZOq4UdAyWLWzxbtpyXnzbtLdKiXAjJzi/KLmPGS9wk86lUFWZFN6sISo4g==
-  dependencies:
-    "@types/yargs-parser" "*"
 
 "@types/yargs@^15.0.0":
   version "15.0.14"
@@ -3212,13 +3120,6 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
-
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
 
 accepts@^1.3.7:
   version "1.3.8"
@@ -5877,11 +5778,6 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
-
 eventemitter3@^4.0.4:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -7966,14 +7862,6 @@ jest-serializer@^26.6.2:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-serializer@^27.0.6:
-  version "27.5.1"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.5.1.tgz#81438410a30ea66fd57ff730835123dea1fb1f64"
-  integrity sha512-jZCyo6iIxO1aqUxpuBlwTDMkzOAJS4a3eYz3YzgxxVQFwLeSA7Jfq5cbqCY+JLvTDrWirgusI/0KwxKMgrdf7w==
-  dependencies:
-    "@types/node" "*"
-    graceful-fs "^4.2.9"
-
 jest-snapshot-serializer-raw@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot-serializer-raw/-/jest-snapshot-serializer-raw-1.1.0.tgz#1d7f09c02f3dbbc3ae70b5b7598fb2f45e37d6c8"
@@ -8772,109 +8660,103 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.76.0.tgz#cb3854ee74a1ecba40680af1b6625aa46928c3c0"
-  integrity sha512-yBF8eJluya2iofhu8nZDXr9It/7bUcgXiKpFPrkiOWcMFY/jqzEbcavQ8uK3lFeXNRyvj0iaKaFs7Qo+2QJfow==
+metro-babel-transformer@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.76.2.tgz#51a6136f554131fb52ac04ec93774267f50fa578"
+  integrity sha512-NRNjVYDs5174K3oS54W67XQ9oUJDDVNJsqz45cJycbxfAx0GKVpvhjvoRQ2LmU0I0IbLL8HQtO/6aQ9No4Udwg==
   dependencies:
     "@babel/core" "^7.20.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.76.0"
+    metro-source-map "0.76.2"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.76.0.tgz#0ab9513c8fc0392e7fde5d4473f220a9352e2cf0"
-  integrity sha512-Oyz+Yo/CG56kMXsDuioLf80MHwUqRzhOjaFsDvam3+gpc9rIGhnFL4ODhc6Qlum5auPRMT9XsksScErouft2tA==
+metro-cache-key@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.76.2.tgz#0d7c3903a1fb2845970486c5c942d319db0bf525"
+  integrity sha512-30kvupiiDVvglywBn8lpNtpcedHXgI7M9Nsh5HRJDq6GF3+4/nrip0UGaa2XRfD1GyHD8B1TpMskvF3+zLKzmw==
 
-metro-cache@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.76.0.tgz#b68d284fa46e74fe6cc7b822a9f3028f8824f952"
-  integrity sha512-J+OkOcIWrJisoXw6fXwWzeR1q4IuysMIKG8v/DWmKUOy8VI2c0gKXUW0mBfEWq6y3w0Czl94/xh1x7X0YLsTNg==
+metro-cache@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.76.2.tgz#d8beafd7f8063a831edef254af0b7f98a3b663c3"
+  integrity sha512-gSSfVBNvgqbveWChmC1Om/Ri61JvjOYzmFU1XgW98cNzMtxGHC5WFi3n7u9/kkIR9quiTfyOyxHpkovqJhOixw==
   dependencies:
-    metro-core "0.76.0"
+    metro-core "0.76.2"
     rimraf "^3.0.2"
 
-metro-config@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.76.0.tgz#fe38e555faa1c6fa7eb2fbe9fa504844b1156154"
-  integrity sha512-5bfOtovHM7qjSobGBGRWXGh9+wMJlXHgot1LhjL3YTaNLUY42umbzdNC7dPcrGNLHH3MXTlG4cyNeCWZxtm6Hg==
+metro-config@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.76.2.tgz#a629f2177c70c1745f5e15ad88ab9ae6437b041a"
+  integrity sha512-BxbmEUlglCK4GJK8beGCXm3C38ri/E0/lFV563YPuyE9OvtG1HeslvYbNAuGt3NzdFEzH4JjaQ7xeKQw5tYYvg==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.76.0"
-    metro-cache "0.76.0"
-    metro-core "0.76.0"
-    metro-runtime "0.76.0"
+    metro "0.76.2"
+    metro-cache "0.76.2"
+    metro-core "0.76.2"
+    metro-runtime "0.76.2"
 
-metro-core@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.76.0.tgz#16f8a73d40173ffe659a2de8b727bb2c84a2846e"
-  integrity sha512-LRNWBpvHWcMeK+LZ74VZRo6QfU8izh6BmmqeW57HnZec69JQ1uODV6e7gQig6PWH89aMzhq8QKQr0dPDUGDYIg==
+metro-core@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.76.2.tgz#e85f8006362b6d1a77e2b024796504f94cc3ddd0"
+  integrity sha512-LXUTPqJLp6J5Ro7IWryd0Q/Lj7AX00fgoJhFfwdOr5RDEkHyzQNeHgObCSOBSqUqDHeEY8hEWD0ugFTA7iIyaA==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.76.0"
+    metro-resolver "0.76.2"
 
-metro-file-map@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.76.0.tgz#a27586bd4e22112864e76ba49bda6bb851bf5e49"
-  integrity sha512-ifhMf75SlkSR8QcRBK1ecDwt9APZNEMWG7U8RIhtoDAtBYKuTbjjHNJiAwAU8UPE78m/Aryz6A+5cwpuAvSGrA==
+metro-file-map@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.76.2.tgz#a092c2c9c20c855c0d4ecdce784a9c614804d293"
+  integrity sha512-thDwa/rAePaXBsW62wuRGQbi2/2BoYbRHhfXPmI8MK3TavPfjnX/tPV57+Gx4yy2MFq4AR4mI1VyMsj8vnsTBg==
   dependencies:
-    abort-controller "^3.0.0"
     anymatch "^3.0.3"
     debug "^2.2.0"
     fb-watchman "^2.0.0"
     graceful-fs "^4.2.4"
     invariant "^2.2.4"
     jest-regex-util "^27.0.6"
-    jest-serializer "^27.0.6"
     jest-util "^27.2.0"
     jest-worker "^27.2.0"
     micromatch "^4.0.4"
+    node-abort-controller "^3.1.1"
     nullthrows "^1.1.1"
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-hermes-compiler@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-hermes-compiler/-/metro-hermes-compiler-0.76.0.tgz#2c4cca498011cab799434527544c0303eb12b806"
-  integrity sha512-ZW1jHtErMp327aPEkhHP69dLmtbzGj7ajsNFEwayoz/tZtyrTXT+f/8j6QVynIBMMpnAJkSIlinNo9fgIbE08w==
-
-metro-inspector-proxy@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.76.0.tgz#01af31de7cd09d9ec5a204b73fc786e3f4ddc793"
-  integrity sha512-1RCMmXzcvDsFvJyfRqzUl2B3r0FTgxW37WlH2c2tMhqVtGxobDGHn5cFySeaCLvKSHps0NELeB+1SF7MB9scxA==
+metro-inspector-proxy@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.76.2.tgz#9b60dd609d2a6a19fda4e796a53d45e81d76e409"
+  integrity sha512-K7ThshkczlHbFJhBDdx1Bxrls3LlQ1rnQINqXzBG2sDkOrPx2seV8s1ApaiUqDCdt803Qo9eoTYTI/vOHFmJxQ==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
     node-fetch "^2.2.0"
     ws "^7.5.1"
-    yargs "^17.5.1"
+    yargs "^17.6.2"
 
-metro-memory-fs@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.76.0.tgz#d3980e40f61cad321fafdb5ac4ac63667dda07a1"
-  integrity sha512-RIC4LklKPAjrrymh4OSC524R3gcRprtxzcToKMAuB60ibrkz+mY5BoLq0zMvPKE4BG9so/xZ5EF1Axa8SDn6rQ==
+metro-memory-fs@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.76.2.tgz#1dcc14e0b66e382d9150579c1cd4ca7778415054"
+  integrity sha512-vA1ua7QrsIBqkb9hI4z+v24dRTEO7ykIuG8rrwZJ54k1nMbB+01epGMooaVgAYPGjwqDdhg+uV5UpKW4ueTLzA==
 
-metro-minify-terser@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.76.0.tgz#49cef5fc0c2ae9b2ed76a8832132934c3a10de4c"
-  integrity sha512-dxaE/pvFDFEvXoNHuiXbA2Tw/jT1MD3B4a9AM+aYPWJBh3PdT9XM1HdzumyJldtZpCn5yka4maYSrtuebKgOyw==
+metro-minify-terser@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.76.2.tgz#f6b85bcd68f97f49f736b1eb505e7208cd72d95d"
+  integrity sha512-JaJ0qlNXtzPlv8JxlfuDRWmNWFZBJ3w5+vQ4tqAIA68ComTpm9DJ7pbde3DUpOts/zM4swsDAPhtu3HuhRTQhA==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.76.0.tgz#a34a64614b5abd364674dc6c0ff567d43d2b525c"
-  integrity sha512-Fuoxr5wLw/2/BUmhJqmIsfNZK+x8BK/DDXID5CZvHmZj5PdN4MN2WGWkM/F4EOw2t1YxbJ1hFSXM8skfSZ7jkw==
+metro-minify-uglify@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.76.2.tgz#f3a22c35e9f2b32213df44652aef95df142ccd43"
+  integrity sha512-eye94ZTWhiF3eG6+MDdvn6WSVMeQed1gB/QqXZCFrBxk6GAfeosMahwpgygc9hFIXdgc7Qv8z7F2T+hWfh+aAQ==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.0.tgz#440a0e8965b2eb01afa391ef95575faeed67636b"
-  integrity sha512-2sM6dy9uAbuQlg7l/VOdiudUUMFRkABJ1YLkZU6Fpqi/rJCXn4fbF0pO+TwCFbBYNIQBY50clv9RPvD2n64hXg==
+metro-react-native-babel-preset@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.2.tgz#dab4ca4b594bb47780adf5987c6b3b9cb41e767b"
+  integrity sha512-Kzi4JhEzwrPOuv3OHjDZvvlPTjInNoIV8QKBRyLTzx7TJuA5a2xReo0lz4sG4x9Bcv1XjKkKRmYUgS9V1I820w==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -8916,62 +8798,62 @@ metro-react-native-babel-preset@0.76.0:
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.0.tgz#8c8872f0d3a0ec9dad2480df53c92c10eac92c79"
-  integrity sha512-mLyUiGq2qPoEwV3oncD82HOtM4wAl8YmXtGY17D4iqH6/5pE32lRnDDYt0WnJYACZDs3RB3MhTjGCM7rJNwn/A==
+metro-react-native-babel-transformer@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.2.tgz#84865806bcbd9376db8190c33f2b7cd178fa342b"
+  integrity sha512-49Jv8fqM+hN1Ocl1hcpRaZbVpUmT98x1+ISPToKMNn2ZnXzwsDHQ00mK+AETLrKBWOWn/Aol/zhmWDb2CwUqlw==
   dependencies:
     "@babel/core" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.76.0"
-    metro-react-native-babel-preset "0.76.0"
-    metro-source-map "0.76.0"
+    metro-babel-transformer "0.76.2"
+    metro-react-native-babel-preset "0.76.2"
+    metro-source-map "0.76.2"
     nullthrows "^1.1.1"
 
-metro-resolver@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.76.0.tgz#3fa778adbab30859023a89e7a1241f4eb68171f2"
-  integrity sha512-bU6HvKzPJOHGoe9na+tUa0g3pZqMUaSGE+noFx2qeSMtoIgOYkDzmuU9ZOAGcUOz0qJJtGs+QmgM+nBqfSS/pQ==
+metro-resolver@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.76.2.tgz#497dd8dc04a8c86b25629544cb0fba4f56d7b0e1"
+  integrity sha512-sLLwhxd31fYVxaOSzhJ8Mumi211qHOkurC2Gh+4QSDFNKDZecovMgV/W5/oIQWJBCX/mi/YkbmnpwLCUvXEoWw==
 
-metro-runtime@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.76.0.tgz#ccc4721010a24d4919bf50e9146d06d28266efb3"
-  integrity sha512-mEt1uWCYVwyvHYhCfsRXp7mqIBgOAYkocgousH5jwi07MwSAAvaDCvyRBUgtFohDQpL4j4N/QxNYExDDqUuuQw==
+metro-runtime@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.76.2.tgz#2f112f9a550737945fceda14dd4882759859331a"
+  integrity sha512-247IYGyA8tS2wkDjq0Ju3vm6Tz79nb7+DPHgMpl71nsh0/kQvgc43bEJLhMwOqouRUcJihN0MgPWUb1xNI1rUg==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-source-map@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.76.0.tgz#0f05263dc4648f654feaab36dae799b7118b36c0"
-  integrity sha512-tAXlHI6EOtRTkhXynZbe/as7pBDBxDaHftq/7pV3QCGyLeSaTNy6wzXI5ewr3kTuZxtBXktQH/Zl0rhKO8DGMA==
+metro-source-map@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.76.2.tgz#e66cb8f7109c8c4bfd8732e6a32a2082378e0847"
+  integrity sha512-fr8mSpn7Z0oYhTdcFCJsrtOX0qgOoDBw9I5mOTZBacMyItiiFYrb+2zyVacBQwrxyo/DqAJaFd3NbdbIInIyvw==
   dependencies:
     "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.76.0"
+    metro-symbolicate "0.76.2"
     nullthrows "^1.1.1"
-    ob1 "0.76.0"
+    ob1 "0.76.2"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.76.0.tgz#3745875473d4fab544d054b90522df6779b41d37"
-  integrity sha512-duq4RbeHDUzYQu4nzU2zWfBdG1YEXpaMqpLSvsXn5WJF3KK+v+BbtBvmo0zrEvzeA7kczNMxtZ97Yev9rqeYrw==
+metro-symbolicate@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.76.2.tgz#4a270f48a1c22dc5e1f185f38c4384cb65f87c75"
+  integrity sha512-yI0eBJK+FeAwNYnyoZve5hq8RplpLTUDqShnmtHmflMw1WWRyjqrxtGg6ctjgV6qQqytnodFAWd31uQQ4ag0Pw==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.76.0"
+    metro-source-map "0.76.2"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.76.0.tgz#dbab337561444cd9cd0882365a5b13b03bb92433"
-  integrity sha512-Pl84l7LZAI+RXVP3+Hv+vLQwv4I3dHE91lM+Lw1EVFSep6jvraVVbER5+5/lnb5j1OTEW4EtHXmFus3nnTckeg==
+metro-transform-plugins@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.76.2.tgz#79921139cf98df1eb444c7598b9d7285c9c2dd80"
+  integrity sha512-kpqOemOzxxrP1Fah3163a/7vOgzfsgmJ2RYceEt1KGg/JGYyB17CBzADiiT7H+K6fJRtZAiuKy9ru08gXnqUpA==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
@@ -8979,29 +8861,28 @@ metro-transform-plugins@0.76.0:
     "@babel/traverse" "^7.20.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.76.0.tgz#b53ae1d7033b9dae550384afcedeec46905cc6f9"
-  integrity sha512-diV1gXL+/5R/LFPH3UwuU+dNlzT59c0qCHZm2iFqJYaVHuXUgAjyw48gVfOGDbytXLLcswQQD6C594Sc0QNnPA==
+metro-transform-worker@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.76.2.tgz#e02a73de65369a1529c9dc45b821878b893c13b0"
+  integrity sha512-BlGDrA+Vp4PkR9IVYi1Zspcqw0NXLyqMlmazFw6WzEON90v9J3rHcIyjrK2lieJ4tdovxFhmHm8YrlCT9S0Bfw==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.76.0"
-    metro-babel-transformer "0.76.0"
-    metro-cache "0.76.0"
-    metro-cache-key "0.76.0"
-    metro-hermes-compiler "0.76.0"
-    metro-source-map "0.76.0"
-    metro-transform-plugins "0.76.0"
+    metro "0.76.2"
+    metro-babel-transformer "0.76.2"
+    metro-cache "0.76.2"
+    metro-cache-key "0.76.2"
+    metro-source-map "0.76.2"
+    metro-transform-plugins "0.76.2"
     nullthrows "^1.1.1"
 
-metro@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.76.0.tgz#eedb7a48c79a222faa953de902f3d81e529eb4c2"
-  integrity sha512-Pm9eMGyNQKnAaDOCmG+26YnodCh34gyl9ZD4UMKSBZA0ent2uUIZWGfZ5Bznljx1WH7JvPvn48VuZVJhctAhLQ==
+metro@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.76.2.tgz#cf8b8235e00721785bc72d01ac942a37064a6b3c"
+  integrity sha512-pF3zWPgdlaFIUDuI6TrouRofgM9Xz5ZrzvxaJGjWen+tvDFhhQ1bah/OZre2ldMvVh800atiSx7uMLITyE+s8A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.20.0"
@@ -9024,23 +8905,22 @@ metro@0.76.0:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.76.0"
-    metro-cache "0.76.0"
-    metro-cache-key "0.76.0"
-    metro-config "0.76.0"
-    metro-core "0.76.0"
-    metro-file-map "0.76.0"
-    metro-hermes-compiler "0.76.0"
-    metro-inspector-proxy "0.76.0"
-    metro-minify-terser "0.76.0"
-    metro-minify-uglify "0.76.0"
-    metro-react-native-babel-preset "0.76.0"
-    metro-resolver "0.76.0"
-    metro-runtime "0.76.0"
-    metro-source-map "0.76.0"
-    metro-symbolicate "0.76.0"
-    metro-transform-plugins "0.76.0"
-    metro-transform-worker "0.76.0"
+    metro-babel-transformer "0.76.2"
+    metro-cache "0.76.2"
+    metro-cache-key "0.76.2"
+    metro-config "0.76.2"
+    metro-core "0.76.2"
+    metro-file-map "0.76.2"
+    metro-inspector-proxy "0.76.2"
+    metro-minify-terser "0.76.2"
+    metro-minify-uglify "0.76.2"
+    metro-react-native-babel-preset "0.76.2"
+    metro-resolver "0.76.2"
+    metro-runtime "0.76.2"
+    metro-source-map "0.76.2"
+    metro-symbolicate "0.76.2"
+    metro-transform-plugins "0.76.2"
+    metro-transform-worker "0.76.2"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -9048,10 +8928,9 @@ metro@0.76.0:
     serialize-error "^2.1.0"
     source-map "^0.5.6"
     strip-ansi "^6.0.0"
-    temp "0.8.3"
     throat "^5.0.0"
     ws "^7.5.1"
-    yargs "^17.5.1"
+    yargs "^17.6.2"
 
 micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -9375,6 +9254,11 @@ nocache@^3.0.1:
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-3.0.1.tgz#54d8b53a7e0a0aa1a288cfceab8a3cefbcde67d4"
   integrity sha512-Gh39xwJwBKy0OvFmWfBs/vDO4Nl7JhnJtkqNP76OUinQz7BiMoszHYrIDHHAaqVl/QKVxCEy4ZxC/XZninu7nQ==
 
+node-abort-controller@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+  integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
+
 node-addon-api@^1.7.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.1.tgz#cf813cd69bb8d9100f6bdca6755fc268f54ac492"
@@ -9689,10 +9573,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.76.0:
-  version "0.76.0"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.76.0.tgz#d36e1a2f2e7ff4534cf25aaf2ab27b48161a408f"
-  integrity sha512-ZLPDN2wCuFRAno0S2BSitMse+l0ipfjQQCDlYZMjZn9YnOGsRneifMlvN+3mWgTA8TOHsoAMYQdciBylgsfAmA==
+ob1@0.76.2:
+  version "0.76.2"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.76.2.tgz#c1566cbb1b6da12c9e11bc47145e8a74180b372c"
+  integrity sha512-4Nazxd75vdXgFwq1braZ+u3QerxT1WVgltU43eByw4MaAdvSeuJt6wKwey7Ts5hfVOZrpfVAkHmmw0nDEg4KMg==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
@@ -11439,11 +11323,6 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@~2.2.6:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
-  integrity sha512-R5KMKHnPAQaZMqLOsyuyUmcIjSeDm+73eoqQpaXA7AZ22BL+6C+1mcUscgOsNd8WVlJuvlgAPsegcx7pjlV0Dg==
-
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -12389,14 +12268,6 @@ temp-write@^4.0.0:
     make-dir "^3.0.0"
     temp-dir "^1.0.0"
     uuid "^3.3.2"
-
-temp@0.8.3:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
-  integrity sha512-jtnWJs6B1cZlHs9wPG7BrowKxZw/rf6+UpGAkr8AaYmiTyTO7zQlLoST8zx/8TcUPnZmeBoB+H8ARuHZaSijVw==
-  dependencies:
-    os-tmpdir "^1.0.0"
-    rimraf "~2.2.6"
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -13403,10 +13274,10 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.5.1:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+yargs@^17.6.2:
+  version "17.7.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
+  integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"


### PR DESCRIPTION
## Summary

- Upgrades Metro dependencies to 0.76.2. This includes the last 2 minor releases with no anticipated compatibility issues.
    - In particular, this contains fixes to experimental Package Exports support, and the removal of some dependencies.
- Removes `@types/metro*` dependencies, since [Metro packages now ship with TypeScript definitions](https://twitter.com/MetroBundler/status/1641490544907153408). Adjusts some `// @ts-ignore`s.

Metro release notes: https://github.com/facebook/metro/releases/tag/v0.76.2
Changelog between 0.76.0 (previous version in `cli-plugin-metro`) and 0.76.2: [https://github.com/facebook/metro/compare/v0.76.0..v0.76.2](https://github.com/facebook/metro/compare/v0.76.0%E2%80%A6v0.76.2)

---

**Reminder**: When React Native updates the CLI to a version that depends on metro 0.76.2, it must also update `metro-runtime` etc to 0.76.2 in the same commit.

---

## Test Plan

- ✅ `yarn build`.
- ✅ `yarn test`.
