### PR TITLE
feat: Add alternative base config check to loadMetroConfig (11.x)

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -20,6 +20,10 @@ export type ConfigLoadingContext = Pick<
   'root' | 'reactNativePath' | 'platforms'
 >;
 
+declare global {
+  var __REACT_NATIVE_METRO_CONFIG_LOADED: boolean;
+}
+
 /**
  * Get the config options to override based on RN CLI inputs.
  */
@@ -98,6 +102,9 @@ export default async function loadMetroConfig(
   logger.debug(`Reading Metro config from ${projectConfig.filepath}`);
 
   if (
+    !global.__REACT_NATIVE_METRO_CONFIG_LOADED &&
+    // TODO(huntie): Remove this check from 0.73 onwards (all users will be on
+    // the next major @react-native/metro-config version)
     !/['"']@react-native\/metro-config['"']/.test(
       fs.readFileSync(projectConfig.filepath, 'utf8'),
     )


### PR DESCRIPTION
## Summary

Resolves https://github.com/react-native-community/cli/issues/1987.

Adds improved check to detect if `@react-native/metro-config` (containing the base Metro config for all non-Expo React Native apps — and including `rnx-kit`) has been loaded for a given project. Paired with change:

- https://github.com/facebook/react-native/pull/38126

Since we cannot expect all users to bump `@react-native/metro-config` in their project between `0.72.0` → `0.72.1`, the previous check remains alongside this. If one of these detection methods works, no warning/fallback loading is performed.

**Targets the `11.x` branch (React Native 0.72).**

---

**📦 Please publish!**: We'd like to get this convenience fix to users for React Native 0.72.1.

---

## Test Plan

**Remove `@react-native/metro-config` import from config file (existing check)**

<img width="1095" alt="image" src="https://github.com/react-native-community/cli/assets/2547783/6ab0d950-6a59-4f3d-8c58-4ba2707404af">

✅ Logs warning and falls back to legacy defaults

**Load `@react-native/metro-config` defaults in separate file (new check needed)**

- With https://github.com/facebook/react-native/pull/38126 applied via `yarn link @react-native/metro-config`

<img width="1127" alt="image" src="https://github.com/react-native-community/cli/assets/2547783/c8b947ac-4d4a-4cd3-b2a2-af1a0f9a971e">

✅ No warning logged, proceeds, builds
(Ignore unrelated newer config option warning)
