### PR TITLE
feat: only show --verbose flag if there are hidden logs

### DIFF
--- a/packages/cli-tools/src/logger.ts
+++ b/packages/cli-tools/src/logger.ts
@@ -4,6 +4,7 @@ const SEPARATOR = ', ';
 
 let verbose = false;
 let disabled = false;
+let hidden = false;
 
 const formatMessages = (messages: Array<string>) =>
   chalk.reset(messages.join(SEPARATOR));
@@ -35,6 +36,8 @@ const error = (...messages: Array<string>) => {
 const debug = (...messages: Array<string>) => {
   if (verbose && !disabled) {
     console.log(`${chalk.gray.bold('debug')} ${formatMessages(messages)}`);
+  } else {
+    hidden = true;
   }
 };
 
@@ -58,6 +61,8 @@ const enable = () => {
   disabled = false;
 };
 
+const hasDebugMessages = () => hidden;
+
 export default {
   success,
   info,
@@ -67,6 +72,7 @@ export default {
   log,
   setVerbose,
   isVerbose,
+  hasDebugMessages,
   disable,
   enable,
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,7 +30,7 @@ const handleError = (err: Error) => {
   if (err.stack) {
     logger.log(err.stack);
   }
-  if (!program.opts().verbose) {
+  if (!program.opts().verbose && logger.hasDebugMessages()) {
     logger.info(
       chalk.dim(
         `Run CLI with ${chalk.reset('--verbose')} ${chalk.dim(


### PR DESCRIPTION
Summary:
---------

We currently always show details about this flag when there is some kind of error. The change will only log this message if there are `debug` log messages when the user has not enabled `--verbose` mode.

I threw some example `logger.debug` text as an example:
![CleanShot 2023-04-28 at 12 18 14](https://user-images.githubusercontent.com/49578/235134552-9747719e-ac6e-47bf-a4d4-c26ed56001ed.png)

Test Plan:
----------

Build and executed in my local environment.