### PR TITLE
fix: `--verbose` option not working for `run-ios`

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,8 @@ const pkgJson = require('../package.json');
 const program = new CommanderCommand()
   .usage('[command] [options]')
   .version(pkgJson.version, '-v', 'Output the current version')
-  .option('--verbose', 'Increase logging verbosity');
+  .option('--verbose', 'Increase logging verbosity')
+  .enablePositionalOptions();
 
 const handleError = (err: Error) => {
   logger.enable();


### PR DESCRIPTION
Summary:
---------
Fixes https://github.com/react-native-community/cli/issues/1391
Closes https://github.com/react-native-community/cli/issues/1391

Added `.enablePositionalOptions();` to `CommanderCommand`.

Read [here](https://github.com/tj/commander.js#parsing-configuration) more about this option.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```other
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --verbose
```
Should correctly pass the --verbose flag to the `run-ios` command.