### PR TITLE
docs: replace `master` with `main`

### DIFF
--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -22,7 +22,7 @@
     "@react-native-community/cli-types": "12.0.0-alpha.4",
     "@types/prompts": "^2.0.9"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-clean",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-clean",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -25,7 +25,7 @@
     "@types/cosmiconfig": "^5.0.3",
     "@types/glob": "^7.1.1"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-config",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-config",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-debugger-ui/package.json
+++ b/packages/cli-debugger-ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "serve-static": "^1.13.1"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/debugger-ui",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-debugger-ui",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -42,7 +42,7 @@
     "@types/semver": "^6.0.2",
     "@types/wcwidth": "^1.0.0"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-doctor",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-doctor",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-hermes/package.json
+++ b/packages/cli-hermes/package.json
@@ -23,7 +23,7 @@
     "@react-native-community/cli-types": "12.0.0-alpha.4",
     "@types/ip": "^1.1.0"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-hermes",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-hermes",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-platform-android/package.json
+++ b/packages/cli-platform-android/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/platform-android",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-platform-android",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-platform-ios/native_modules.rb
+++ b/packages/cli-platform-ios/native_modules.rb
@@ -54,7 +54,7 @@ def use_native_modules!(config = nil)
         [
           "Check to see if there is an updated version that contains the necessary podspec file",
           "Contact the library maintainers or send them a PR to add a podspec. The react-native-webview podspec is a good example of a package.json driven podspec. See https://github.com/react-native-community/react-native-webview/blob/master/react-native-webview.podspec",
-          "If necessary, you can disable autolinking for the dependency and link it manually. See https://github.com/react-native-community/cli/blob/master/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library"
+          "If necessary, you can disable autolinking for the dependency and link it manually. See https://github.com/react-native-community/cli/blob/main/docs/autolinking.md#how-can-i-disable-autolinking-for-unsupported-library"
         ])
     end
     next if podspec_path.nil? || podspec_path.empty?

--- a/packages/cli-platform-ios/package.json
+++ b/packages/cli-platform-ios/package.json
@@ -26,7 +26,7 @@
     "!*.map",
     "native_modules.rb"
   ],
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/platform-ios",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-platform-ios",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-platform-ios/src/config/__tests__/__snapshots__/findPodfilePath.test.ts.snap
+++ b/packages/cli-platform-ios/src/config/__tests__/__snapshots__/findPodfilePath.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`ios::findPodfilePath prints a warning when multile Podfiles are found 1`] = `
 Array [
   Array [
-    "Multiple Podfiles were found: bar/ios/Podfile,foo/ios/Podfile. Choosing bar/ios/Podfile automatically. If you would like to select a different one, you can configure it via \\"project.ios.sourceDir\\". You can learn more about it here: https://github.com/react-native-community/cli/blob/master/docs/configuration.md",
+    "Multiple Podfiles were found: bar/ios/Podfile,foo/ios/Podfile. Choosing bar/ios/Podfile automatically. If you would like to select a different one, you can configure it via \\"project.ios.sourceDir\\". You can learn more about it here: https://github.com/react-native-community/cli/blob/main/docs/configuration.md",
   ],
 ]
 `;

--- a/packages/cli-platform-ios/src/config/findPodfilePath.ts
+++ b/packages/cli-platform-ios/src/config/findPodfilePath.ts
@@ -55,7 +55,7 @@ export default function findPodfilePath(cwd: string) {
         inlineString(`
           Multiple Podfiles were found: ${podfiles}. Choosing ${podfiles[0]} automatically.
           If you would like to select a different one, you can configure it via "project.ios.sourceDir".
-          You can learn more about it here: https://github.com/react-native-community/cli/blob/master/docs/configuration.md
+          You can learn more about it here: https://github.com/react-native-community/cli/blob/main/docs/configuration.md
         `),
       );
     }

--- a/packages/cli-plugin-metro/README.md
+++ b/packages/cli-plugin-metro/README.md
@@ -159,7 +159,7 @@ Report SourceMapURL using its full path.
 
 Directory name where to store assets referenced in the bundle.
 
-If you are planning on building a debug APK that will run without the packager, see ([--bundle-output](https://github.com/react-native-community/cli/blob/master/docs/commands.md#--bundle-output-string))
+If you are planning on building a debug APK that will run without the packager, see ([--bundle-output](https://github.com/react-native-community/cli/blob/main/packages/cli-plugin-metro/README.md#--bundle-output-string))
 
 <details>
   Alternatively if you want to run <code>react-native bundle</code> manually and then create the APK with <code>./gradlew assembleDebug</code> you have to make sure to put the assets into the right directory, so that gradle can find them.

--- a/packages/cli-plugin-metro/package.json
+++ b/packages/cli-plugin-metro/package.json
@@ -26,7 +26,7 @@
     "build",
     "!*.map"
   ],
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-plugin-metro",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-plugin-metro",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-server-api/package.json
+++ b/packages/cli-server-api/package.json
@@ -27,7 +27,7 @@
     "build",
     "!*.map"
   ],
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-server-api",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-server-api",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -30,7 +30,7 @@
     "!*.d.ts",
     "!*.map"
   ],
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/tools",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-tools",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -14,7 +14,7 @@
   },
   "types": "build/index.d.ts",
   "license": "MIT",
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli-types",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-types",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,7 +52,7 @@
     "slash": "^3.0.0",
     "snapshot-diff": "^0.7.0"
   },
-  "homepage": "https://github.com/react-native-community/cli/tree/master/packages/cli",
+  "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli",
   "repository": {
     "type": "git",
     "url": "https://github.com/react-native-community/cli.git",

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -50,7 +50,7 @@ export function getTemplateConfig(
     throw new CLIError(
       `Couldn't find the "${configFilePath} file inside "${templateName}" template. Please make sure the template is valid.
       Read more: ${chalk.underline.dim(
-        'https://github.com/react-native-community/cli/blob/master/docs/init.md#creating-custom-template',
+        'https://github.com/react-native-community/cli/blob/main/docs/init.md#creating-custom-template',
       )}`,
     );
   }


### PR DESCRIPTION
Summary:
---------
Changed from `master` to `main` in links, and also some links in `homepage` field in `package.json` didn't have `cli` prefix 🙈

Test Plan:
----------
All links should work now. ✅