### PR TITLE
fix: add missing argument to xcodebuild shell (destination) for v8.x

### DIFF
--- a/packages/platform-ios/src/commands/runIOS/index.ts
+++ b/packages/platform-ios/src/commands/runIOS/index.ts
@@ -37,6 +37,7 @@ type FlagsT = {
   verbose: boolean;
   port: number;
   terminal: string | undefined;
+  destination?: string;
 };
 
 function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
@@ -317,7 +318,7 @@ function buildProject(
       '-scheme',
       scheme,
       '-destination',
-      `id=${udid}`,
+      `id=${udid}` + (args.destination ? ',' + args.destination : ''),
     ];
     // @todo use `getLoader` from cli-tools package
     const loader = ora();
@@ -603,6 +604,10 @@ export default {
       name: '--device [string]',
       description:
         'Explicitly set device to use by name.  The value is not required if you have a single device connected.',
+    },
+    {
+      name: '--destination <string>',
+      description: 'Explicitly extend distination e.g. "arch=x86_64"',
     },
     {
       name: '--udid <string>',


### PR DESCRIPTION
Summary:
---------

This is a fix to allow the run-ios command to accept a destination arg so that rosetta devices can be used via the terminal build command on projects using v8 of the cli.

This is a v8 backport fix of this PR https://github.com/react-native-community/cli/pull/1934

Please also read: https://github.com/react-native-community/cli/issues/1918
