### PR TITLE
fix: adjust `doctor` command to work with custom `ios/` folder location

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
@@ -28,9 +28,7 @@ export default {
   description: 'File to customize Xcode environment',
   getDiagnostics: async (_, config) => {
     try {
-      const iosFolderPath = config?.project.ios
-        ? config?.project.ios.sourceDir
-        : '';
+      const iosFolderPath = config?.project.ios?.sourceDir ?? '';
 
       const missingXcodeEnvFile = findPodfilePaths(iosFolderPath).some(
         (podfilePath) => {
@@ -61,9 +59,7 @@ export default {
       const src = path.join(templateIosPath, templateXcodeEnv);
       const copyFileAsync = promisify(fs.copyFile);
 
-      const iosFolderPath = config?.project.ios
-        ? config?.project.ios.sourceDir
-        : '';
+      const iosFolderPath = config?.project.ios?.sourceDir ?? '';
 
       findPodfilePaths(iosFolderPath)
         .map((podfilePath) =>

--- a/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/xcodeEnv.ts
@@ -9,14 +9,13 @@ import {promisify} from 'util';
 import {HealthCheckInterface} from '../../types';
 
 const xcodeEnvFile = '.xcode.env';
-const pathSeparator = '/';
 
 function removeLastPathComponent(pathString: string): string {
   return path.dirname(pathString);
 }
 
 function pathHasXcodeEnvFile(pathString: string): boolean {
-  const xcodeEnvPath = pathString + pathSeparator + xcodeEnvFile;
+  const xcodeEnvPath = path.join(pathString, xcodeEnvFile);
   return fs.existsSync(xcodeEnvPath);
 }
 
@@ -29,11 +28,18 @@ export default {
   description: 'File to customize Xcode environment',
   getDiagnostics: async (_, config) => {
     try {
-      const projectRoot = config?.root ?? findProjectRoot();
-      const missingXcodeEnvFile = findPodfilePaths(projectRoot).some((p) => {
-        const basePath = path.dirname(p);
-        return !pathHasXcodeEnvFile(basePath);
-      });
+      const iosFolderPath = config?.project.ios
+        ? config?.project.ios.sourceDir
+        : '';
+
+      const missingXcodeEnvFile = findPodfilePaths(iosFolderPath).some(
+        (podfilePath) => {
+          return !pathHasXcodeEnvFile(
+            removeLastPathComponent(path.join(iosFolderPath, podfilePath)),
+          );
+        },
+      );
+
       return {
         needsToBeFixed: missingXcodeEnvFile,
       };
@@ -52,15 +58,21 @@ export default {
         projectRoot,
         'react-native/template/ios',
       );
-      const src = templateIosPath + pathSeparator + templateXcodeEnv;
+      const src = path.join(templateIosPath, templateXcodeEnv);
       const copyFileAsync = promisify(fs.copyFile);
 
-      findPodfilePaths(projectRoot)
-        .map(removeLastPathComponent)
+      const iosFolderPath = config?.project.ios
+        ? config?.project.ios.sourceDir
+        : '';
+
+      findPodfilePaths(iosFolderPath)
+        .map((podfilePath) =>
+          removeLastPathComponent(path.join(iosFolderPath, podfilePath)),
+        )
         // avoid overriding existing .xcode.env
         .filter(pathDoesNotHaveXcodeEnvFile)
         .forEach(async (pathString: string) => {
-          const destFilePath = pathString + pathSeparator + xcodeEnvFile;
+          const destFilePath = path.join(pathString, xcodeEnvFile);
           await copyFileAsync(src, destFilePath);
         });
       loader.succeed('.xcode.env file have been created!');


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/1989
Right now when looking for `.xcode.env` file, we look in directories defined in `react-native.config.js`. It fixes the problem for the brownfield setups, where very often there `ios/` folder is not in the default location. 

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js doctor
```
Should find the `.xcode.env`, and if it doesn't exist - after fixing issues by pressing `f` inside terminal, it should create the file in correct location.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
