### PR TITLE
fix: allow DevTools to connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/node": "^16.0.0"
   },
   "lint-staged": {
-    "./packages/**/*.{ts}": [
+    "./packages/**/*.ts": [
       "yarn lint"
     ]
   }

--- a/packages/cli-server-api/src/securityHeadersMiddleware.ts
+++ b/packages/cli-server-api/src/securityHeadersMiddleware.ts
@@ -14,7 +14,8 @@ export default function securityHeadersMiddleware(
   // Block any cross origin request.
   if (
     typeof req.headers.origin === 'string' &&
-    !req.headers.origin.match(/^https?:\/\/localhost:/)
+    !req.headers.origin.match(/^https?:\/\/localhost:/) &&
+    !req.headers.origin.startsWith('devtools://devtools')
   ) {
     next(
       new Error(

--- a/packages/cli-tools/src/throwIfNonAllowedProtocol.ts
+++ b/packages/cli-tools/src/throwIfNonAllowedProtocol.ts
@@ -2,7 +2,7 @@
  * Check if a url uses an allowed protocol
  */
 
-const ALLOWED_PROTOCOLS = ['http:', 'https:', 'flipper:'];
+const ALLOWED_PROTOCOLS = ['http:', 'https:', 'devtools:', 'flipper:'];
 
 export default function throwIfNonAllowedProtocol(url: string) {
   const _url = new URL(url);


### PR DESCRIPTION
Summary:
---------

Using this guide to connect Chrome DevTools, I was unable to get source maps because CLI was blocking it: https://reactnative.dev/docs/next/hermes

Bonus: Also fixed this warning:

```
⚠ Detected incorrect braces with only single value: `./packages/**/*.{ts}`. Reformatted as: `./packages/**/*.ts`
```

Test Plan:
----------

Follow the guide above, and make sure Ctrl-/⌘P lets you select source files (not just the bundle itself).

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
