### PR TITLE
fix: use `none` as platform for printing upgrading link

### DIFF
--- a/packages/cli-tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/printNewRelease.ts
@@ -21,7 +21,7 @@ export default function printNewRelease(
   logger.info(`Diff: ${chalk.dim.underline(latestRelease.diffUrl)}`);
   logger.info(
     `For more info, check out "${chalk.dim.underline(
-      link.docs('upgrading', 'inherit'),
+      link.docs('upgrading', 'none'),
     )}".`,
   );
 


### PR DESCRIPTION
Summary:
---------
In #1882 there was introduced `inherit` platform, when using `link.docs` function, and when using this platform there is following check:
https://github.com/react-native-community/cli/blob/f1de95b60f8d0701327a77a468f51f72a973aafe/packages/cli-tools/src/doclink.ts#L68-L73
it fails, when there's no platform selected. When printing information about new release (we're doing this in `info` and `start` command), we can't really say what platform it is, so the solution for this is to use `none` as platform.

| Before | After |
| ------------- | ------------- |
|   <img width="1397" alt="CleanShot 2023-07-13 at 12 52 33@2x" src="https://github.com/react-native-community/cli/assets/63900941/3c4a3f20-7b19-4898-b2ab-dd9d68c8c7bc"> |  <img width="656" alt="CleanShot 2023-07-13 at 12 52 08@2x" src="https://github.com/react-native-community/cli/assets/63900941/6da6c253-db3f-46f3-bf1e-d5531daaf349">
>


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create React Native app which is not using latest version e.g. `npx react-native@latest init --version 0.72.2`
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js start
```
4. Link to the docs should be correctly printed.

 


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
