### PR TITLE
fix: improve flow in `init` command on higher Yarn versions

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -21,6 +21,7 @@ import * as PackageManager from '../../tools/packageManager';
 import {installPods} from '@react-native-community/cli-doctor';
 import banner from './banner';
 import TemplateAndVersionError from './errors/TemplateAndVersionError';
+import addNodeLinker from '../../tools/addNodeLinker';
 
 const DEFAULT_VERSION = 'latest';
 
@@ -162,6 +163,10 @@ async function installDependencies({
   root: string;
 }) {
   loader.start('Installing dependencies');
+
+  if (!npm) {
+    addNodeLinker(root);
+  }
 
   await PackageManager.installAll({
     preferYarn: !npm,

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -6,6 +6,7 @@ import copyFiles from '../../tools/copyFiles';
 import replacePathSepForRegex from '../../tools/replacePathSepForRegex';
 import fs from 'fs';
 import chalk from 'chalk';
+import addNodeLinker from '../../tools/addNodeLinker';
 
 export type TemplateConfig = {
   placeholderName: string;
@@ -26,6 +27,10 @@ export async function installTemplatePackage(
     silent: true,
     root,
   });
+
+  if (!npm) {
+    addNodeLinker(root);
+  }
 
   return PackageManager.install([templateName], {
     preferYarn: !npm,

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -6,7 +6,6 @@ import copyFiles from '../../tools/copyFiles';
 import replacePathSepForRegex from '../../tools/replacePathSepForRegex';
 import fs from 'fs';
 import chalk from 'chalk';
-import addNodeLinker from '../../tools/addNodeLinker';
 
 export type TemplateConfig = {
   placeholderName: string;
@@ -21,16 +20,6 @@ export async function installTemplatePackage(
   npm?: boolean,
 ) {
   logger.debug(`Installing template from ${templateName}`);
-
-  await PackageManager.init({
-    preferYarn: !npm,
-    silent: true,
-    root,
-  });
-
-  if (!npm) {
-    addNodeLinker(root);
-  }
 
   return PackageManager.install([templateName], {
     preferYarn: !npm,

--- a/packages/cli/src/tools/addNodeLinker.ts
+++ b/packages/cli/src/tools/addNodeLinker.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import fs from 'fs';
 
 /**
- Creates a `.yarnrc.yml` file in the root of the project to force Yarn to use the `node-modules` linker, because React Native doesn't support the Plug'n'Play node linker.
+ Creates a `.yarnrc.yml` file with "nodeLinker: node-module" in passed path to force Yarn to use the `node-modules` linker, because React Native doesn't support the Plug'n'Play node linker.
  */
 
 const addNodeLinker = (root: string) => {

--- a/packages/cli/src/tools/addNodeLinker.ts
+++ b/packages/cli/src/tools/addNodeLinker.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+import fs from 'fs';
+
+/**
+ Creates a `.yarnrc.yml` file in the root of the project to force Yarn to use the `node-modules` linker, because React Native doesn't support the Plug'n'Play node linker.
+ */
+
+const addNodeLinker = (root: string) => {
+  const yarnrcFileContent = 'nodeLinker: node-modules\n';
+
+  fs.writeFileSync(path.join(root, '.yarnrc.yml'), yarnrcFileContent, {
+    encoding: 'utf8',
+    flag: 'w',
+  });
+};
+
+export default addNodeLinker;


### PR DESCRIPTION
Summary:
---------
Closes https://github.com/react-native-community/cli/issues/1637
Closes https://github.com/react-native-community/cli/issues/1912

This PR improves flow creating project when user has higher Yarn version.

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md).
2. Install yarn at version 2.x.x.
3. Run this command:
```other
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
It should ask to create `.yarnrc.yml` inside project or to use Yarn Classic.
4. Install yarn at version 3.x.x.
5. Run this command:
```other
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
It should detect your `.yarnrc.yml` and check what `nodeLinker` is specified. If it isn't `node-modules`, CLI should ask to change it.
6. Install yarn at version 1.x.x.
7. Run this command:
```other
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
It should create project correctly.