### PR TITLE
fix : Getting rid of duplicate gradle error messages

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -122,7 +122,7 @@ async function runOnAllDevices(
 
 function createInstallError(error: Error & {stderr: string}) {
   const stderr = (error.stderr || '').toString();
-  let message = error.message ?? '';
+  let message = '';
   // Pass the error message from the command to stdout because we pipe it to
   // parent process so it's not visible
   logger.log(stderr);
@@ -148,8 +148,8 @@ function createInstallError(error: Error & {stderr: string}) {
   }
 
   return new CLIError(
-    `Failed to install the app. ${message}`,
-    message.length > 0 ? undefined : error,
+    `Failed to install the app.${message || ''}`,
+    error.message.length > 0 ? undefined : error,
   );
 }
 

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -148,7 +148,7 @@ function createInstallError(error: Error & {stderr: string}) {
   }
 
   return new CLIError(
-    `Failed to install the app.${message || ''}`,
+    `Failed to install the app.${message ? ' ' + message : ''}`,
     error.message.length > 0 ? undefined : error,
   );
 }


### PR DESCRIPTION
Summary:
---------

Getting rid of duplicate error logging for Gradle. Leaving error messages for specific cases like :

1. No connected devices
2. License
3. Incompatible Java version

in place where we already know what's wrong and provide more helpful error message instead of dumping gradle error. However in all other generic cases, getting rid of duplicate error messages for Gradle.

Test Plan:
----------

1. Build cli codebase using : `node ./scripts/build.js && yarn build:debugger`
4. `cd packages/cli-platform-android`
5. Link packages using : `yarn link`
6. In RN app AwesomeProject, run `yarn link "@react-native-community/cli-platform-android"` to see successful linking :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % yarn link "@react-native-community/cli-platform-android"
yarn link v1.22.19
warning ../package.json: No license field
success Using linked package for "@react-native-community/cli-platform-android".
✨  Done in 0.02s.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```

BEFORE :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % npx react-native run-android
info Starting JS server...
info Launching emulator...
error Failed to launch emulator. Reason: The emulator (Pixel_5_API_33) quit before it finished opening. You can try starting the emulator manually from the terminal with: /opt/android_sdk/emulator/emulator @Pixel_5_API_33.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.

info 💡 Tip: Make sure that you have set up your development environment correctly, by running react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor 


FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'AwesomeProject'.
> Could not determine the dependencies of null.
   > Could not resolve all task dependencies for configuration ':classpath'.
      > Could not find com.android.tools.build:gradle:.
        Required by:
            project :
      > Could not resolve com.facebook.react:react-native-gradle-plugin.
        Required by:
            project :
         > No matching variant of project :gradle-plugin was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.0.1' but:
             - Variant 'apiElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a library, packaged as a jar, and its dependencies declared externally:
                 - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
                 - Other compatible attribute:
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
             - Variant 'mainSourceElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a component, and its dependencies declared externally:
                 - Incompatible because this component declares a component of category 'verification' and the consumer needed a library
                 - Other compatible attributes:
                     - Doesn't say anything about its target Java version (required compatibility with Java 8)
                     - Doesn't say anything about its elements (required them packaged as a jar)
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
                     - Doesn't say anything about its usage (required runtime)
             - Variant 'runtimeElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
                 - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
                 - Other compatible attribute:
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
             - Variant 'testResultsElementsForTest' capability com.facebook.react:react-native-gradle-plugin:unspecified:
                 - Incompatible because this component declares a component of category 'verification' and the consumer needed a library
                 - Other compatible attributes:
                     - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                     - Doesn't say anything about its target Java version (required compatibility with Java 8)
                     - Doesn't say anything about its elements (required them packaged as a jar)
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
                     - Doesn't say anything about its usage (required runtime)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
error Failed to install the app. Command failed with exit code 1: ./gradlew tasks FAILURE: Build failed with an exception. * What went wrong:
A problem occurred configuring root project 'AwesomeProject'.
> Could not determine the dependencies of null. > Could not resolve all task dependencies for configuration ':classpath'. > Could not find com.android.tools.build:gradle:. Required by: project : > Could not resolve com.facebook.react:react-native-gradle-plugin. Required by: project : > No matching variant of project :gradle-plugin was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.0.1' but: - Variant 'apiElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a library, packaged as a jar, and its dependencies declared externally: - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8 - Other compatible attribute: - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1') - Variant 'mainSourceElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a component, and its dependencies declared externally: - Incompatible because this component declares a component of category 'verification' and the consumer needed a library - Other compatible attributes: - Doesn't say anything about its target Java version (required compatibility with Java 8) - Doesn't say anything about its elements (required them packaged as a jar) - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1') - Doesn't say anything about its usage (required runtime) - Variant 'runtimeElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a library for use during runtime, packaged as a jar, and its dependencies declared externally: - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8 - Other compatible attribute: - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1') - Variant 'testResultsElementsForTest' capability com.facebook.react:react-native-gradle-plugin:unspecified: - Incompatible because this component declares a component of category 'verification' and the consumer needed a library - Other compatible attributes: - Doesn't say anything about how its dependencies are found (required its dependencies declared externally) - Doesn't say anything about its target Java version (required compatibility with Java 8) - Doesn't say anything about its elements (required them packaged as a jar) - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1') - Doesn't say anything about its usage (required runtime) * Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights. * Get more help at https://help.gradle.org BUILD FAILED in 3s.
arushikesarwani@arushikesarwani-mbp AwesomeProject %
```

AFTER :

```
arushikesarwani@arushikesarwani-mbp AwesomeProject % npx react-native run-android
info Starting JS server...
info Launching emulator...
error Failed to launch emulator. Reason: The emulator (Pixel_5_API_33) quit before it finished opening. You can try starting the emulator manually from the terminal with: /opt/android_sdk/emulator/emulator @Pixel_5_API_33.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.

info 💡 Tip: Make sure that you have set up your development environment correctly, by running react-native doctor. To read more about doctor command visit: https://github.com/react-native-community/cli/blob/main/packages/cli-doctor/README.md#doctor 


FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'AwesomeProject'.
> Could not determine the dependencies of null.
   > Could not resolve all task dependencies for configuration ':classpath'.
      > Could not find com.android.tools.build:gradle:.
        Required by:
            project :
      > Could not resolve com.facebook.react:react-native-gradle-plugin.
        Required by:
            project :
         > No matching variant of project :gradle-plugin was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.0.1' but:
             - Variant 'apiElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a library, packaged as a jar, and its dependencies declared externally:
                 - Incompatible because this component declares a component for use during compile-time, compatible with Java 11 and the consumer needed a component for use during runtime, compatible with Java 8
                 - Other compatible attribute:
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
             - Variant 'mainSourceElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a component, and its dependencies declared externally:
                 - Incompatible because this component declares a component of category 'verification' and the consumer needed a library
                 - Other compatible attributes:
                     - Doesn't say anything about its target Java version (required compatibility with Java 8)
                     - Doesn't say anything about its elements (required them packaged as a jar)
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
                     - Doesn't say anything about its usage (required runtime)
             - Variant 'runtimeElements' capability com.facebook.react:react-native-gradle-plugin:unspecified declares a library for use during runtime, packaged as a jar, and its dependencies declared externally:
                 - Incompatible because this component declares a component, compatible with Java 11 and the consumer needed a component, compatible with Java 8
                 - Other compatible attribute:
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
             - Variant 'testResultsElementsForTest' capability com.facebook.react:react-native-gradle-plugin:unspecified:
                 - Incompatible because this component declares a component of category 'verification' and the consumer needed a library
                 - Other compatible attributes:
                     - Doesn't say anything about how its dependencies are found (required its dependencies declared externally)
                     - Doesn't say anything about its target Java version (required compatibility with Java 8)
                     - Doesn't say anything about its elements (required them packaged as a jar)
                     - Doesn't say anything about org.gradle.plugin.api-version (required '8.0.1')
                     - Doesn't say anything about its usage (required runtime)

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 3s
error Failed to install the app.
arushikesarwani@arushikesarwani-mbp AwesomeProject % 
```
