### PR TITLE
fix: "Multiple Podfiles were found" due to vendor inclusion

### DIFF
--- a/packages/cli-platform-ios/src/config/findAllPodfilePaths.ts
+++ b/packages/cli-platform-ios/src/config/findAllPodfilePaths.ts
@@ -8,7 +8,7 @@
 import glob from 'glob';
 
 // These folders will be excluded from search to speed it up
-const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules|Carthage)/**'];
+const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules|Carthage|vendor)/**'];
 
 export default function findAllPodfilePaths(cwd: string) {
   return glob.sync('**/Podfile', {


### PR DESCRIPTION
Summary:
---------

`cli-plugin-ios` performs a glob search for `Podfile` as a heuristic for the ios project root. In a default installation, where Bundler installs Cocoapods as a gem into `vendor`, the vendored cocoapods directory itself contains a Podfile, and this leads to a harmless but noisy warning:

> warn Multiple Podfiles were found: ios/Podfile,vendor/bundle/ruby/2.7.0/gems/cocoapods-core-1.12.1/lib/cocoapods-core/Podfile. Choosing ios/Podfile automatically. If you would like to select a different one, you can configure it via "project.ios.sourceDir". You can learn more about it here: https://github.com/react-native-community/cli/blob/master/docs/configuration.md

This amends the existing exclusion list for the `Podfile` search (which already hardcodes and exclusion for eg `/node_modules/` to also exclude Bundler's equivalent, `/vendor/`.

Test Plan:
----------

Made this change locally (I happen to be working in RN 0.71.11 but I don't think anything relevant has changed here)

## Before

<img width="892" alt="image" src="https://github.com/react-native-community/cli/assets/2590098/c0e6828d-1325-4cf2-af45-1765a47c35d8">


## After

<img width="895" alt="image" src="https://github.com/react-native-community/cli/assets/2590098/a4151dc9-f6c9-4afc-8a45-67f91acdf22f">
