### PR TITLE
fix: remove `@ts-ignore` in `cli-plugin-metro`

### DIFF
--- a/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
@@ -7,8 +7,7 @@
  */
 
 import Server from 'metro/src/Server';
-// @ts-ignore - no typed definition for the package
-const outputBundle = require('metro/src/shared/output/bundle');
+import outputBundle from 'metro/src/shared/output/bundle';
 import type {BundleOptions} from 'metro/src/shared/types';
 import type {ConfigT} from 'metro-config';
 import path from 'path';
@@ -24,7 +23,7 @@ interface RequestOptions {
   sourceMapUrl: string | undefined;
   dev: boolean;
   minify: boolean;
-  platform: string | undefined;
+  platform: string;
   unstable_transformProfile: BundleOptions['unstable_transformProfile'];
 }
 

--- a/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/bundleCommandLineArgs.ts
@@ -20,7 +20,7 @@ export interface CommandLineArgs {
   platform: string;
   dev: boolean;
   bundleOutput: string;
-  bundleEncoding?: string;
+  bundleEncoding?: 'utf8' | 'utf16le' | 'ascii';
   maxWorkers?: number;
   sourcemapOutput?: string;
   sourcemapSourcesRoot?: string;

--- a/packages/cli-plugin-metro/src/commands/start/runServer.ts
+++ b/packages/cli-plugin-metro/src/commands/start/runServer.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// @ts-ignore untyped metro
 import Metro from 'metro';
 import type Server from 'metro/src/Server';
 import type {Middleware} from 'metro-config';


### PR DESCRIPTION
Summary:
---------

Removes `@ts-ignore` from `cli-plugin-metro` package, and now types matches in types in Metro.

Test Plan:
----------
CI Green ✅