### PR TITLE
chore: use Homebrew for installing `ios-deploy`

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/iosDeploy.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/iosDeploy.ts
@@ -1,124 +1,35 @@
-import execa from 'execa';
+import {isSoftwareNotInstalled} from '../checkInstallation';
+import {HealthCheckInterface} from '../../types';
+import {brewInstall} from '../brewInstall';
 import chalk from 'chalk';
-import prompts from 'prompts';
-import {isSoftwareNotInstalled, PACKAGE_MANAGERS} from '../checkInstallation';
-import {packageManager} from './packageManagers';
-import {logError, removeMessage} from './common';
-import {HealthCheckInterface, Loader} from '../../types';
 
-const label = 'ios-deploy';
-
-const installationWithYarn = 'yarn global add ios-deploy';
-const installationWithNpm = 'npm install ios-deploy --global';
-
-const identifyInstallationCommand = () => {
-  if (packageManager === PACKAGE_MANAGERS.YARN) {
-    return installationWithYarn;
-  }
-
-  if (packageManager === PACKAGE_MANAGERS.NPM) {
-    return installationWithNpm;
-  }
-
-  return undefined;
-};
-
-const installLibrary = async ({
-  installationCommand,
-  packageManagerToUse,
-  loader,
-}: {
-  installationCommand: string;
-  packageManagerToUse: 'yarn' | 'npm';
-  loader: Loader;
-}) => {
-  try {
-    loader.start(`${label} (installing with ${packageManagerToUse})`);
-
-    const installationCommandArgs = installationCommand.split(' ');
-
-    await execa(installationCommandArgs[0], installationCommandArgs.splice(1));
-
-    loader.succeed(`${label} (installed with ${packageManagerToUse})`);
-  } catch (error) {
-    logError({
-      healthcheck: label,
-      loader,
-      error: error as Error,
-      command: installationCommand,
-    });
-  }
-};
+const packageName = 'ios-deploy';
 
 export default {
-  label,
+  label: packageName,
   isRequired: false,
   description:
     'Required for installing your app on a physical device with the CLI',
   getDiagnostics: async () => ({
-    needsToBeFixed: await isSoftwareNotInstalled('ios-deploy'),
+    needsToBeFixed: await isSoftwareNotInstalled(packageName),
   }),
   runAutomaticFix: async ({loader, logManualInstallation}) => {
-    loader.stop();
-
-    const installationCommand = identifyInstallationCommand();
-
-    // This means that we couldn't "guess" the package manager
-    if (installationCommand === undefined) {
-      const promptQuestion = `ios-deploy needs to be installed either by ${chalk.bold(
-        'yarn',
-      )} ${chalk.reset('or')} ${chalk.bold(
-        'npm',
-      )} ${chalk.reset()}, which one do you want to use?`;
-      const installWithYarn = {title: 'yarn', value: 'yarn'};
-      const installWithNpm = {title: 'npm', value: 'npm'};
-      const skipInstallation = {
-        title: 'Skip installation',
-        value: 'skip',
-      };
-
-      const {chosenPackageManager} = await prompts([
-        {
-          type: 'select',
-          name: 'chosenPackageManager',
-          message: promptQuestion,
-          choices: [installWithYarn, installWithNpm, skipInstallation],
-        },
-      ]);
-
-      removeMessage(`? ${promptQuestion} ${chosenPackageManager}`);
-
-      if (
-        chosenPackageManager === skipInstallation.value ||
-        !chosenPackageManager // e.g. when user presses Esc
-      ) {
-        loader.fail();
-
-        // Then we just print out the URL that the user can head to download the library
-        logManualInstallation({
-          healthcheck: 'ios-deploy',
-          url: 'https://github.com/ios-control/ios-deploy#readme',
-        });
-
-        return;
-      }
-
-      const shouldInstallWithYarn =
-        chosenPackageManager === installWithYarn.value;
-
-      return installLibrary({
-        installationCommand: shouldInstallWithYarn
-          ? installationWithYarn
-          : installationWithNpm,
-        loader,
-        packageManagerToUse: chosenPackageManager,
-      });
-    }
-
-    return installLibrary({
-      installationCommand,
-      packageManagerToUse: packageManager!.toLowerCase() as 'yarn' | 'npm',
+    await brewInstall({
+      pkg: packageName,
+      label: packageName,
       loader,
+      onSuccess: () => {
+        loader.succeed(
+          `Successfully installed ${chalk.bold(packageName)} with Homebrew`,
+        );
+      },
+      onFail: () => {
+        loader.fail();
+        logManualInstallation({
+          healthcheck: packageName,
+          url: 'https://github.com/ios-control/ios-deploy#installation',
+        });
+      },
     });
   },
 } as HealthCheckInterface;

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -360,7 +360,7 @@ async function runOnDevice(
   if (isIOSDeployInstalled.error) {
     throw new CLIError(
       `Failed to install the app on the device because we couldn't execute the "ios-deploy" command. Please install it by running "${chalk.bold(
-        'npm install -g ios-deploy',
+        'brew install ios-deploy',
       )}" and try again.`,
     );
   }


### PR DESCRIPTION
Summary:
---------
Fixes #2011
Changed the package manager for installing `ios-deploy`. We were installing package via `npm` or `yarn`, but to follow `ios-deploy`'s offical docs we should install the package [with Homebrew](https://github.com/ios-control/ios-deploy#installation). 

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Make sure you have not installed `ios-deploy` package. 
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js doctor
```
Click `f`  to try to fix issue, and `ios-deploy` package should be installed with Homebrew ✅


----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
