### PR TITLE
feat: read main activity from `AndroidManifest.xml` automatically

### DIFF
--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -65,7 +65,8 @@ exports[`shows up current config without unnecessary output 1`] = `
     "android": {
       "sourceDir": "<<REPLACED_ROOT>>/TestProject/android",
       "appName": "app",
-      "packageName": "com.testproject"
+      "packageName": "com.testproject",
+      "mainActivity": "MainActivity"
     }
   }
 }

--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -66,7 +66,7 @@ exports[`shows up current config without unnecessary output 1`] = `
       "sourceDir": "<<REPLACED_ROOT>>/TestProject/android",
       "appName": "app",
       "packageName": "com.testproject",
-      "mainActivity": "MainActivity"
+      "mainActivity": ".MainActivity"
     }
   }
 }

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -84,6 +84,7 @@ type AndroidProjectConfig = {
   sourceDir: string;
   appName: string;
   packageName: string;
+  mainActivity: string;
   dependencyConfiguration?: string;
   watchModeCommandParams: string;
 };

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -406,12 +406,28 @@ test('should convert project sourceDir relative path to absolute', () => {
       <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         package="com.coinbase.android">
+        <application android:name=".MainApplication">
+          <activity android:name=".MainActivity">
+            <intent-filter>
+              <action android:name="android.intent.action.MAIN" />
+              <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+          </activity>
+        </application>
       </manifest>
     `,
     'android2/AndroidManifest.xml': `
       <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         package="com.coinbase.android">
+        <application android:name=".MainApplication">
+          <activity android:name=".MainActivity">
+            <intent-filter>
+              <action android:name="android.intent.action.MAIN" />
+              <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+          </activity>
+        </application>
       </manifest>
     `,
   });

--- a/packages/cli-platform-android/package.json
+++ b/packages/cli-platform-android/package.json
@@ -10,6 +10,7 @@
     "@react-native-community/cli-tools": "12.0.0-alpha.4",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
+    "fast-xml-parser": "^4.2.4",
     "glob": "^7.1.3",
     "logkitty": "^0.7.1"
   },

--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -67,6 +67,7 @@ describe('--appFolder', () => {
     appName: 'app',
     packageName: 'com.test',
     sourceDir: '/android',
+    mainActivity: '.MainActivity',
   };
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -46,6 +46,10 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
     link.setVersion(config.reactNativeVersion);
   }
 
+  if (!args.mainActivity && config.project.android?.mainActivity) {
+    args.mainActivity = config.project.android?.mainActivity;
+  }
+
   if (args.binaryPath) {
     if (args.tasks) {
       throw new CLIError(
@@ -283,7 +287,6 @@ export default {
     {
       name: '--main-activity <string>',
       description: 'Name of the activity to start',
-      default: 'MainActivity',
     },
     {
       name: '--deviceId <string>',

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -46,10 +46,6 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
     link.setVersion(config.reactNativeVersion);
   }
 
-  if (!args.mainActivity && config.project.android?.mainActivity) {
-    args.mainActivity = config.project.android?.mainActivity;
-  }
-
   if (args.binaryPath) {
     if (args.tasks) {
       throw new CLIError(
@@ -68,7 +64,11 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
     }
   }
 
-  const androidProject = getAndroidProject(config);
+  let androidProject = getAndroidProject(config);
+
+  if (args.mainActivity) {
+    androidProject.mainActivity = args.mainActivity;
+  }
 
   await runPackager(args, config);
   return buildAndRun(args, androidProject);
@@ -258,12 +258,8 @@ function installAndLaunchOnDevice(
     androidProject,
     selectedTask,
   );
-  tryLaunchAppOnDevice(
-    selectedDevice,
-    androidProject.packageName,
-    adbPath,
-    args,
-  );
+
+  tryLaunchAppOnDevice(selectedDevice, androidProject, adbPath, args);
 }
 
 export default {

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -115,7 +115,7 @@ async function runOnAllDevices(
       if (args.binaryPath && device) {
         tryInstallAppOnDevice(args, adbPath, device, androidProject);
       }
-      tryLaunchAppOnDevice(device, androidProject.packageName, adbPath, args);
+      tryLaunchAppOnDevice(device, androidProject, adbPath, args);
     },
   );
 }

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -7,23 +7,25 @@
  */
 
 import execa from 'execa';
-import {Flags} from '.';
+import {AndroidProject, Flags} from '.';
 import {logger, CLIError} from '@react-native-community/cli-tools';
 
 function tryLaunchAppOnDevice(
   device: string | void,
-  packageName: string,
+  androidProject: AndroidProject,
   adbPath: string,
   args: Flags,
 ) {
   const {appId, appIdSuffix} = args;
+  const {packageName, mainActivity} = androidProject;
+
   const packageNameWithSuffix = [appId || packageName, appIdSuffix]
     .filter(Boolean)
     .join('.');
 
-  const activityToLaunch = args.mainActivity.includes('.')
-    ? args.mainActivity
-    : [packageName, args.mainActivity].filter(Boolean).join('.');
+  const activityToLaunch = mainActivity.includes('.')
+    ? mainActivity
+    : [packageName, mainActivity].filter(Boolean).join('.');
 
   try {
     // Here we're using the same flags as Android Studio to launch the app

--- a/packages/cli-platform-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-platform-android/src/config/__fixtures__/android.ts
@@ -26,6 +26,10 @@ const fewActivitiesManifest = fs.readFileSync(
   path.join(__dirname, './files/AndroidManifest-few-activities.xml'),
 );
 
+const classNameManifest = fs.readFileSync(
+  path.join(__dirname, './files/AndroidManifest-className.xml'),
+);
+
 function generateValidFileStructureForLib(classFileName: string) {
   return {
     'build.gradle': buildGradle,
@@ -286,5 +290,11 @@ export const findPackagesClassNameJavaNotValid = [
 export const fewActivities = {
   src: {
     'AndroidManifest.xml': fewActivitiesManifest,
+  },
+};
+
+export const className = {
+  src: {
+    'AndroidManifest.xml': classNameManifest,
   },
 };

--- a/packages/cli-platform-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-platform-android/src/config/__fixtures__/android.ts
@@ -22,6 +22,10 @@ const appBuildGradle = fs.readFileSync(
   path.join(__dirname, './files/appbuild.gradle'),
 );
 
+const fewActivitiesManifest = fs.readFileSync(
+  path.join(__dirname, './files/AndroidManifest-few-activities.xml'),
+);
+
 function generateValidFileStructureForLib(classFileName: string) {
   return {
     'build.gradle': buildGradle,
@@ -278,3 +282,9 @@ export const findPackagesClassNameJavaNotValid = [
   }
   `,
 ];
+
+export const fewActivities = {
+  src: {
+    'AndroidManifest.xml': fewActivitiesManifest,
+  },
+};

--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-className.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-className.xml
@@ -1,0 +1,12 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.some.example">
+	<uses-permission android:name="android.permission.INTERNET" />
+
+	<application android:name=".MainApplication">
+		<activity android:name="com.example.ExampleAppActivity">
+			<intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
+		</activity>
+	</application>
+</manifest>

--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-few-activities.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-few-activities.xml
@@ -1,0 +1,20 @@
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:name=".ExampleApplication">
+    <activity android:name=".ExampleAppActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="rntester" android:host="example" />
+      </intent-filter>
+    </activity>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
+  </application>
+  </queries>
+</manifest>

--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest.xml
@@ -1,4 +1,12 @@
-<manifest
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.some.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.some.example">
+	<uses-permission android:name="android.permission.INTERNET" />
+
+	<application android:name=".MainApplication">
+		<activity android:name=".MainActivity">
+			<intent-filter>
+				<action android:name="android.intent.action.MAIN" />
+				<category android:name="android.intent.category.LAUNCHER" />
+			</intent-filter>
+		</activity>
+	</application>
 </manifest>

--- a/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -4,6 +4,7 @@ exports[`android::getProjectConfig returns an object with android project config
 Object {
   "appName": "",
   "dependencyConfiguration": undefined,
+  "mainActivity": "MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/flat/android",
   "unstable_reactLegacyComponentNames": undefined,
@@ -15,6 +16,7 @@ exports[`android::getProjectConfig returns an object with android project config
 Object {
   "appName": "",
   "dependencyConfiguration": undefined,
+  "mainActivity": "MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/multiple/android",
   "unstable_reactLegacyComponentNames": undefined,
@@ -26,6 +28,7 @@ exports[`android::getProjectConfig returns an object with android project config
 Object {
   "appName": "app",
   "dependencyConfiguration": undefined,
+  "mainActivity": "MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/nested/android",
   "unstable_reactLegacyComponentNames": undefined,

--- a/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -4,7 +4,7 @@ exports[`android::getProjectConfig returns an object with android project config
 Object {
   "appName": "",
   "dependencyConfiguration": undefined,
-  "mainActivity": "MainActivity",
+  "mainActivity": ".MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/flat/android",
   "unstable_reactLegacyComponentNames": undefined,
@@ -16,7 +16,7 @@ exports[`android::getProjectConfig returns an object with android project config
 Object {
   "appName": "",
   "dependencyConfiguration": undefined,
-  "mainActivity": "MainActivity",
+  "mainActivity": ".MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/multiple/android",
   "unstable_reactLegacyComponentNames": undefined,
@@ -28,7 +28,7 @@ exports[`android::getProjectConfig returns an object with android project config
 Object {
   "appName": "app",
   "dependencyConfiguration": undefined,
-  "mainActivity": "MainActivity",
+  "mainActivity": ".MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/nested/android",
   "unstable_reactLegacyComponentNames": undefined,

--- a/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
@@ -7,13 +7,18 @@ jest.mock('fs');
 
 const fs = require('fs');
 
-describe('android::readManifest', () => {
+describe('android::getMainActivity', () => {
   beforeAll(() => {
     fs.__setMockFilesystem({
       empty: {},
       valid: {
         android: {
           app: mocks.valid,
+        },
+      },
+      className: {
+        android: {
+          app: mocks.className,
         },
       },
       few: {
@@ -29,7 +34,7 @@ describe('android::readManifest', () => {
     const manifest = getMainActivity(manifestPath || '');
     expect(manifest).not.toBeNull();
     expect(typeof manifest).toBe('string');
-    expect(manifest).toBe('MainActivity');
+    expect(manifest).toBe('.MainActivity');
   });
 
   it('returns main activity if there is few activities', () => {
@@ -37,7 +42,15 @@ describe('android::readManifest', () => {
     const mainActivity = getMainActivity(manifestPath || '');
     expect(mainActivity).not.toBeNull();
     expect(typeof mainActivity).toBe('string');
-    expect(mainActivity).toBe('ExampleAppActivity');
+    expect(mainActivity).toBe('.ExampleAppActivity');
+  });
+
+  it('returns main activity if it is class name', () => {
+    const manifestPath = findManifest('/className');
+    const mainActivity = getMainActivity(manifestPath || '');
+    expect(mainActivity).not.toBeNull();
+    expect(typeof mainActivity).toBe('string');
+    expect(mainActivity).toBe('com.example.ExampleAppActivity');
   });
 
   it('returns null if file do not exist', () => {

--- a/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
@@ -1,0 +1,47 @@
+import findManifest from '../findManifest';
+import getMainActivity from '../getMainActivity';
+import * as mocks from '../__fixtures__/android';
+
+jest.mock('path');
+jest.mock('fs');
+
+const fs = require('fs');
+
+describe('android::readManifest', () => {
+  beforeAll(() => {
+    fs.__setMockFilesystem({
+      empty: {},
+      valid: {
+        android: {
+          app: mocks.valid,
+        },
+      },
+      few: {
+        android: {
+          app: mocks.fewActivities,
+        },
+      },
+    });
+  });
+
+  it('returns main activity if file exists in the folder', () => {
+    const manifestPath = findManifest('/valid');
+    const manifest = getMainActivity(manifestPath || '');
+    expect(manifest).not.toBeNull();
+    expect(typeof manifest).toBe('string');
+    expect(manifest).toBe('MainActivity');
+  });
+
+  it('returns main activity if there is few activities', () => {
+    const manifestPath = findManifest('/few');
+    const mainActivity = getMainActivity(manifestPath || '');
+    expect(mainActivity).not.toBeNull();
+    expect(typeof mainActivity).toBe('string');
+    expect(mainActivity).toBe('ExampleAppActivity');
+  });
+
+  it('returns null if file do not exist', () => {
+    const fakeManifestPath = findManifest('/empty');
+    expect(getMainActivity(fakeManifestPath || '')).toBeNull();
+  });
+});

--- a/packages/cli-platform-android/src/config/getMainActivity.ts
+++ b/packages/cli-platform-android/src/config/getMainActivity.ts
@@ -1,0 +1,108 @@
+import fs from 'fs';
+import {XMLParser, XMLValidator} from 'fast-xml-parser';
+
+const MAIN_ACTION = 'android.intent.action.MAIN';
+const LAUNCHER = 'android.intent.category.LAUNCHER';
+
+interface Activity {
+  [x: string]: any;
+}
+
+interface IntentFilter {
+  action:
+    | {
+        '@_android:name': string;
+      }
+    | {
+        '@_android:name': string;
+      }[];
+  category:
+    | {
+        '@_android:name': string;
+      }
+    | {
+        '@_android:name': string;
+      }[];
+}
+
+/**
+ * Reads the AndroidManifest.xml file and returns the name of the main activity.
+ */
+
+export default function getMainActivity(manifestPath: string): string | null {
+  try {
+    const xmlParser = new XMLParser({ignoreAttributes: false});
+    const manifestContent = fs.readFileSync(manifestPath, {encoding: 'utf8'});
+
+    if (XMLValidator.validate(manifestContent)) {
+      const {manifest} = xmlParser.parse(manifestContent);
+
+      const application = manifest.application || {};
+      const activity = application.activity || {};
+
+      let activities: Activity[] = [];
+
+      if (!Array.isArray(activity)) {
+        activities = [activity];
+      } else {
+        activities = activity;
+      }
+
+      const mainActivity = activities.find((act: Activity) => {
+        let intentFilters = act['intent-filter'];
+
+        if (!intentFilters) {
+          return false;
+        }
+
+        if (!Array.isArray(intentFilters)) {
+          intentFilters = [intentFilters];
+        }
+
+        return intentFilters.find((intentFilter: IntentFilter) => {
+          const {action, category} = intentFilter;
+
+          let actions;
+          let categories;
+
+          if (!Array.isArray(action)) {
+            actions = [action];
+          } else {
+            actions = action;
+          }
+
+          if (!Array.isArray(category)) {
+            categories = [category];
+          } else {
+            categories = category;
+          }
+
+          if (actions && categories) {
+            const parsedActions: string[] = actions.map(
+              ({'@_android:name': name}) => name,
+            );
+
+            const parsedCategories: string[] = categories.map(
+              ({'@_android:name': name}) => name,
+            );
+
+            return (
+              parsedActions.includes(MAIN_ACTION) &&
+              parsedCategories.includes(LAUNCHER)
+            );
+          }
+
+          return false;
+        });
+      });
+
+      return mainActivity
+        ? mainActivity['@_android:name'].replace('.', '')
+        : null;
+    } else {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli-platform-android/src/config/getMainActivity.ts
+++ b/packages/cli-platform-android/src/config/getMainActivity.ts
@@ -8,21 +8,13 @@ interface Activity {
   [x: string]: any;
 }
 
+interface AndroidNameProperty {
+  '@_android:name': string;
+}
+
 interface IntentFilter {
-  action:
-    | {
-        '@_android:name': string;
-      }
-    | {
-        '@_android:name': string;
-      }[];
-  category:
-    | {
-        '@_android:name': string;
-      }
-    | {
-        '@_android:name': string;
-      }[];
+  action: AndroidNameProperty | AndroidNameProperty[];
+  category: AndroidNameProperty | AndroidNameProperty[];
 }
 
 /**

--- a/packages/cli-platform-android/src/config/getMainActivity.ts
+++ b/packages/cli-platform-android/src/config/getMainActivity.ts
@@ -96,9 +96,7 @@ export default function getMainActivity(manifestPath: string): string | null {
         });
       });
 
-      return mainActivity
-        ? mainActivity['@_android:name'].replace('.', '')
-        : null;
+      return mainActivity ? mainActivity['@_android:name'] : null;
     } else {
       return null;
     }

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -22,6 +22,7 @@ import {findLibraryName} from './findLibraryName';
 import {findComponentDescriptors} from './findComponentDescriptors';
 import {findBuildGradle} from './findBuildGradle';
 import {CLIError} from '@react-native-community/cli-tools';
+import getMainActivity from './getMainActivity';
 
 /**
  * Gets android project config by analyzing given folder and taking some
@@ -59,10 +60,17 @@ export function projectConfig(
     );
   }
 
+  const mainActivity = getMainActivity(manifestPath || '');
+
+  if (!mainActivity) {
+    throw new CLIError(`Main activity not found in ${manifestPath}`);
+  }
+
   return {
     sourceDir,
     appName,
     packageName,
+    mainActivity,
     dependencyConfiguration: userConfig.dependencyConfiguration,
     watchModeCommandParams: userConfig.watchModeCommandParams,
     unstable_reactLegacyComponentNames:

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -2,6 +2,7 @@ export interface AndroidProjectConfig {
   sourceDir: string;
   appName: string;
   packageName: string;
+  mainActivity: string;
   dependencyConfiguration?: string;
   watchModeCommandParams?: string[];
   unstable_reactLegacyComponentNames?: string[] | null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6104,6 +6104,13 @@ fast-xml-parser@^4.0.12:
   dependencies:
     strnum "^1.0.5"
 
+fast-xml-parser@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.4.tgz#6e846ede1e56ad9e5ef07d8720809edf0ed07e9b"
+  integrity sha512-fbfMDvgBNIdDJLdLOwacjFAPYt67tr31H9ZhWSm45CDAxvd0I6WTlSOUo7K2P/K5sA5JgMKG64PI3DMcaFdWpQ==
+  dependencies:
+    strnum "^1.0.5"
+
 fastparse@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"


### PR DESCRIPTION
Summary:
---------

Fixes: https://github.com/react-native-community/cli/issues/896

In this PR I created `getMainActivity` function that reads `AndroidManifest.xml` file and gets the main activity name. 
Before this PR when user changed the main activity they have to manually provide main activity by option `--main-activity`.

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Change main activity name.
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-android
```
Main activity should be correctly read from `AndroidManifest.xml` and correctly launched on emulator.


