### PR TITLE
fix: add missing arguments to `adb shell` in `run-android` command

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -26,13 +26,19 @@ function tryLaunchAppOnDevice(
     : [packageName, args.mainActivity].filter(Boolean).join('.');
 
   try {
+    // Here we're using the same flags as Android Studio to launch the app
     const adbArgs = [
       'shell',
       'am',
       'start',
       '-n',
       `${packageNameWithSuffix}/${activityToLaunch}`,
+      '-a',
+      'android.intent.action.MAIN',
+      '-c',
+      'android.intent.category.LAUNCHER',
     ];
+
     if (device) {
       adbArgs.unshift('-s', device);
       logger.info(`Starting the app on "${device}"...`);


### PR DESCRIPTION
Summary:
---------
Closes #1907


https://user-images.githubusercontent.com/63900941/232549980-ff709892-ec65-4a2b-8d48-d81588a21587.mp4




Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```other
node /path/to/react-native-cli/packages/cli/build/bin.js run-android
```
should launch `adb shell` with `-a android.intent.action.MAIN -c android.intent.category.LAUNCHER`

