### PR TITLE
fix(ios): fix crash when `--mode` is specified

### DIFF
--- a/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
@@ -1,3 +1,4 @@
+import type {IosProjectInfo} from '../../types';
 import {checkIfConfigurationExists} from '../checkIfConfigurationExists';
 
 const CONFIGURATIONS = ['Debug', 'Release'];
@@ -23,6 +24,13 @@ describe('checkIfConfigurationExists', () => {
 
   test('should not throw an error if project info contains selected configuration', () => {
     const checkConfig = () => checkIfConfigurationExists(PROJECT_INFO, 'Debug');
+
+    expect(checkConfig).not.toThrow();
+  });
+
+  test('should not throw an error if project could not be found', () => {
+    const checkConfig = () =>
+      checkIfConfigurationExists(undefined as IosProjectInfo, 'Debug');
 
     expect(checkConfig).not.toThrow();
   });

--- a/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
+++ b/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
@@ -1,10 +1,15 @@
-import {CLIError} from '@react-native-community/cli-tools';
+import {CLIError, logger} from '@react-native-community/cli-tools';
 import {IosProjectInfo} from '../types';
 
 export function checkIfConfigurationExists(
   project: IosProjectInfo,
   mode: string,
 ) {
+  if (!project) {
+    logger.warn(`Unable to check whether "${mode}" exists in your project`);
+    return;
+  }
+
   if (!project.configurations.includes(mode)) {
     throw new CLIError(
       `Configuration "${mode}" does not exist in your project. Please use one of the existing configurations: ${project.configurations.join(


### PR DESCRIPTION
Summary:
---------

Assumptions about where the `.xcodeproj` lives causes `checkIfConfigurationExists` to crash because `undefined` was passed as project.

Test Plan:
----------

```
git clone https://github.com/microsoft/react-native-test-app.git
cd react-native-test-app
npm run set-react-version 0.72
yarn
cd example
pod install --project-directory=ios
yarn ios --mode 'Debug'
```

The last command should not crash.