### PR TITLE
fix: filter depreciation warning in `run/build-android` commands

### DIFF
--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -13,6 +13,7 @@ import getAdbPath from '../runAndroid/getAdbPath';
 import {startServerInNewWindow} from '@react-native-community/cli-plugin-metro';
 import {getTaskNames} from '../runAndroid/getTaskNames';
 import {promptForTaskSelection} from '../runAndroid/listAndroidTasks';
+import {filterGradlewOutput} from '../../tools/filterGradlewOutput';
 
 export interface BuildFlags {
   mode?: string;
@@ -129,9 +130,13 @@ export function build(gradleArgs: string[], sourceDir: string) {
   logger.info('Building the app...');
   logger.debug(`Running command "${cmd} ${gradleArgs.join(' ')}"`);
   try {
-    execa.sync(cmd, gradleArgs, {
-      stdio: 'inherit',
+    const {stdout} = execa(cmd, gradleArgs, {
+      buffer: true,
       cwd: sourceDir,
+    });
+
+    stdout?.on('data', (data) => {
+      filterGradlewOutput(data.toString());
     });
   } catch (error) {
     printRunDoctorTip();

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -22,6 +22,7 @@ import tryLaunchEmulator from './tryLaunchEmulator';
 import tryInstallAppOnDevice from './tryInstallAppOnDevice';
 import {getTaskNames} from './getTaskNames';
 import type {Flags} from '.';
+import {filterGradlewOutput} from '../../tools/filterGradlewOutput';
 
 type AndroidProject = NonNullable<Config['project']['android']>;
 
@@ -99,9 +100,13 @@ async function runOnAllDevices(
         `Running command "cd android && ${cmd} ${gradleArgs.join(' ')}"`,
       );
 
-      await execa(cmd, gradleArgs, {
-        stdio: ['inherit', 'inherit', 'pipe'],
+      const {stdout} = execa(cmd, gradleArgs, {
+        buffer: true,
         cwd: androidProject.sourceDir,
+      });
+
+      stdout?.on('data', (data) => {
+        filterGradlewOutput(data.toString());
       });
     }
   } catch (error) {

--- a/packages/cli-platform-android/src/tools/filterGradlewOutput.ts
+++ b/packages/cli-platform-android/src/tools/filterGradlewOutput.ts
@@ -1,0 +1,26 @@
+import {logger} from '@react-native-community/cli-tools';
+
+/**
+ *
+ * @param output
+
+  This function takes the output of the gradlew command and filters out the deprecation warning about setting the namespace in `AndroidManifest.xml`.
+
+  Warning:
+  package="com.library" found in source AndroidManifest.xml: /Users/user/app/node_modules/library/android/src/main/AndroidManifest.xml.
+  Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
+
+  Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: https://developer.android.com/studio/build/configure-app-module#set-namespace
+
+  This migration can be done automatically using the AGP Upgrade Assistant, please refer to https://developer.android.com/studio/build/agp-upgrade-assistant for more information.
+ */
+
+export const filterGradlewOutput = (output: string) => {
+  const regex = new RegExp(
+    /package="([^"]+)" found in source AndroidManifest\.xml:(.*?)Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated\.(.*?)Please instead set the namespace \(or testNamespace\) in the module's build\.gradle file, as described here: https:\/\/developer\.android\.com\/studio\/build\/configure-app-module#set-namespace(.*?\n)*This migration can be done automatically using the AGP Upgrade Assistant, please refer to https:\/\/developer\.android\.com\/studio\/build\/agp-upgrade-assistant for more information\./gms,
+  );
+
+  if (!regex.test(output)) {
+    logger.log(output);
+  }
+};

--- a/packages/cli-platform-android/src/tools/filterGradlewOutput.ts
+++ b/packages/cli-platform-android/src/tools/filterGradlewOutput.ts
@@ -1,10 +1,10 @@
-import {logger} from '@react-native-community/cli-tools';
-
 /**
  *
  * @param output
 
   This function takes the output of the gradlew command and filters out the deprecation warning about setting the namespace in `AndroidManifest.xml`.
+
+  For wider context, see https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1597386954
 
   Warning:
   package="com.library" found in source AndroidManifest.xml: /Users/user/app/node_modules/library/android/src/main/AndroidManifest.xml.
@@ -21,6 +21,6 @@ export const filterGradlewOutput = (output: string) => {
   );
 
   if (!regex.test(output)) {
-    logger.log(output);
+    console.log(output);
   }
 };


### PR DESCRIPTION
Summary:
---------
Recently there was created [discussion](https://github.com/react-native-community/discussions-and-proposals/issues/671) about removing `package` property from library's `AndroidManifest.xml`, and use `namespace` in `build.gradle`. But it turned out that [it breaks compatibility](https://github.com/react-native-community/discussions-and-proposals/issues/671#issuecomment-1597341277) and if you wish to retain the highest compatibility it's better to don't remove the `package` property from `AndroidManifest.xml`, and keep both these fields. And that's totally fine, but if we have `package` property and we're on RN version > 71 we'll see the warning about  deprecation (that you should specify namespace via `build.gradle`).

In this PR I added filtering deprecation warning from gradlew commands output. 

### TODO:
- [ ] Test changes on Windows.

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create app with RN version > 71
3. Install library that have in `AndroidManifest.xml` `package` property, e.g. `yarn add react-native-pager-view`
4. Run this command
```bash
node /path/to/react-native-cli/packages/cli/build/bin.js run-android 
```

You shouldn't see warning regarding that setting `package` property in `AndroidManifest.xml` is deprecated. 



