### PR TITLE
chore: replace `glob` with `fast-glob`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.3",
     "execa": "^5.0.0",
-    "glob": "^7.1.3",
+    "fast-glob": "^3.3.0",
     "husky": "^8.0.2",
     "jest": "^26.6.2",
     "jest-circus": "^26.6.2",

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -12,7 +12,7 @@
     "chalk": "^4.1.2",
     "cosmiconfig": "^5.1.0",
     "deepmerge": "^4.3.0",
-    "glob": "^7.1.3",
+    "fast-glob": "^3.3.0",
     "joi": "^17.2.1"
   },
   "files": [

--- a/packages/cli-platform-android/package.json
+++ b/packages/cli-platform-android/package.json
@@ -10,7 +10,7 @@
     "@react-native-community/cli-tools": "12.0.0-alpha.7",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
-    "glob": "^7.1.3",
+    "fast-glob": "^3.3.0",
     "logkitty": "^0.7.1"
   },
   "files": [

--- a/packages/cli-platform-android/src/config/findComponentDescriptors.ts
+++ b/packages/cli-platform-android/src/config/findComponentDescriptors.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import glob from 'glob';
+import fg from 'fast-glob';
 import {extractComponentDescriptors} from './extractComponentDescriptors';
 
 export function findComponentDescriptors(packageRoot: string) {
-  const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {
+  const files = fg.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {
     cwd: packageRoot,
-    nodir: true,
-    ignore: '**/node_modules/**',
+    onlyFiles: true,
+    ignore: ['**/node_modules/**'],
   });
   const codegenComponent = files
     .map((filePath) =>

--- a/packages/cli-platform-android/src/config/findComponentDescriptors.ts
+++ b/packages/cli-platform-android/src/config/findComponentDescriptors.ts
@@ -1,10 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import fg from 'fast-glob';
+import glob from 'fast-glob';
 import {extractComponentDescriptors} from './extractComponentDescriptors';
 
 export function findComponentDescriptors(packageRoot: string) {
-  const files = fg.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {
+  const files = glob.sync('**/+(*.js|*.jsx|*.ts|*.tsx)', {
     cwd: packageRoot,
     onlyFiles: true,
     ignore: ['**/node_modules/**'],

--- a/packages/cli-platform-android/src/config/findManifest.ts
+++ b/packages/cli-platform-android/src/config/findManifest.ts
@@ -6,11 +6,11 @@
  *
  */
 
-import fg from 'fast-glob';
+import glob from 'fast-glob';
 import path from 'path';
 
 export default function findManifest(folder: string) {
-  const manifestPath = fg.sync(path.join('**', 'AndroidManifest.xml'), {
+  const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
     cwd: folder,
     ignore: [
       'node_modules/**',

--- a/packages/cli-platform-android/src/config/findManifest.ts
+++ b/packages/cli-platform-android/src/config/findManifest.ts
@@ -6,11 +6,11 @@
  *
  */
 
-import glob from 'glob';
+import fg from 'fast-glob';
 import path from 'path';
 
 export default function findManifest(folder: string) {
-  const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
+  const manifestPath = fg.sync(path.join('**', 'AndroidManifest.xml'), {
     cwd: folder,
     ignore: [
       'node_modules/**',

--- a/packages/cli-platform-android/src/config/findPackageClassName.ts
+++ b/packages/cli-platform-android/src/config/findPackageClassName.ts
@@ -7,11 +7,14 @@
  */
 
 import fs from 'fs';
-import glob from 'glob';
+import fg from 'fast-glob';
 import path from 'path';
+import {unixifyPaths} from '@react-native-community/cli-tools';
 
 export default function getPackageClassName(folder: string) {
-  const files = glob.sync('**/+(*.java|*.kt)', {cwd: folder});
+  const files = fg.sync('**/+(*.java|*.kt)', {
+    cwd: unixifyPaths(folder),
+  });
 
   const packages = files
     .map((filePath) => fs.readFileSync(path.join(folder, filePath), 'utf8'))

--- a/packages/cli-platform-android/src/config/findPackageClassName.ts
+++ b/packages/cli-platform-android/src/config/findPackageClassName.ts
@@ -7,12 +7,12 @@
  */
 
 import fs from 'fs';
-import fg from 'fast-glob';
+import glob from 'fast-glob';
 import path from 'path';
 import {unixifyPaths} from '@react-native-community/cli-tools';
 
 export default function getPackageClassName(folder: string) {
-  const files = fg.sync('**/+(*.java|*.kt)', {
+  const files = glob.sync('**/+(*.java|*.kt)', {
     cwd: unixifyPaths(folder),
   });
 

--- a/packages/cli-platform-ios/package.json
+++ b/packages/cli-platform-ios/package.json
@@ -10,8 +10,8 @@
     "@react-native-community/cli-tools": "12.0.0-alpha.7",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
+    "fast-glob": "^3.3.0",
     "fast-xml-parser": "^4.0.12",
-    "glob": "^7.1.3",
     "ora": "^5.4.1"
   },
   "devDependencies": {

--- a/packages/cli-platform-ios/src/config/__tests__/findPodfilePath.test.ts
+++ b/packages/cli-platform-ios/src/config/__tests__/findPodfilePath.test.ts
@@ -7,19 +7,30 @@ jest.mock('fs');
 
 const fs = require('fs');
 
-afterEach(() => {
-  jest.resetAllMocks();
-});
-
 describe('ios::findPodfilePath', () => {
+  beforeAll(() => {
+    fs.__setMockFilesystem({
+      empty: {},
+      flat: {
+        ...projects.project,
+      },
+      multiple: {
+        bar: {
+          ...projects.project,
+        },
+        foo: {
+          ...projects.project,
+        },
+      },
+    });
+  });
+
   it('returns null if there is no Podfile', () => {
-    fs.__setMockFilesystem({});
-    expect(findPodfilePath('/')).toBeNull();
+    expect(findPodfilePath('/empty')).toBeNull();
   });
 
   it('returns Podfile path if it exists', () => {
-    fs.__setMockFilesystem(projects.project);
-    expect(findPodfilePath('/')).toContain('ios/Podfile');
+    expect(findPodfilePath('/flat')).toContain('/ios/Podfile');
   });
 
   it('prints a warning when multile Podfiles are found', () => {
@@ -28,7 +39,7 @@ describe('ios::findPodfilePath', () => {
       foo: projects.project,
       bar: projects.project,
     });
-    expect(findPodfilePath('/')).toContain('bar/ios/Podfile');
+    expect(findPodfilePath('/multiple')).toContain('/multiple/bar/ios/Podfile');
     expect(warn.mock.calls).toMatchSnapshot();
   });
 

--- a/packages/cli-platform-ios/src/config/__tests__/findPodspec.test.ts
+++ b/packages/cli-platform-ios/src/config/__tests__/findPodspec.test.ts
@@ -14,41 +14,44 @@ jest.mock('fs');
 const fs = require('fs');
 
 describe('ios::findPodspec', () => {
-  it('returns null if there is not podspec file', () => {
-    fs.__setMockFilesystem({});
-    expect(findPodspec('')).toBeNull();
-  });
-
-  it('returns podspec name if only one exists', () => {
+  beforeAll(() => {
     fs.__setMockFilesystem({
-      'TestPod.podspec': 'empty',
-    });
-    expect(findPodspec('/')).toBe('/TestPod.podspec');
-  });
-
-  it('returns podspec name that match packet directory', () => {
-    fs.__setMockFilesystem({
-      user: {
-        PacketName: {
-          'Another.podspec': 'empty',
-          'PacketName.podspec': 'empty',
+      empty: {},
+      flat: {
+        'TestPod.podspec': 'empty',
+      },
+      multiple: {
+        user: {
+          PacketName: {
+            'Another.podspec': 'empty',
+            'PacketName.podspec': 'empty',
+          },
+          packet: {
+            'Another.podspec': 'empty',
+            'PacketName.podspec': 'empty',
+          },
         },
       },
     });
-    expect(findPodspec('/user/PacketName')).toBe(
-      '/user/PacketName/PacketName.podspec',
+  });
+
+  it('returns null if there is not podspec file', () => {
+    expect(findPodspec('/empty')).toBeNull();
+  });
+
+  it('returns podspec name if only one exists', () => {
+    expect(findPodspec('/flat')).toBe('/flat/TestPod.podspec');
+  });
+
+  it('returns podspec name that match packet directory', () => {
+    expect(findPodspec('/multiple/user/PacketName')).toBe(
+      '/multiple/user/PacketName/PacketName.podspec',
     );
   });
 
   it('returns first podspec name if not match in directory', () => {
-    fs.__setMockFilesystem({
-      user: {
-        packet: {
-          'Another.podspec': 'empty',
-          'PacketName.podspec': 'empty',
-        },
-      },
-    });
-    expect(findPodspec('/user/packet')).toBe('/user/packet/Another.podspec');
+    expect(findPodspec('/multiple/user/packet')).toBe(
+      '/multiple/user/packet/Another.podspec',
+    );
   });
 });

--- a/packages/cli-platform-ios/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/cli-platform-ios/src/config/__tests__/getProjectConfig.test.ts
@@ -13,39 +13,44 @@ jest.mock('fs');
 const fs = require('fs');
 
 describe('ios::getProjectConfig', () => {
-  it('returns `null` if Podfile was not found', () => {
-    fs.__setMockFilesystem({});
-    expect(projectConfig('/', {})).toBe(null);
-  });
-  it('returns an object with ios project configuration', () => {
+  beforeAll(() => {
     fs.__setMockFilesystem({
-      ios: {
-        Podfile: '',
+      empty: {},
+      flat: {
+        ios: {
+          Podfile: '',
+        },
+      },
+      multiple: {
+        sample: {
+          Podfile: '',
+        },
+        ios: {
+          Podfile: '',
+        },
+        example: {
+          Podfile: '',
+        },
       },
     });
-    expect(projectConfig('/', {})).toMatchInlineSnapshot(`
+  });
+
+  it('returns `null` if Podfile was not found', () => {
+    expect(projectConfig('/empty', {})).toBe(null);
+  });
+  it('returns an object with ios project configuration', () => {
+    expect(projectConfig('/flat', {})).toMatchInlineSnapshot(`
       Object {
-        "sourceDir": "/ios",
+        "sourceDir": "/flat/ios",
         "watchModeCommandParams": undefined,
         "xcodeProject": null,
       }
     `);
   });
   it('returns correct configuration when multiple Podfile are present', () => {
-    fs.__setMockFilesystem({
-      sample: {
-        Podfile: '',
-      },
-      ios: {
-        Podfile: '',
-      },
-      example: {
-        Podfile: '',
-      },
-    });
-    expect(projectConfig('/', {})).toMatchInlineSnapshot(`
+    expect(projectConfig('/multiple', {})).toMatchInlineSnapshot(`
       Object {
-        "sourceDir": "/ios",
+        "sourceDir": "/multiple/ios",
         "watchModeCommandParams": undefined,
         "xcodeProject": null,
       }

--- a/packages/cli-platform-ios/src/config/findAllPodfilePaths.ts
+++ b/packages/cli-platform-ios/src/config/findAllPodfilePaths.ts
@@ -7,13 +7,13 @@
  */
 
 import {unixifyPaths} from '@react-native-community/cli-tools';
-import fg from 'fast-glob';
+import glob from 'fast-glob';
 
 // These folders will be excluded from search to speed it up
 const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules|Carthage|vendor)/**'];
 
 export default function findAllPodfilePaths(cwd: string) {
-  return fg.sync('**/Podfile', {
+  return glob.sync('**/Podfile', {
     cwd: unixifyPaths(cwd),
     ignore: GLOB_EXCLUDE_PATTERN,
   });

--- a/packages/cli-platform-ios/src/config/findAllPodfilePaths.ts
+++ b/packages/cli-platform-ios/src/config/findAllPodfilePaths.ts
@@ -5,14 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import glob from 'glob';
+
+import {unixifyPaths} from '@react-native-community/cli-tools';
+import fg from 'fast-glob';
 
 // These folders will be excluded from search to speed it up
 const GLOB_EXCLUDE_PATTERN = ['**/@(Pods|node_modules|Carthage|vendor)/**'];
 
 export default function findAllPodfilePaths(cwd: string) {
-  return glob.sync('**/Podfile', {
-    cwd,
+  return fg.sync('**/Podfile', {
+    cwd: unixifyPaths(cwd),
     ignore: GLOB_EXCLUDE_PATTERN,
   });
 }

--- a/packages/cli-platform-ios/src/config/findPodspec.ts
+++ b/packages/cli-platform-ios/src/config/findPodspec.ts
@@ -1,9 +1,9 @@
 import {unixifyPaths} from '@react-native-community/cli-tools';
-import fg from 'fast-glob';
+import glob from 'fast-glob';
 import path from 'path';
 
 export default function findPodspec(folder: string): string | null {
-  const podspecs = fg.sync('*.podspec', {cwd: unixifyPaths(folder)});
+  const podspecs = glob.sync('*.podspec', {cwd: unixifyPaths(folder)});
 
   if (podspecs.length === 0) {
     return null;

--- a/packages/cli-platform-ios/src/config/findPodspec.ts
+++ b/packages/cli-platform-ios/src/config/findPodspec.ts
@@ -1,8 +1,9 @@
-import glob from 'glob';
+import {unixifyPaths} from '@react-native-community/cli-tools';
+import fg from 'fast-glob';
 import path from 'path';
 
 export default function findPodspec(folder: string): string | null {
-  const podspecs = glob.sync('*.podspec', {cwd: folder});
+  const podspecs = fg.sync('*.podspec', {cwd: unixifyPaths(folder)});
 
   if (podspecs.length === 0) {
     return null;

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -11,6 +11,7 @@ export {default as hookStdout} from './hookStdout';
 export {getLoader, NoopLoader, Loader} from './loader';
 export {default as findProjectRoot} from './findProjectRoot';
 export {default as printRunDoctorTip} from './printRunDoctorTip';
+export {default as unixifyPaths} from './unixifyPaths';
 export * as link from './doclink';
 
 export * from './errors';

--- a/packages/cli-tools/src/unixifyPaths.ts
+++ b/packages/cli-tools/src/unixifyPaths.ts
@@ -1,0 +1,11 @@
+/**
+ *
+ * @param path string
+ * @returns string
+ *
+ * This function converts Windows paths to Unix paths.
+ */
+
+export default function unixifyPaths(path: string): string {
+  return path.replace(/^([a-zA-Z]+:|\.\/)/, '');
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const fg = require('fast-glob');
 const babel = require('@babel/core');
 const chalk = require('chalk');
 const micromatch = require('micromatch');
@@ -55,8 +55,8 @@ function getBuildPath(file, buildFolder) {
 function buildNodePackage(p) {
   const srcDir = path.resolve(p, SRC_DIR);
   const pattern = path.resolve(srcDir, '**/*');
-  const files = glob.sync(pattern, {
-    nodir: true,
+  const files = fg.sync(pattern, {
+    onlyFiles: true,
   });
 
   process.stdout.write(adjustToTerminalWidth(`${path.basename(p)}\n`));

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const fg = require('fast-glob');
+const glob = require('fast-glob');
 const babel = require('@babel/core');
 const chalk = require('chalk');
 const micromatch = require('micromatch');
@@ -55,7 +55,7 @@ function getBuildPath(file, buildFolder) {
 function buildNodePackage(p) {
   const srcDir = path.resolve(p, SRC_DIR);
   const pattern = path.resolve(srcDir, '**/*');
-  const files = fg.sync(pattern, {
+  const files = glob.sync(pattern, {
     onlyFiles: true,
   });
 

--- a/scripts/linkPackages.js
+++ b/scripts/linkPackages.js
@@ -1,9 +1,9 @@
 const execa = require('execa');
 const chalk = require('chalk');
 const path = require('path');
-const fg = require('fast-glob');
+const glob = require('fast-glob');
 
-const projects = fg.sync('packages/*/package.json');
+const projects = glob.sync('packages/*/package.json');
 
 projects.forEach((project) => {
   const cwd = path.dirname(project);

--- a/scripts/linkPackages.js
+++ b/scripts/linkPackages.js
@@ -1,9 +1,9 @@
 const execa = require('execa');
 const chalk = require('chalk');
 const path = require('path');
-const glob = require('glob');
+const fg = require('fast-glob');
 
-const projects = glob.sync('packages/*/package.json');
+const projects = fg.sync('packages/*/package.json');
 
 projects.forEach((project) => {
   const cwd = path.dirname(project);

--- a/scripts/update-metro.js
+++ b/scripts/update-metro.js
@@ -7,7 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
-const fg = require('fast-glob').sync;
+const glob = require('fast-glob').sync;
 const chalk = require('chalk');
 
 /**
@@ -42,7 +42,7 @@ const updateDependencies = (depsObject) => {
 };
 
 const start = new Date().getTime();
-['./package.json', ...fg('./packages/*/package.json')].forEach((pkgPath) => {
+['./package.json', ...glob('./packages/*/package.json')].forEach((pkgPath) => {
   const pkg = require(path.join(process.cwd(), pkgPath));
 
   const updatedDependency = pkg.dependencies

--- a/scripts/update-metro.js
+++ b/scripts/update-metro.js
@@ -7,7 +7,7 @@
 const fs = require('fs');
 const path = require('path');
 const cp = require('child_process');
-const glob = require('glob').sync;
+const fg = require('fast-glob').sync;
 const chalk = require('chalk');
 
 /**
@@ -42,7 +42,7 @@ const updateDependencies = (depsObject) => {
 };
 
 const start = new Date().getTime();
-['./package.json', ...glob('./packages/*/package.json')].forEach((pkgPath) => {
+['./package.json', ...fg('./packages/*/package.json')].forEach((pkgPath) => {
   const pkg = require(path.join(process.cwd(), pkgPath));
 
   const updatedDependency = pkg.dependencies

--- a/yarn.lock
+++ b/yarn.lock
@@ -6286,6 +6286,17 @@ fast-glob@^3.1.1:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.0.tgz#7c40cb491e1e2ed5664749e87bfb516dbe8727c0"
+  integrity sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Replaced `glob` package with `fast-glob`, because:
- `fast-glob` is a lot faster than `glob`,
- `fast-glob` is few times lighter than `glob`.

TODO:
----------
- [ ] Make sure that these changes don't broke running CLI on Windows.

Test Plan:
----------

CI Green ✅

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
