### PR TITLE
fix: always add `--verbose` to the command

### DIFF
--- a/__e2e__/__snapshots__/default.test.ts.snap
+++ b/__e2e__/__snapshots__/default.test.ts.snap
@@ -5,7 +5,6 @@ exports[`shows up help information without passing in any args 1`] = `
 
 Options:
   -v                            Output the current version
-  --verbose                     Increase logging verbosity
   -h, --help                    display help for command
 
 Commands:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,6 @@ const pkgJson = require('../package.json');
 const program = new CommanderCommand()
   .usage('[command] [options]')
   .version(pkgJson.version, '-v', 'Output the current version')
-  .option('--verbose', 'Increase logging verbosity')
   .enablePositionalOptions();
 
 const handleError = (err: Error) => {
@@ -85,6 +84,7 @@ function attachCommand<C extends Command<boolean>>(
 ): void {
   const cmd = program
     .command(command.name)
+    .option('--verbose', 'Increase logging verbosity')
     .action(async function handleAction(
       this: CommanderCommand,
       ...args: string[]


### PR DESCRIPTION
Summary:
---------

Recently we [added](https://github.com/react-native-community/cli/pull/1946) `.enablePositionalOptions()` to the commander, and this caused one problem, because we specified `--verbose` directly to the `react-native` so we were able to do `react-native --verbose`, but if we did `react-native run-android --verbose` it didn't work - so the solution for this is to add `--verbose` to every command.

Test Plan:
----------

`npx react-native -v` <- should give version of CLI
`npx react-native --verbose` <- shouldn't work
`npx react-native run-android --verbose` <- should pass verbose to `run-android`