### PR TITLE
fix: init when there's a package.json in folder

### DIFF
--- a/packages/cli-tools/src/releaseChecker/index.ts
+++ b/packages/cli-tools/src/releaseChecker/index.ts
@@ -75,7 +75,7 @@ export function current(projectRoot: string): SemVer | undefined {
     if (found) {
       return found;
     }
-  } catch (_) {
+  } catch {
     throw new UnknownProjectError(projectRoot);
   }
   return undefined;


### PR DESCRIPTION
Summary:
---------

When `init` in a folder that contains any kind of `package.json` the failed with:
```
error Failed to load configuration of your project.
```

This is due to `reactNativeVersion` introduced in https://github.com/react-native-community/cli/pull/1870 accessing the `initialConfig.reactNativePath` getter, which throws in situations where there's no `package.json` file available in the directory. Reading this in `finalConfig` is fine, because when there's no `package.json`, it skips the logic inside the `.reduce`, which accesses `initialConfig.reactNativePath` variable. 

Tbh, this is rather convoluted logic and because of that during code review we failed identifying it as a potential problem. Let's treat this as a band-aid for now and as a followup think about refactoring this piece. 


Test Plan:
----------

I haven't really tested the versioned link generation, so please make sure to verify it