### PR TITLE
fix: delete `com.` prefix in package name

### DIFF
--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -210,14 +210,13 @@ describe('replacePlaceholderWithPackageName', () => {
       placeholderTitle: 'Test',
       packageName: PACKAGE_NAME,
     });
-    const [prefix, ...segments] = PACKAGE_NAME.split('.');
 
     const mainActivityFile = fs.readFileSync(
       path.resolve(
         testPath,
         'android',
-        prefix,
-        segments.join('.'),
+        'com',
+        PACKAGE_NAME,
         'MainActivity.java',
       ),
       'utf8',

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -175,20 +175,12 @@ export async function replacePlaceholderWithPackageName({
     const iosFile = isIosFile(filePath);
 
     if (!(await fs.stat(filePath)).isDirectory()) {
-      let newName = startsWithCom
-        ? cleanPackageName
-        : `com.${cleanPackageName}`;
-
-      if (iosFile) {
-        newName = projectName;
-      }
+      let newName = iosFile ? projectName : cleanPackageName;
 
       //replace bundleID for iOS
       await replaceNameInUTF8File(
         filePath,
-        `PRODUCT_BUNDLE_IDENTIFIER = "${
-          startsWithCom ? cleanPackageName : `com.${cleanPackageName}`
-        }"`,
+        `PRODUCT_BUNDLE_IDENTIFIER = "${cleanPackageName}"`,
         'PRODUCT_BUNDLE_IDENTIFIER = "(.*)"',
       );
 

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -34,7 +34,7 @@ export function validatePackageName(packageName: string) {
   }
 }
 
-async function replaceNameInUTF8File(
+export async function replaceNameInUTF8File(
   filePath: string,
   projectName: string,
   templateName: string,

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -101,49 +101,33 @@ async function processDotfiles(filePath: string) {
   await renameFile(filePath, `_${dotfile}`, `.${dotfile}`);
 }
 
-function getPackageNameDetails(packageName: string) {
-  const cleanPackageName = packageName.replace(/[^\p{L}\p{N}.]+/gu, '');
-  const packageNameArray = cleanPackageName.split('.');
-  const [prefix, ...segments] = packageNameArray;
-  const startsWithCom = prefix === 'com';
-
-  return {
-    cleanPackageName,
-    packageNameArray,
-    prefix,
-    segments,
-    startsWithCom,
-  };
-}
-
 async function createAndroidPackagePaths(
   filePath: string,
   packageName: string,
 ) {
-  const {startsWithCom, segments, packageNameArray} = getPackageNameDetails(
-    packageName,
-  );
-  const pathFolders = filePath.split('/').slice(-2);
-  if (pathFolders[0] === 'java' && pathFolders[1] === 'com') {
-    const segmentsList = startsWithCom ? segments : packageNameArray;
+  const pathParts = filePath.split('/').slice(-2);
+
+  if (pathParts[0] === 'java' && pathParts[1] === 'com') {
+    const pathToFolders = filePath.split('/').slice(0, -2).join('/');
+    const segmentsList = packageName.split('.');
 
     if (segmentsList.length > 1) {
       const initialDir = process.cwd();
-      process.chdir(filePath);
+      process.chdir(filePath.split('/').slice(0, -1).join('/'));
 
       try {
         await fs.rename(
           `${filePath}/${segmentsList.join('.')}`,
-          `${filePath}/${segmentsList[segmentsList.length - 1]}`,
+          `${pathToFolders}/${segmentsList[segmentsList.length - 1]}`,
         );
+        await fs.rmdir(filePath);
 
         for (const segment of segmentsList) {
           fs.mkdirSync(segment);
           process.chdir(segment);
         }
-
         await fs.rename(
-          `${filePath}/${segmentsList[segmentsList.length - 1]}`,
+          `${pathToFolders}/${segmentsList[segmentsList.length - 1]}`,
           process.cwd(),
         );
       } catch {
@@ -162,10 +146,7 @@ export async function replacePlaceholderWithPackageName({
   packageName,
 }: Omit<Required<PlaceholderConfig>, 'projectTitle'>) {
   validatePackageName(packageName);
-
-  const {cleanPackageName, segments, startsWithCom} = getPackageNameDetails(
-    packageName,
-  );
+  const cleanPackageName = packageName.replace(/[^\p{L}\p{N}.]+/gu, '');
 
   for (const filePath of walk(process.cwd()).reverse()) {
     if (shouldIgnoreFile(filePath)) {
@@ -209,7 +190,7 @@ export async function replacePlaceholderWithPackageName({
       }
     }
 
-    let fileName = startsWithCom ? segments.join('.') : cleanPackageName;
+    let fileName = cleanPackageName;
 
     if (shouldRenameFile(filePath, placeholderName)) {
       if (iosFile) {
@@ -225,7 +206,7 @@ export async function replacePlaceholderWithPackageName({
       );
     }
     try {
-      await createAndroidPackagePaths(filePath, packageName);
+      await createAndroidPackagePaths(filePath, cleanPackageName);
     } catch (error) {
       throw new CLIError('Failed to create correct paths for Android.');
     }


### PR DESCRIPTION
Summary:
---------
This PR removes the addition of `com.` to the package name during project initialization.
Closes #1903

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```other
node /path/to/react-native-cli/packages/cli/build/bin.js init ProjectName --package-name net.company.projectname
```
3. Check two things: 

- `net.company.projectname` should be used as package name, without `com.` prefix
-  path `android/app/src/debug/java/net/company/projectname` should exsist.