### PR TITLE
chore : Upgrading metro dependencies to 0.76.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "jest-snapshot-serializer-raw": "^1.1.0",
     "lerna": "^4.0.0",
     "lint-staged": "^13.1.0",
-    "metro-memory-fs": "0.76.2",
+    "metro-memory-fs": "0.76.3",
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "slash": "^3.0.0",

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -11,12 +11,12 @@
     "@react-native-community/cli-tools": "12.0.0-alpha.3",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
-    "metro": "0.76.2",
-    "metro-config": "0.76.2",
-    "metro-core": "0.76.2",
-    "metro-react-native-babel-transformer": "0.76.2",
-    "metro-resolver": "0.76.2",
-    "metro-runtime": "0.76.2",
+    "metro": "0.76.3",
+    "metro-config": "0.76.3",
+    "metro-core": "0.76.3",
+    "metro-react-native-babel-transformer": "0.76.3",
+    "metro-resolver": "0.76.3",
+    "metro-runtime": "0.76.3",
     "readline": "^1.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8660,53 +8660,53 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-metro-babel-transformer@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.76.2.tgz#51a6136f554131fb52ac04ec93774267f50fa578"
-  integrity sha512-NRNjVYDs5174K3oS54W67XQ9oUJDDVNJsqz45cJycbxfAx0GKVpvhjvoRQ2LmU0I0IbLL8HQtO/6aQ9No4Udwg==
+metro-babel-transformer@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.76.3.tgz#bae4c41152799ab7a4eaa7e7f9608ee67cde808f"
+  integrity sha512-q9GLsr6lcj9yOKrLeT1cMwSXYRqnmPfjjGgtS2dl0MLUiHnkd/JRz87wI5LiMGv1KetbCKW4jBxhxMllz+CEvw==
   dependencies:
     "@babel/core" "^7.20.0"
     hermes-parser "0.8.0"
-    metro-source-map "0.76.2"
+    metro-source-map "0.76.3"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.76.2.tgz#0d7c3903a1fb2845970486c5c942d319db0bf525"
-  integrity sha512-30kvupiiDVvglywBn8lpNtpcedHXgI7M9Nsh5HRJDq6GF3+4/nrip0UGaa2XRfD1GyHD8B1TpMskvF3+zLKzmw==
+metro-cache-key@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.76.3.tgz#9bfcb5245abffa52139cbcea60ed9d955e4d329e"
+  integrity sha512-6MJMSj48KpcvwrJscAfqaVf+7tW0YwAfGiZK/wucFXRhuM3ID3OxLTTL2XCJu9zUwYZreIHanvP+8HPDqOow9g==
 
-metro-cache@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.76.2.tgz#d8beafd7f8063a831edef254af0b7f98a3b663c3"
-  integrity sha512-gSSfVBNvgqbveWChmC1Om/Ri61JvjOYzmFU1XgW98cNzMtxGHC5WFi3n7u9/kkIR9quiTfyOyxHpkovqJhOixw==
+metro-cache@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.76.3.tgz#c10607da95ccea4534d679d47f1fc8d90896ee63"
+  integrity sha512-q8PEkGJ4xVWw2mgh47FreaTE7Ve8VAnq2QcnYzum6qPCVVs9u3Z+b8Gat61X0VjwihzsZpEes6fpFgV6omQtFw==
   dependencies:
-    metro-core "0.76.2"
+    metro-core "0.76.3"
     rimraf "^3.0.2"
 
-metro-config@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.76.2.tgz#a629f2177c70c1745f5e15ad88ab9ae6437b041a"
-  integrity sha512-BxbmEUlglCK4GJK8beGCXm3C38ri/E0/lFV563YPuyE9OvtG1HeslvYbNAuGt3NzdFEzH4JjaQ7xeKQw5tYYvg==
+metro-config@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.76.3.tgz#43ae77ce97d1d561d62476a7f26daec9c5b283e4"
+  integrity sha512-rRzvFZ+8i9Sa4qiJlmxpPZEp2WAZTI11g0skRe0uzhy5vbNNPhKumIFDlv+FgtI8OzMyZ2wItLf+VgeP8aPqmQ==
   dependencies:
     cosmiconfig "^5.0.5"
     jest-validate "^26.5.2"
-    metro "0.76.2"
-    metro-cache "0.76.2"
-    metro-core "0.76.2"
-    metro-runtime "0.76.2"
+    metro "0.76.3"
+    metro-cache "0.76.3"
+    metro-core "0.76.3"
+    metro-runtime "0.76.3"
 
-metro-core@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.76.2.tgz#e85f8006362b6d1a77e2b024796504f94cc3ddd0"
-  integrity sha512-LXUTPqJLp6J5Ro7IWryd0Q/Lj7AX00fgoJhFfwdOr5RDEkHyzQNeHgObCSOBSqUqDHeEY8hEWD0ugFTA7iIyaA==
+metro-core@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.76.3.tgz#c046e1db2f2492e9d5df7577e3dadd918e7102fb"
+  integrity sha512-sB/7pu516PRaVHSMmftE3uz3UGb49LYwn8LBps1ydDy+LbrWqEsRDJBbOEEayHJoLetqKOTfxvl4AfQKr5AzOw==
   dependencies:
     lodash.throttle "^4.1.1"
-    metro-resolver "0.76.2"
+    metro-resolver "0.76.3"
 
-metro-file-map@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.76.2.tgz#a092c2c9c20c855c0d4ecdce784a9c614804d293"
-  integrity sha512-thDwa/rAePaXBsW62wuRGQbi2/2BoYbRHhfXPmI8MK3TavPfjnX/tPV57+Gx4yy2MFq4AR4mI1VyMsj8vnsTBg==
+metro-file-map@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.76.3.tgz#36ed1e4faf4ec37369470192eaede3fee4f913ce"
+  integrity sha512-Y0ByNJ01bqCY7Afdg8/LQcvgi3eF+m0KTKb/2NQkZMMfUjkCv4SNUiGw2PuHKa9eM2i2vsyF/F+5qvAU9YqlWw==
   dependencies:
     anymatch "^3.0.3"
     debug "^2.2.0"
@@ -8723,10 +8723,10 @@ metro-file-map@0.76.2:
   optionalDependencies:
     fsevents "^2.3.2"
 
-metro-inspector-proxy@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.76.2.tgz#9b60dd609d2a6a19fda4e796a53d45e81d76e409"
-  integrity sha512-K7ThshkczlHbFJhBDdx1Bxrls3LlQ1rnQINqXzBG2sDkOrPx2seV8s1ApaiUqDCdt803Qo9eoTYTI/vOHFmJxQ==
+metro-inspector-proxy@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-inspector-proxy/-/metro-inspector-proxy-0.76.3.tgz#b2e91e6d16e4e285cc510ba5fa93327630277a7c"
+  integrity sha512-e/8976TshdflR0TzBzssxx24nrumUkRpAC5N2i/eXJZwnNgVmG0lFmgmXd36mVuTHBLE+ctolIRsvy3w12HXmw==
   dependencies:
     connect "^3.6.5"
     debug "^2.2.0"
@@ -8734,29 +8734,29 @@ metro-inspector-proxy@0.76.2:
     ws "^7.5.1"
     yargs "^17.6.2"
 
-metro-memory-fs@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.76.2.tgz#1dcc14e0b66e382d9150579c1cd4ca7778415054"
-  integrity sha512-vA1ua7QrsIBqkb9hI4z+v24dRTEO7ykIuG8rrwZJ54k1nMbB+01epGMooaVgAYPGjwqDdhg+uV5UpKW4ueTLzA==
+metro-memory-fs@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-memory-fs/-/metro-memory-fs-0.76.3.tgz#648fddc4258eee22df50d1ad3aa24c149af57bd4"
+  integrity sha512-wQb4+0XVMWl8UECNAZ8Z1cJWG+lwatZswjnLq2QAanpyA5y6eFEA+7MxH/sy2E101kNIBFKAaV6YzDNeK77F/Q==
 
-metro-minify-terser@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.76.2.tgz#f6b85bcd68f97f49f736b1eb505e7208cd72d95d"
-  integrity sha512-JaJ0qlNXtzPlv8JxlfuDRWmNWFZBJ3w5+vQ4tqAIA68ComTpm9DJ7pbde3DUpOts/zM4swsDAPhtu3HuhRTQhA==
+metro-minify-terser@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.76.3.tgz#2f0b95c552e064d0280ec5c46c158aea142bbb71"
+  integrity sha512-5A+vQq80j3b4ulAG99l0tIQk9CsxR4b9iUC97HQMTUndF+VvCU/eEb628wewh3s0NbADcgGtAbKOylrpyWgJjw==
   dependencies:
     terser "^5.15.0"
 
-metro-minify-uglify@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.76.2.tgz#f3a22c35e9f2b32213df44652aef95df142ccd43"
-  integrity sha512-eye94ZTWhiF3eG6+MDdvn6WSVMeQed1gB/QqXZCFrBxk6GAfeosMahwpgygc9hFIXdgc7Qv8z7F2T+hWfh+aAQ==
+metro-minify-uglify@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-minify-uglify/-/metro-minify-uglify-0.76.3.tgz#a04d0964ee272630a05a76bce27a3a18408f2d0c"
+  integrity sha512-/U2Ze5HkJLqI8syi5gUTW6h3vv3KXuNOZFIUPc05XydHvZnLd145K5f82ZKNh8s1/WISBzlBAe1TI0qC6qNmUw==
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.2.tgz#dab4ca4b594bb47780adf5987c6b3b9cb41e767b"
-  integrity sha512-Kzi4JhEzwrPOuv3OHjDZvvlPTjInNoIV8QKBRyLTzx7TJuA5a2xReo0lz4sG4x9Bcv1XjKkKRmYUgS9V1I820w==
+metro-react-native-babel-preset@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.76.3.tgz#efedce64251c4733446a127a7e19e1f36cd4a600"
+  integrity sha512-3DyE0aP/k8OdIcA0Dy0MQwx6EiXaTLq5YPy4Z38lwOFxD9ZRm2rwnaNXNczsYisJqeq1vcEJpfMnjS26Kqq97g==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/plugin-proposal-async-generator-functions" "^7.0.0"
@@ -8798,62 +8798,62 @@ metro-react-native-babel-preset@0.76.2:
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.4.0"
 
-metro-react-native-babel-transformer@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.2.tgz#84865806bcbd9376db8190c33f2b7cd178fa342b"
-  integrity sha512-49Jv8fqM+hN1Ocl1hcpRaZbVpUmT98x1+ISPToKMNn2ZnXzwsDHQ00mK+AETLrKBWOWn/Aol/zhmWDb2CwUqlw==
+metro-react-native-babel-transformer@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-react-native-babel-transformer/-/metro-react-native-babel-transformer-0.76.3.tgz#cad6b15ceed9e3113fcbce50bf29ec1c80926cd2"
+  integrity sha512-uXws0E8tl5ux1velbPbo9EZNGNDAb4dwqcEjspqCJ+2HEfj54roJsP3hxSo/5DyPV+m0qusD6LhJnbqONa6q6A==
   dependencies:
     "@babel/core" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
     hermes-parser "0.8.0"
-    metro-babel-transformer "0.76.2"
-    metro-react-native-babel-preset "0.76.2"
-    metro-source-map "0.76.2"
+    metro-babel-transformer "0.76.3"
+    metro-react-native-babel-preset "0.76.3"
+    metro-source-map "0.76.3"
     nullthrows "^1.1.1"
 
-metro-resolver@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.76.2.tgz#497dd8dc04a8c86b25629544cb0fba4f56d7b0e1"
-  integrity sha512-sLLwhxd31fYVxaOSzhJ8Mumi211qHOkurC2Gh+4QSDFNKDZecovMgV/W5/oIQWJBCX/mi/YkbmnpwLCUvXEoWw==
+metro-resolver@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.76.3.tgz#5ebc611fb9d101f132990be621479008531089a9"
+  integrity sha512-izQYKJV117U62KTZHrYi1G+ntD70d/bIzse7kEtAI6vuyYAQlfmtwqS9st9Qebe79rNj1qQONAtt+bAMz7bYqw==
 
-metro-runtime@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.76.2.tgz#2f112f9a550737945fceda14dd4882759859331a"
-  integrity sha512-247IYGyA8tS2wkDjq0Ju3vm6Tz79nb7+DPHgMpl71nsh0/kQvgc43bEJLhMwOqouRUcJihN0MgPWUb1xNI1rUg==
+metro-runtime@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.76.3.tgz#3c6f0f7694740c3c11de2550d697c5fe65ab70ff"
+  integrity sha512-VYqP6CKrQqF1MvaiO2Jb+4B4BOTYlMLUIOJpui0gJHfEvacq85tMRpJwtFxuob3TETU5AC0/ehDFfrWLe76GuQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     react-refresh "^0.4.0"
 
-metro-source-map@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.76.2.tgz#e66cb8f7109c8c4bfd8732e6a32a2082378e0847"
-  integrity sha512-fr8mSpn7Z0oYhTdcFCJsrtOX0qgOoDBw9I5mOTZBacMyItiiFYrb+2zyVacBQwrxyo/DqAJaFd3NbdbIInIyvw==
+metro-source-map@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.76.3.tgz#3d3fe4e74401429579fc8098173e3ec116b7001a"
+  integrity sha512-2C965nkUtjM1FuVyht8BD75i8qLgq+lSVBxTWaYDL6n4e5yM7NHbVVNa+aTRFpnvfDFYNi0wqcSlsjM4qAcpPw==
   dependencies:
     "@babel/traverse" "^7.20.0"
     "@babel/types" "^7.20.0"
     invariant "^2.2.4"
-    metro-symbolicate "0.76.2"
+    metro-symbolicate "0.76.3"
     nullthrows "^1.1.1"
-    ob1 "0.76.2"
+    ob1 "0.76.3"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.76.2.tgz#4a270f48a1c22dc5e1f185f38c4384cb65f87c75"
-  integrity sha512-yI0eBJK+FeAwNYnyoZve5hq8RplpLTUDqShnmtHmflMw1WWRyjqrxtGg6ctjgV6qQqytnodFAWd31uQQ4ag0Pw==
+metro-symbolicate@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.76.3.tgz#fd5a7c132cd96bb6ae6a2b84107d10b2d5c6b503"
+  integrity sha512-uxXPXyZl3zXOL1RBtEXiWXOhdXvhEadVk1vAazm02jTYhDWespz/j031ZkGd/6hcccHOm0AnJ5JdUI/bVE5Msw==
   dependencies:
     invariant "^2.2.4"
-    metro-source-map "0.76.2"
+    metro-source-map "0.76.3"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     through2 "^2.0.1"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.76.2.tgz#79921139cf98df1eb444c7598b9d7285c9c2dd80"
-  integrity sha512-kpqOemOzxxrP1Fah3163a/7vOgzfsgmJ2RYceEt1KGg/JGYyB17CBzADiiT7H+K6fJRtZAiuKy9ru08gXnqUpA==
+metro-transform-plugins@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.76.3.tgz#d29d4f71ce54983cfcfe51355a430c3c5a1bba46"
+  integrity sha512-QGxu9JbFbAIypj3GnbHMADhKVTOtVSJDZBcHyUuSEEpHBqxPL+vzqCkCUS4jzIjscKmL2NzQNJFdu6oxQv4pfQ==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
@@ -8861,28 +8861,28 @@ metro-transform-plugins@0.76.2:
     "@babel/traverse" "^7.20.0"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.76.2.tgz#e02a73de65369a1529c9dc45b821878b893c13b0"
-  integrity sha512-BlGDrA+Vp4PkR9IVYi1Zspcqw0NXLyqMlmazFw6WzEON90v9J3rHcIyjrK2lieJ4tdovxFhmHm8YrlCT9S0Bfw==
+metro-transform-worker@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.76.3.tgz#4445353bbb2107cf597879209b95dbcfd5d7595c"
+  integrity sha512-3yzHj5R+q0OAXB8ZBVAMEx7hZ50zXCc803sAL7O38r5kq7SEz2mBiLmgf6fmTCQUK8xr3c6Se20nxFnxcVZgiw==
   dependencies:
     "@babel/core" "^7.20.0"
     "@babel/generator" "^7.20.0"
     "@babel/parser" "^7.20.0"
     "@babel/types" "^7.20.0"
     babel-preset-fbjs "^3.4.0"
-    metro "0.76.2"
-    metro-babel-transformer "0.76.2"
-    metro-cache "0.76.2"
-    metro-cache-key "0.76.2"
-    metro-source-map "0.76.2"
-    metro-transform-plugins "0.76.2"
+    metro "0.76.3"
+    metro-babel-transformer "0.76.3"
+    metro-cache "0.76.3"
+    metro-cache-key "0.76.3"
+    metro-source-map "0.76.3"
+    metro-transform-plugins "0.76.3"
     nullthrows "^1.1.1"
 
-metro@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.76.2.tgz#cf8b8235e00721785bc72d01ac942a37064a6b3c"
-  integrity sha512-pF3zWPgdlaFIUDuI6TrouRofgM9Xz5ZrzvxaJGjWen+tvDFhhQ1bah/OZre2ldMvVh800atiSx7uMLITyE+s8A==
+metro@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.76.3.tgz#4dce70d3f67c66a530917b2d7bc98a1c7e08f336"
+  integrity sha512-nuL9anuExAVKLd8/KdwqF3iQ0eLg7R3OXIiUZvyok2cZral0dh6ZvWGxDJcKXPgGXU6gE3z+PV2PhPuED2La8w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     "@babel/core" "^7.20.0"
@@ -8905,22 +8905,22 @@ metro@0.76.2:
     invariant "^2.2.4"
     jest-worker "^27.2.0"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.76.2"
-    metro-cache "0.76.2"
-    metro-cache-key "0.76.2"
-    metro-config "0.76.2"
-    metro-core "0.76.2"
-    metro-file-map "0.76.2"
-    metro-inspector-proxy "0.76.2"
-    metro-minify-terser "0.76.2"
-    metro-minify-uglify "0.76.2"
-    metro-react-native-babel-preset "0.76.2"
-    metro-resolver "0.76.2"
-    metro-runtime "0.76.2"
-    metro-source-map "0.76.2"
-    metro-symbolicate "0.76.2"
-    metro-transform-plugins "0.76.2"
-    metro-transform-worker "0.76.2"
+    metro-babel-transformer "0.76.3"
+    metro-cache "0.76.3"
+    metro-cache-key "0.76.3"
+    metro-config "0.76.3"
+    metro-core "0.76.3"
+    metro-file-map "0.76.3"
+    metro-inspector-proxy "0.76.3"
+    metro-minify-terser "0.76.3"
+    metro-minify-uglify "0.76.3"
+    metro-react-native-babel-preset "0.76.3"
+    metro-resolver "0.76.3"
+    metro-runtime "0.76.3"
+    metro-source-map "0.76.3"
+    metro-symbolicate "0.76.3"
+    metro-transform-plugins "0.76.3"
+    metro-transform-worker "0.76.3"
     mime-types "^2.1.27"
     node-fetch "^2.2.0"
     nullthrows "^1.1.1"
@@ -9573,10 +9573,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-ob1@0.76.2:
-  version "0.76.2"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.76.2.tgz#c1566cbb1b6da12c9e11bc47145e8a74180b372c"
-  integrity sha512-4Nazxd75vdXgFwq1braZ+u3QerxT1WVgltU43eByw4MaAdvSeuJt6wKwey7Ts5hfVOZrpfVAkHmmw0nDEg4KMg==
+ob1@0.76.3:
+  version "0.76.3"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.76.3.tgz#ffde2c92c9a7b139bdbb2f7a9bb49b10675c2f83"
+  integrity sha512-LRYelZPfCZJ3xLt8IlATP2z3NWyCxPsIlC48yMGIXb1bMWx6zO+3maYXo2yWkS+/bXPxDuFry72qZ2wZn6dAuw==
 
 object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
Summary:
---------
Updating the versions of Metro in the `cli-plugin-metro` to incorporate the new Metro Release v0.76.3. 
https://github.com/facebook/metro/releases/tag/v0.76.3

Per the release notes shared below, this is not a breaking change for RN CLI and only patch release.

**Metro release notes:** 
* **[Feature]**: Support custom `__loadBundleAsync` implementations in the default `asyncRequire` function. See the [lazy bundling RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0605-lazy-bundling.md) for more details. (https://github.com/facebook/metro/commit/ac3adced45a6ca32286dda9e9470eab6eb4218bf, https://github.com/facebook/metro/commit/f07ce5c455a76b63d47c5ccec9611fc8cd66cd0e by @motiz88)
* **[Feature]**: Support `lazy` parameter in bundle requests. See the [lazy bundling RFC](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0605-lazy-bundling.md) for more details. (https://github.com/facebook/metro/commit/4ef14f9a2f6c0b566df86f9caebb5a98bb7ba52a by @motiz88)
* **[Feature]**: Preserve comments in unminified builds, while continuing to strip all comments from minified builds. (https://github.com/facebook/metro/pull/967 by @tido64)
* **[Deprecated]**: The `transformer.asyncRequireModulePath` config option is deprecated. Use [`__loadBundleAsync`](https://github.com/react-native-community/discussions-and-proposals/blob/main/proposals/0605-lazy-bundling.md#__loadbundleasync-in-metro) instead.(https://github.com/facebook/metro/commit/c7b684f0ae90ec22f7cddf82858dcaa8aa4bc64a by @motiz88)


> NOTE: Experimental features are not covered by semver and can change at any time.

* **[Experimental]** Package Exports unstable_conditionNames now defaults to ['require', 'import'] (https://github.com/facebook/metro/commit/e70ceef126a528c5e18d58c5ed47adb864e8a76b by @huntie)
* **[Experimental]** Removed `server.experimentalImportBundleSupport` config option. (https://github.com/facebook/metro/commit/4ef14f9a2f6c0b566df86f9caebb5a98bb7ba52a by @motiz88)

**Full Changelog**: https://github.com/facebook/metro/compare/v0.76.2...v0.76.3

**Reminder:** When React Native updates the CLI to a version that depends on metro 0.76.3, it must also update metro-runtime etc to 0.76.3 in the same commit.

Test Plan:
----------

Updated dependencies with yarn.

```
yarn upgrade metro-memory-fs@0.76.3
cd packages/cli-plugin-metro
metro_version=0.76.3; yarn upgrade metro@$metro_version metro-config@$metro_version  metro-core@$metro_version metro-react-native-babel-transformer@$metro_version metro-resolver@$metro_version metro-runtime@$metro_version
```