### PR TITLE
npmPackageName should be resolved from project root, not from cli-plugin-metro

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -55,7 +55,7 @@ function getOverrideConfig(ctx: ConfigLoadingContext): InputConfigT {
         ...outOfTreePlatforms.map((platform) =>
           require.resolve(
             `${ctx.platforms[platform]
-              .npmPackageName!}/Libraries/Core/InitializeCore`,
+              .npmPackageName!}/Libraries/Core/InitializeCore`, {paths: [ctx.root]}
           ),
         ),
       ],

--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -55,7 +55,8 @@ function getOverrideConfig(ctx: ConfigLoadingContext): InputConfigT {
         ...outOfTreePlatforms.map((platform) =>
           require.resolve(
             `${ctx.platforms[platform]
-              .npmPackageName!}/Libraries/Core/InitializeCore`, {paths: [ctx.root]}
+              .npmPackageName!}/Libraries/Core/InitializeCore`,
+            {paths: [ctx.root]},
           ),
         ),
       ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,9 +5102,9 @@ dayjs@^1.8.15:
   integrity sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ==
 
 deasync@^0.1.14:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.19.tgz#e7ea89fcc9ad483367e8a48fe78f508ca86286e8"
-  integrity sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.28.tgz#9b447b79b3f822432f0ab6a8614c0062808b5ad2"
+  integrity sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"


### PR DESCRIPTION
Summary:
---------

When resolving npmPackageName currently, we are resolving it from the cli-plugin-metro package. But cli-plugin-metro does not have a direct dependency on any of the out of tree platform packages (say react-native-windows or react-native-macos).  Instead we should be resolving npmPackageName from the project root, which will have the out of tree package as a dependency.

This generally works today because so many package managers hoist everything and so packages can resolve other packages that are used in the repo even if they are not declared as dependencies.  But some package managers are moving to be more strict about this.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
