### PR TITLE
Update `react-native run-ios` command error output.

### DIFF
--- a/packages/cli-platform-ios/src/commands/buildIOS/buildProject.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/buildProject.ts
@@ -111,9 +111,9 @@ export function buildProject(
             `
             Failed to build iOS project.
 
-            We ran "xcodebuild" command but it exited with error code ${code}. To debug build
+            "xcodebuild" exited with error code '${code}'. To debug build
             logs further, consider building your app with Xcode.app, by opening
-            ${xcodeProject.name}.
+            '${xcodeProject.name}'.
           `,
             xcodebuildOutputFormatter
               ? undefined


### PR DESCRIPTION
Summary:
---------

This PR cleans up the error message when running `react-native run-ios`. It is now shorter, variables are escaped, and most importantly it removes the "We" which has no meaning in the context of running a command on my computer.


Test Plan:
----------

Check the output of `react-native run-ios` when it throws an error.
