### PR TITLE
fix: remove useless check in `upgrade` command

### DIFF
--- a/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
@@ -66,14 +66,6 @@ export default async function getLatestRelease(
       logger.debug(`Cached release version: ${cachedLatest}`);
     }
 
-    const aWeek = 7 * 24 * 60 * 60 * 1000;
-    const lastChecked = cacheManager.get(name, 'lastChecked');
-    const now = new Date();
-    if (lastChecked && Number(now) - Number(new Date(lastChecked)) < aWeek) {
-      logger.debug('Cached release is still recent, skipping remote check');
-      return;
-    }
-
     logger.debug('Checking for newer releases on GitHub');
     const eTag = cacheManager.get(name, 'eTag');
     const {stable, candidate} = await getLatestRnDiffPurgeVersion(name, eTag);


### PR DESCRIPTION
Summary:
---------

This PR removes useless check which actually caused error when the version was released less than week ago, and if yes it returns nothing - what caused strange situation. For example if I were on `0.71.11` (latest release) and I ran `upgrade` command I had an error "Cannot figure out your...", from this line:
https://github.com/react-native-community/cli/blob/4650a8d41c5f9851e0f6bf5939a1bd8f4326c990/packages/cli/src/commands/upgrade/upgrade.ts#L13-L19

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create app with `npx react-native@latest init --version 0.71.10`
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js upgrade
```
This command should give this output:
```
To upgrade React Native please follow the instructions here:

  https://react-native-community.github.io/upgrade-helper?from=0.71.10&to=0.71.11
```
