### PR TITLE
fix: add missing argument to xcodebuild shell (destination)

### DIFF
--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -65,6 +65,10 @@ Explicitly set Xcode scheme to use.
 
 Explicitly set device to use by name. The value is not required if you have a single device connected.
 
+#### `--destination <string>`
+
+Explicitly extend distination e.g. "arch=x86_64"
+
 #### `--udid <string>`
 
 Explicitly set device to use by udid.

--- a/packages/cli-platform-ios/src/commands/buildIOS/buildProject.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/buildProject.ts
@@ -20,6 +20,7 @@ export type BuildFlags = {
   port: number;
   terminal: string | undefined;
   interactive?: boolean;
+  destination?: string;
   extraParams?: string[];
 };
 
@@ -40,11 +41,12 @@ export function buildProject(
       '-scheme',
       scheme,
       '-destination',
-      udid
+      (udid
         ? `id=${udid}`
         : args.mode === 'Debug'
         ? 'generic/platform=iOS Simulator'
-        : 'generic/platform=iOS',
+        : 'generic/platform=iOS') +
+        (args.destination ? ',' + args.destination : ''),
     ];
 
     if (args.extraParams) {

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -229,6 +229,10 @@ export const iosBuildOptions = [
       'Explicitly set device to use by name.  The value is not required if you have a single device connected.',
   },
   {
+    name: '--destination <string>',
+    description: 'Explicitly extend distination e.g. "arch=x86_64"',
+  },
+  {
     name: '--udid <string>',
     description: 'Explicitly set device to use by udid',
   },


### PR DESCRIPTION
- destination is used for to specify the arch for iOS build
- this is needed for modules which require arch x84_64

Summary:
---------

With the destination build parameter it can be specified what destination (arch x86_64) gonna be used to build iOS

In case you are using an apple silicon Mac to build your app and you  are using Pod dependencies which were not made for apple silicon it were not possible to change the arch for these dependencies from cli.

Error:
`could not find module 'Adyen' for target 'arm64-apple-ios-simulator'; found: x86_64-apple-ios-simulator, at:`

xcode would prompt to Build for Rosetta and add en config file

<img width="550" alt="buildforrosetta" src="https://github.com/react-native-community/cli/assets/11231563/b266df20-6a6e-47a8-8758-44882baccf34">

And create a settings file (which has no effect for cli build):
<img width="1108" alt="Bildschirmfoto 2023-05-10 um 18 15 45" src="https://github.com/react-native-community/cli/assets/11231563/5d37c837-2a49-457e-a98f-45e9c2668185">

<img width="796" alt="Bildschirmfoto 2023-05-10 um 18 46 16" src="https://github.com/react-native-community/cli/assets/11231563/b72e696b-f6ea-4bf5-8169-fc21682bfa3e">


Test Plan:
----------

1. Install this fork
2. Run following command `npx react-native run-ios --simulator="iPhone 14 Pro" --destination arch=x86_64`