### PR TITLE
Allow out of tree platforms to provide customized saveAssets experiences

### DIFF
--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -96,6 +96,7 @@ export const dependencyConfig = t
       t.string(),
       t.object({
         npmPackageName: t.string().optional(),
+        saveAssetsPlugin: t.string().optional(),
         dependencyConfig: t.func(),
         projectConfig: t.func(),
         linkConfig: t.func(),
@@ -180,6 +181,7 @@ export const projectConfig = t
       t.string(),
       t.object({
         npmPackageName: t.string().optional(),
+        saveAssetsPlugin: t.string().optional(),
         dependencyConfig: t.func(),
         projectConfig: t.func(),
         linkConfig: t.func(),

--- a/packages/cli-plugin-metro/src/commands/bundle/__tests__/filterPlatformAssetScales-test.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/__tests__/filterPlatformAssetScales-test.ts
@@ -14,23 +14,23 @@ jest.dontMock('../filterPlatformAssetScales').dontMock('../assetPathUtils');
 
 describe('filterPlatformAssetScales', () => {
   it('removes everything but 2x and 3x for iOS', () => {
-    expect(filterPlatformAssetScales('ios', [1, 1.5, 2, 3, 4])).toEqual([
+    expect(filterPlatformAssetScales([1, 2, 3], [1, 1.5, 2, 3, 4])).toEqual([
       1,
       2,
       3,
     ]);
-    expect(filterPlatformAssetScales('ios', [3, 4])).toEqual([3]);
+    expect(filterPlatformAssetScales([1, 2, 3], [3, 4])).toEqual([3]);
   });
 
   it('keeps closest largest one if nothing matches', () => {
-    expect(filterPlatformAssetScales('ios', [0.5, 4, 100])).toEqual([4]);
-    expect(filterPlatformAssetScales('ios', [0.5, 100])).toEqual([100]);
-    expect(filterPlatformAssetScales('ios', [0.5])).toEqual([0.5]);
-    expect(filterPlatformAssetScales('ios', [])).toEqual([]);
+    expect(filterPlatformAssetScales([1, 2, 3], [0.5, 4, 100])).toEqual([4]);
+    expect(filterPlatformAssetScales([1, 2, 3], [0.5, 100])).toEqual([100]);
+    expect(filterPlatformAssetScales([1, 2, 3], [0.5])).toEqual([0.5]);
+    expect(filterPlatformAssetScales([1, 2, 3], [])).toEqual([]);
   });
 
   it('keeps all scales for unknown platform', () => {
-    expect(filterPlatformAssetScales('freebsd', [1, 1.5, 2, 3.7])).toEqual([
+    expect(filterPlatformAssetScales(undefined, [1, 1.5, 2, 3.7])).toEqual([
       1,
       1.5,
       2,

--- a/packages/cli-plugin-metro/src/commands/bundle/__tests__/getAssetDestPathIOS-test.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/__tests__/getAssetDestPathIOS-test.ts
@@ -8,9 +8,9 @@
  * @emails oncall+javascript_foundation
  */
 
-import getAssetDestPathIOS from '../getAssetDestPathIOS';
+import getAssetDestPath from '../getAssetDestPath';
 
-jest.dontMock('../getAssetDestPathIOS');
+jest.dontMock('../getAssetDestPath');
 
 const path = require('path');
 
@@ -22,7 +22,7 @@ describe('getAssetDestPathIOS', () => {
       httpServerLocation: '/assets/test',
     };
 
-    expect(getAssetDestPathIOS(asset, 1)).toBe(
+    expect(getAssetDestPath(asset, 1)).toBe(
       path.normalize('assets/test/icon.png'),
     );
   });
@@ -34,10 +34,10 @@ describe('getAssetDestPathIOS', () => {
       httpServerLocation: '/assets/test',
     };
 
-    expect(getAssetDestPathIOS(asset, 2)).toBe(
+    expect(getAssetDestPath(asset, 2)).toBe(
       path.normalize('assets/test/icon@2x.png'),
     );
-    expect(getAssetDestPathIOS(asset, 3)).toBe(
+    expect(getAssetDestPath(asset, 3)).toBe(
       path.normalize('assets/test/icon@3x.png'),
     );
   });
@@ -49,7 +49,7 @@ describe('getAssetDestPathIOS', () => {
       httpServerLocation: '/assets/../../test',
     };
 
-    expect(getAssetDestPathIOS(asset, 1)).toBe(
+    expect(getAssetDestPath(asset, 1)).toBe(
       path.normalize('assets/__test/icon.png'),
     );
   });

--- a/packages/cli-plugin-metro/src/commands/bundle/filterPlatformAssetScales.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/filterPlatformAssetScales.ts
@@ -6,15 +6,10 @@
  *
  */
 
-const ALLOWED_SCALES: {[key: string]: number[]} = {
-  ios: [1, 2, 3],
-};
-
 function filterPlatformAssetScales(
-  platform: string,
+  whitelist: ReadonlyArray<number> | undefined,
   scales: ReadonlyArray<number>,
 ): ReadonlyArray<number> {
-  const whitelist: number[] = ALLOWED_SCALES[platform];
   if (!whitelist) {
     return scales;
   }

--- a/packages/cli-plugin-metro/src/commands/bundle/getAssetDestPath.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/getAssetDestPath.ts
@@ -9,7 +9,7 @@
 import path from 'path';
 import {PackagerAsset} from './assetPathUtils';
 
-function getAssetDestPathIOS(asset: PackagerAsset, scale: number): string {
+function getAssetDestPath(asset: PackagerAsset, scale: number): string {
   const suffix = scale === 1 ? '' : `@${scale}x`;
   const fileName = `${asset.name + suffix}.${asset.type}`;
   return path.join(
@@ -21,4 +21,4 @@ function getAssetDestPathIOS(asset: PackagerAsset, scale: number): string {
   );
 }
 
-export default getAssetDestPathIOS;
+export default getAssetDestPath;

--- a/packages/cli-plugin-metro/src/commands/bundle/saveAssetsAndroid.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/saveAssetsAndroid.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {AssetData} from 'metro';
+import getAssetDestPathAndroid from './getAssetDestPathAndroid';
+
+function saveAssetsAndroid(
+  assets: ReadonlyArray<AssetData>,
+  _platform: string,
+  _assetsDest: string | undefined,
+  _assetCatalogDest: string | undefined,
+  addAssetToCopy: (
+    asset: AssetData,
+    allowedScales: number[] | undefined,
+    getAssetDestPath: (asset: AssetData, scale: number) => string,
+  ) => void,
+) {
+  assets.forEach((asset) =>
+    addAssetToCopy(asset, undefined, getAssetDestPathAndroid),
+  );
+}
+
+export default saveAssetsAndroid;

--- a/packages/cli-plugin-metro/src/commands/bundle/saveAssetsDefault.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/saveAssetsDefault.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import type {AssetData} from 'metro';
+import getAssetDestPath from './getAssetDestPath';
+
+function saveAssetsDefault(
+  assets: ReadonlyArray<AssetData>,
+  _platform: string,
+  _assetsDest: string | undefined,
+  _assetCatalogDest: string | undefined,
+  addAssetToCopy: (
+    asset: AssetData,
+    allowedScales: number[] | undefined,
+    getAssetDestPath: (asset: AssetData, scale: number) => string,
+  ) => void,
+) {
+  assets.forEach((asset) => addAssetToCopy(asset, undefined, getAssetDestPath));
+}
+
+export default saveAssetsDefault;

--- a/packages/cli-plugin-metro/src/commands/bundle/saveAssetsIOS.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/saveAssetsIOS.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {logger} from '@react-native-community/cli-tools';
+import fs from 'fs';
+import type {AssetData} from 'metro';
+import path from 'path';
+import {
+  cleanAssetCatalog,
+  getImageSet,
+  isCatalogAsset,
+  writeImageSet,
+} from './assetCatalogIOS';
+import filterPlatformAssetScales from './filterPlatformAssetScales';
+import getAssetDestPath from './getAssetDestPath';
+
+const ALLOWED_SCALES = [1, 2, 3];
+
+function saveAssetsIOS(
+  assets: ReadonlyArray<AssetData>,
+  _platform: string,
+  _assetsDest: string | undefined,
+  assetCatalogDest: string | undefined,
+  addAssetToCopy: (
+    asset: AssetData,
+    allowedScales: number[] | undefined,
+    getAssetDestPath: (asset: AssetData, scale: number) => string,
+  ) => void,
+) {
+  if (assetCatalogDest != null) {
+    // Use iOS Asset Catalog for images. This will allow Apple app thinning to
+    // remove unused scales from the optimized bundle.
+    const catalogDir = path.join(assetCatalogDest, 'RNAssets.xcassets');
+    if (!fs.existsSync(catalogDir)) {
+      logger.error(
+        `Could not find asset catalog 'RNAssets.xcassets' in ${assetCatalogDest}. Make sure to create it if it does not exist.`,
+      );
+      return;
+    }
+
+    logger.info('Adding images to asset catalog', catalogDir);
+    cleanAssetCatalog(catalogDir);
+    for (const asset of assets) {
+      if (isCatalogAsset(asset)) {
+        const imageSet = getImageSet(
+          catalogDir,
+          asset,
+          filterPlatformAssetScales(ALLOWED_SCALES, asset.scales),
+        );
+        writeImageSet(imageSet);
+      } else {
+        addAssetToCopy(asset, ALLOWED_SCALES, getAssetDestPath);
+      }
+    }
+    logger.info('Done adding images to asset catalog');
+  } else {
+    assets.forEach((asset) =>
+      addAssetToCopy(asset, ALLOWED_SCALES, getAssetDestPath),
+    );
+  }
+}
+
+export default saveAssetsIOS;

--- a/packages/cli-types/src/index.ts
+++ b/packages/cli-types/src/index.ts
@@ -66,6 +66,7 @@ interface PlatformConfig<
   DependencyParams
 > {
   npmPackageName?: string;
+  saveAssetsPlugin?: string;
   projectConfig: (
     projectRoot: string,
     projectParams: ProjectParams | void,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5102,9 +5102,9 @@ dayjs@^1.8.15:
   integrity sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ==
 
 deasync@^0.1.14:
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.19.tgz#e7ea89fcc9ad483367e8a48fe78f508ca86286e8"
-  integrity sha512-oh3MRktfnPlLysCPpBpKZZzb4cUC/p0aA3SyRGp15lN30juJBTo/CiD0d4fR+f1kBtUQoJj1NE9RPNWQ7BQ9Mg==
+  version "0.1.28"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.28.tgz#9b447b79b3f822432f0ab6a8614c0062808b5ad2"
+  integrity sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"


### PR DESCRIPTION
Summary:
---------

Currently the CLI provides logic to `saveAssets` for iOS/Android.  -- with some combination of the two implementations working for the basic cases for other platforms.  But as other platforms mature, they want to be able to provide more platform specific optimizations similar to how iOS provides logic to generate asset catalogs.

This change introduces a new property to react-native config for platform out of tree implementations to optionally provide.  This property provides a location for a js module that can be used to call into a platform specific implementation of much of the saveAssets logic.

For example, macos would be able to duplicate the iOS asset catalog behavior.  And windows could modify the asset filenames to align with its native scaling logic.

Test Plan:
----------

https://github.com/microsoft/react-native-windows/pull/11839 adds support for the new `saveAssetsPlugin` property to successfully relocate assets.

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
