### PR TITLE
Reintroduce tvOS as valid simulator version when matching for simulators 

### DIFF
--- a/packages/cli-platform-ios/src/tools/__tests__/findMatchingSimulator.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/findMatchingSimulator.test.ts
@@ -1027,4 +1027,41 @@ describe('findMatchingSimulator', () => {
       version: 'iOS 16.0',
     });
   });
+
+  it('should return AppleTV devices if in the list', () => {
+    expect(
+      findMatchingSimulator(
+        {
+          devices: {
+            'com.apple.CoreSimulator.SimRuntime.tvOS-11-2': [
+              {
+                state: 'Booted',
+                availability: '(available)',
+                name: 'Apple TV',
+                udid: '816C30EA-38EA-41AC-BFDA-96FB632D522E',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'Apple TV 4K',
+                udid: 'BCBB7E4B-D872-4D61-BC61-7C9805551075',
+              },
+              {
+                state: 'Shutdown',
+                availability: '(available)',
+                name: 'Apple TV 4K (at 1080p)',
+                udid: '1DE12308-1C14-4F0F-991E-A3ADC41BDFFC',
+              },
+            ],
+          },
+        },
+        {simulator: 'Apple TV'},
+      ),
+    ).toEqual({
+      udid: '816C30EA-38EA-41AC-BFDA-96FB632D522E',
+      name: 'Apple TV',
+      booted: true,
+      version: 'tvOS 11.2',
+    });
+  });
 });

--- a/packages/cli-platform-ios/src/tools/findMatchingSimulator.ts
+++ b/packages/cli-platform-ios/src/tools/findMatchingSimulator.ts
@@ -66,7 +66,7 @@ function findMatchingSimulator(
     }
 
     // Making sure the version of the simulator is an iOS or tvOS (Removes Apple Watch, etc)
-    if (!version.includes('iOS')) {
+    if (!version.includes('iOS') && !version.includes('tvOS')) {
       continue;
     }
     if (simulatorVersion && !version.endsWith(simulatorVersion)) {


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->

This pull request should close issue https://github.com/react-native-community/cli/issues/1927. It was caused by being too rigid when it comes to filtering out versions while searching for a valid simulator. This PR reintroduces `tvOS` as a valid version on this code path. @adamTrz is there a reason why it has been removed in the first place?


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

1. Go to https://github.com/react-native-community/cli/issues/1927 and follow the repro steps. Run the `yarn ios` command with `--simulator` set as `Apple TV`.
2. Create a new React Native project and try to run non-tvOS simulator - `yarn ios --simulator "iPhone 14 Pro"` or not specific simulator at all `yarn ios`. It should still run.
