### PR TITLE
fix(perf): ignore Pods and Hermes files when looking for AndroidManifest

### DIFF
--- a/packages/cli-platform-android/src/config/findManifest.ts
+++ b/packages/cli-platform-android/src/config/findManifest.ts
@@ -18,6 +18,8 @@ export default function findManifest(folder: string) {
       '**/debug/**',
       'Examples/**',
       'examples/**',
+      '**/Pods/**',
+      '**/sdks/hermes/android/**',
     ],
   })[0];
 


### PR DESCRIPTION
Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2012

It looks that the `glob` package was looking in wrong directories in my case (I tested this in RNTester on `main`). One thing that is interesting, before RN moved to monorepo the `glob` was finding `AndroidManifest.xml` immediately, but after RN moved fully to the monorepo, glob is looking into packages, which takes some time. But I think this change will make it enough fast. 

Before this change:
| 0.71 | 0.72 |
| ------------- | ------------- |
|  <img width="558" alt="CleanShot 2023-07-11 at 17 27 18@2x" src="https://github.com/react-native-community/cli/assets/63900941/0557b62a-6711-4649-bdb0-663b88c57f28">  | <img width="865" alt="CleanShot 2023-07-11 at 17 28 51@2x" src="https://github.com/react-native-community/cli/assets/63900941/b91ece75-bb13-453d-80ad-4be8568df602">

After this change: 

| 0.71 | 0.72 |
| ------------- | ------------- |
|  <img width="565" alt="CleanShot 2023-07-11 at 17 28 01@2x" src="https://github.com/react-native-community/cli/assets/63900941/7ddcad6c-0667-490c-bde9-9e57a4cdf631"> | <img width="850" alt="CleanShot 2023-07-11 at 17 30 34@2x" src="https://github.com/react-native-community/cli/assets/63900941/57f515de-fdfa-485a-b21f-0b444da68677"> |



Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-android
```

The first two logs:
```
info JS server already running.
info Installing the app...
```
should appear **fast**.
 


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
