### PR TITLE
chore (doctor): update Java version range to be strictly 11-18

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/jdk.test.ts
@@ -35,7 +35,7 @@ describe('jdk', () => {
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
-  it('returns false if JDK version is in range (JDK 9+ version number format)', async () => {
+  it('returns false if JDK version is in range (JDK [11-18] version number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
       version: '14.0.4',
@@ -45,7 +45,7 @@ describe('jdk', () => {
     expect(diagnostics.needsToBeFixed).toBe(false);
   });
 
-  it('returns true if JDK version is not in range (JDK <= 8 version number format)', async () => {
+  it('returns true if JDK version is not in range (JDK < 11 version number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
       version: '1.8.0_282',
@@ -55,10 +55,10 @@ describe('jdk', () => {
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
-  it('returns true if JDK version is not in range (JDK 9+ verison number format)', async () => {
+  it('returns true if JDK version is not in range (JDK > 18 version number format)', async () => {
     // @ts-ignore
     environmentInfo.Languages.Java = {
-      version: '10.0.15+10',
+      version: '19.0.1',
     };
 
     const diagnostics = await jdk.getDiagnostics(environmentInfo);

--- a/packages/cli-doctor/src/tools/versionRanges.ts
+++ b/packages/cli-doctor/src/tools/versionRanges.ts
@@ -4,7 +4,7 @@ export default {
   YARN: '>= 1.10.x',
   NPM: '>= 4.x',
   RUBY: '>= 2.6.10',
-  JAVA: '>= 11',
+  JAVA: '>= 11 < 19',
   // Android
   ANDROID_SDK: '>= 33.x',
   ANDROID_NDK: '>= 23.x',


### PR DESCRIPTION
Summary:
---------

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes.
Help us understand your motivation by explaining why you decided to make this change: -->
Updated Java version check in [versionRanges](https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/src/tools/versionRanges.ts) to be strictly [11 - 18] (i.e. 19 is not supported).

Part of #1936

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Updated tests and run `yarn test`
