### PR TITLE
fix(ios): fix Xcode defaulting to 'Release'

### DIFF
--- a/packages/cli-platform-ios/src/tools/getConfigurationScheme.ts
+++ b/packages/cli-platform-ios/src/tools/getConfigurationScheme.ts
@@ -11,9 +11,12 @@ export function getConfigurationScheme(
 ) {
   if (scheme && mode) {
     return mode;
-  } else if (scheme) {
-    return getBuildConfigurationFromXcScheme(scheme, mode, sourceDir);
   }
 
-  return mode || 'Debug';
+  const configuration = mode || 'Debug';
+  if (scheme) {
+    return getBuildConfigurationFromXcScheme(scheme, configuration, sourceDir);
+  }
+
+  return configuration;
 }


### PR DESCRIPTION
Summary:
---------

`getBuildConfigurationFromXcScheme` currently assumes where the `.xcodeproj` lives (it could be anywhere). The proper fix is to get the path from `.xcworkspace`, but that's a much more intrusive change. The least we can do for now is to fall back to `Debug`.

Test Plan:
----------

```
git clone https://github.com/microsoft/react-native-test-app.git
cd react-native-test-app
npm run set-react-version 0.72
yarn
cd example
pod install --project-directory=ios
yarn ios
```

Take note of whether `-configuration` is correctly set when `xcodebuild` is run. This is what it looks like without this fix:

```
info Building (using "xcodebuild -workspace Example.xcworkspace -configuration  -scheme Example -destination id=0")
```