### PR TITLE
feat: add `watchModeCommandParams` to `react-native.config.js`

### DIFF
--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -77,6 +77,7 @@ type IOSProjectConfig = {
     name: string;
     isWorkspace: boolean;
   } | null;
+  watchModeCommandParams: string;
 };
 
 type AndroidProjectConfig = {
@@ -84,6 +85,7 @@ type AndroidProjectConfig = {
   appName: string;
   packageName: string;
   dependencyConfiguration?: string;
+  watchModeCommandParams: string;
 };
 ```
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -64,6 +64,7 @@ The following settings are available on iOS and Android:
 ```ts
 type IOSProjectParams = {
   sourceDir?: string;
+  watchModeCommandParams?: string[];
   unstable_reactLegacyComponentNames?: string[] | null;
 };
 
@@ -73,6 +74,7 @@ type AndroidProjectParams = {
   manifestPath?: string;
   packageName?: string;
   dependencyConfiguration?: string;
+  watchModeCommandParams?: string[];
   unstable_reactLegacyComponentNames?: string[] | null;
 };
 ```
@@ -81,6 +83,10 @@ type AndroidProjectParams = {
 
 A path to a directory where iOS source files are located. In most cases, you shouldn't need to set it, unless you have
 multiple `Podfile` files in your project.
+
+#### project.ios.watchModeCommandParams
+
+Array of strings that will be passed to the `react-native run-ios` command when running in watch mode.
 
 #### project.ios.unstable_reactLegacyComponentNames
 
@@ -113,6 +119,10 @@ See [`dependency.platforms.android.packageName`](dependencies.md#platformsandroi
 #### project.android.dependencyConfiguration
 
 See [`dependency.platforms.android.configuration`](dependencies.md#platformsandroiddependencyconfiguration)
+
+#### project.android.watchModeCommandParams
+
+Array of strings that will be passed to the `react-native run-android` command when running in watch mode.
 
 #### project.android.unstable_reactLegacyComponentNames
 

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -150,6 +150,7 @@ export const projectConfig = t
           // IOSProjectParams
           .object({
             sourceDir: t.string(),
+            watchModeCommandParams: t.array().items(t.string()),
             unstable_reactLegacyComponentNames: t
               .array()
               .items(t.string())
@@ -164,6 +165,7 @@ export const projectConfig = t
             manifestPath: t.string(),
             packageName: t.string(),
             dependencyConfiguration: t.string(),
+            watchModeCommandParams: t.array().items(t.string()),
             unstable_reactLegacyComponentNames: t
               .array()
               .items(t.string())

--- a/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -7,6 +7,7 @@ Object {
   "packageName": "com.some.example",
   "sourceDir": "/flat/android",
   "unstable_reactLegacyComponentNames": undefined,
+  "watchModeCommandParams": undefined,
 }
 `;
 
@@ -17,6 +18,7 @@ Object {
   "packageName": "com.some.example",
   "sourceDir": "/multiple/android",
   "unstable_reactLegacyComponentNames": undefined,
+  "watchModeCommandParams": undefined,
 }
 `;
 
@@ -27,5 +29,6 @@ Object {
   "packageName": "com.some.example",
   "sourceDir": "/nested/android",
   "unstable_reactLegacyComponentNames": undefined,
+  "watchModeCommandParams": undefined,
 }
 `;

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -64,6 +64,7 @@ export function projectConfig(
     appName,
     packageName,
     dependencyConfiguration: userConfig.dependencyConfiguration,
+    watchModeCommandParams: userConfig.watchModeCommandParams,
     unstable_reactLegacyComponentNames:
       userConfig.unstable_reactLegacyComponentNames,
   };

--- a/packages/cli-platform-ios/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/cli-platform-ios/src/config/__tests__/getProjectConfig.test.ts
@@ -26,6 +26,7 @@ describe('ios::getProjectConfig', () => {
     expect(projectConfig('/', {})).toMatchInlineSnapshot(`
       Object {
         "sourceDir": "/ios",
+        "watchModeCommandParams": undefined,
         "xcodeProject": null,
       }
     `);
@@ -45,6 +46,7 @@ describe('ios::getProjectConfig', () => {
     expect(projectConfig('/', {})).toMatchInlineSnapshot(`
       Object {
         "sourceDir": "/ios",
+        "watchModeCommandParams": undefined,
         "xcodeProject": null,
       }
     `);

--- a/packages/cli-platform-ios/src/config/index.ts
+++ b/packages/cli-platform-ios/src/config/index.ts
@@ -47,6 +47,7 @@ export function projectConfig(
 
   return {
     sourceDir,
+    watchModeCommandParams: userConfig.watchModeCommandParams,
     xcodeProject,
   };
 }

--- a/packages/cli-plugin-metro/src/commands/start/runServer.ts
+++ b/packages/cli-plugin-metro/src/commands/start/runServer.ts
@@ -108,7 +108,7 @@ async function runServer(_argv: Array<string>, ctx: Config, args: Args) {
   reportEvent = eventsSocketEndpoint.reportEvent;
 
   if (args.interactive) {
-    enableWatchMode(messageSocketEndpoint);
+    enableWatchMode(messageSocketEndpoint, ctx);
   }
 
   // In Node 8, the default keep-alive for an HTTP connection is 5 seconds. In

--- a/packages/cli-plugin-metro/src/commands/start/watchMode.ts
+++ b/packages/cli-plugin-metro/src/commands/start/watchMode.ts
@@ -2,6 +2,7 @@ import readline from 'readline';
 import {logger, hookStdout} from '@react-native-community/cli-tools';
 import execa from 'execa';
 import chalk from 'chalk';
+import {Config} from '@react-native-community/cli-types';
 
 function printWatchModeInstructions() {
   logger.log(
@@ -13,7 +14,7 @@ function printWatchModeInstructions() {
   );
 }
 
-function enableWatchMode(messageSocket: any) {
+function enableWatchMode(messageSocket: any, ctx: Config) {
   // We need to set this to true to catch key presses individually.
   // As a result we have to implement our own method for exiting
   // and other commands (e.g. ctrl+c & ctrl+z)
@@ -55,9 +56,14 @@ function enableWatchMode(messageSocket: any) {
       logger.info('Opening developer menu...');
     } else if (name === 'i' || name === 'a') {
       logger.info(`Opening the app on ${name === 'i' ? 'iOS' : 'Android'}...`);
+      const params =
+        name === 'i'
+          ? ctx.project.ios?.watchModeCommandParams
+          : ctx.project.android?.watchModeCommandParams;
       execa('npx', [
         'react-native',
         name === 'i' ? 'run-ios' : 'run-android',
+        ...(params ?? []),
       ]).stdout?.pipe(process.stdout);
     } else {
       console.log(_key);

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -3,6 +3,7 @@ export interface AndroidProjectConfig {
   appName: string;
   packageName: string;
   dependencyConfiguration?: string;
+  watchModeCommandParams?: string[];
   unstable_reactLegacyComponentNames?: string[] | null;
 }
 
@@ -12,6 +13,7 @@ export type AndroidProjectParams = {
   manifestPath?: string;
   packageName?: string;
   dependencyConfiguration?: string;
+  watchModeCommandParams?: string[];
   unstable_reactLegacyComponentNames?: string[] | null;
 };
 

--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -5,6 +5,7 @@
 
 export interface IOSProjectParams {
   sourceDir?: string;
+  watchModeCommandParams?: string[];
 }
 
 export type IOSProjectInfo = {
@@ -15,6 +16,7 @@ export type IOSProjectInfo = {
 export interface IOSProjectConfig {
   sourceDir: string;
   xcodeProject: IOSProjectInfo | null;
+  watchModeCommandParams?: string[];
 }
 
 export interface IOSDependencyConfig {


### PR DESCRIPTION
Summary:
---------
Closes #1872

Add `watchModeCommandParams` to configure `run-ios` or `run-android` commands when pressing `i` or `a` inside terminal in watch mode.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Edit `react-native.config.js` inside project to look something like this:
```js
module.exports = {
  project: {
    ios: {
      watchModeCommandParams: ['--mode', 'Release'],
    },
    android: {
      watchModeCommandParams: ['--mode', 'Release'],
    },
  },
};
```
4. Run this command:

```other
node /path/to/react-native-cli/packages/cli/build/bin.js start
```
5. Press `i` inside terminal and the comand `npx react-native run-ios --mode Release` should be run.
6. Press `a` inside terminal and the comand `npx react-native run-android --mode Release` should be run.