### PR TITLE
fix: Potential EEXIST error when iOS asset catalog dir already exists

### DIFF
--- a/packages/cli-plugin-metro/src/commands/bundle/assetCatalogIOS.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/assetCatalogIOS.ts
@@ -49,7 +49,7 @@ export function isCatalogAsset(asset: AssetData): boolean {
 }
 
 export function writeImageSet(imageSet: ImageSet): void {
-  fs.mkdirSync(imageSet.basePath);
+  fs.mkdirSync(imageSet.basePath, {recursive: true});
 
   for (const file of imageSet.files) {
     const dest = path.join(imageSet.basePath, file.name);


### PR DESCRIPTION
Summary:
---------

https://github.com/react-native-community/cli/pull/1971 sought to replace `fs-extra` with native `fs` APIs but missed the behaviour difference of the subtly-differently-named API. [`fsExtra.mkdirsSync`](https://github.com/jprichardson/node-fs-extra/blob/v2.1.2/docs/ensureDir-sync.md) operates like `mkdir -p` - recursively creating non-existent directories, and not complaining when a directory already exists. 

This is the behaviour of [`fs.mkdirSync`](https://nodejs.org/api/fs.html#fsmkdirpath-options-callback) if and only if `recursive` is set.

> If `recursive` is `false` and the directory exists, an `EEXIST` error occurs.

CC @huntie 

Test Plan:
----------

Restores previous behaviour