### PR TITLE
feat: change default `taskPrefix` in `build-android` command

### DIFF
--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -91,7 +91,7 @@ async function buildAndroid(
     androidProject.appName,
     args.mode || args.variant,
     tasks,
-    'assemble',
+    'bundle',
     androidProject.sourceDir,
   );
 

--- a/packages/cli-platform-android/src/commands/runAndroid/getTaskNames.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/getTaskNames.ts
@@ -7,7 +7,7 @@ export function getTaskNames(
   appName: string,
   mode: BuildFlags['mode'] = 'debug',
   tasks: BuildFlags['tasks'],
-  taskPrefix: 'assemble' | 'install',
+  taskPrefix: 'assemble' | 'install' | 'bundle',
   sourceDir: string,
 ): Array<string> {
   let appTasks = tasks || [taskPrefix + toPascalCase(mode)];


### PR DESCRIPTION
Summary:
---------
Changed default `taskPrefix` in `build-android` command from `assemble` to `bundle`.

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:
```
node /path/to/react-native-cli/packages/cli/build/bin.js build-android
```
Command should generate `android/app/build/outputs/bundle/debug/app-debug.aab`.