### PR TITLE
fix: trim whitespace in `parseTasksFromGradleFile` on Windows

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidTasks.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidTasks.ts
@@ -17,7 +17,7 @@ export const parseTasksFromGradleFile = (
     taskType === 'build' ? '^assemble|^bundle' : '^install',
   );
   text.split('\n').forEach((line) => {
-    if (taskRegex.test(line) && /(?!.*?Test)^.*$/.test(line)) {
+    if (taskRegex.test(line.trim()) && /(?!.*?Test)^.*$/.test(line.trim())) {
       const metadata = line.split(' - ');
       instalTasks.push({
         task: metadata[0],


### PR DESCRIPTION
Summary:
---------

Fixes: [#36561](https://github.com/facebook/react-native/issues/36561)


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```other
node /path/to/react-native-cli/packages/cli/build/bin.js run-android
```

Android build variants should be found correctly, and this command should run correctly app. 