### PR TITLE
chore: Remove generateStaticViewConfigs option from bundle command

### DIFF
--- a/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
@@ -26,7 +26,6 @@ interface RequestOptions {
   minify: boolean;
   platform: string | undefined;
   unstable_transformProfile: BundleOptions['unstable_transformProfile'];
-  generateStaticViewConfigs: boolean;
 }
 
 async function buildBundle(
@@ -87,7 +86,6 @@ export async function buildBundleWithConfig(
     minify: args.minify !== undefined ? args.minify : !args.dev,
     platform: args.platform,
     unstable_transformProfile: args.unstableTransformProfile as BundleOptions['unstable_transformProfile'],
-    generateStaticViewConfigs: args.generateStaticViewConfigs,
   };
   const server = new Server(config);
 

--- a/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
@@ -27,7 +27,6 @@ export interface CommandLineArgs {
   sourcemapUseAbsolutePath: boolean;
   verbose: boolean;
   unstableTransformProfile: string;
-  generateStaticViewConfigs: boolean;
 }
 
 export default [
@@ -123,12 +122,5 @@ export default [
     name: '--config <string>',
     description: 'Path to the CLI configuration file',
     parse: (val: string) => path.resolve(val),
-  },
-  {
-    name: '--generate-static-view-configs',
-    description:
-      'Generate static view configs for Fabric components. ' +
-      'If there are no Fabric components in the bundle or Fabric is disabled, this is just no-op.',
-    default: true,
   },
 ];


### PR DESCRIPTION
## Summary

Cleans up unused arg added in https://github.com/react-native-community/cli/pull/1595. This property is not present in Metro's source code.

@dmytrorykun has confirmed that this flag is unused.

Changelog: None

## Test Plan

—