### PR TITLE
fix: does not override user-defined reporter

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -6,6 +6,7 @@ import {
   mergeConfig,
   resolveConfig,
   ResolverConfigT,
+  YargArguments,
 } from 'metro-config';
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import type {Config} from '@react-native-community/cli-types';
@@ -66,17 +67,6 @@ function getOverrideConfig(ctx: ConfigLoadingContext): InputConfigT {
   };
 }
 
-export interface ConfigOptionsT {
-  maxWorkers?: number;
-  port?: number;
-  projectRoot?: string;
-  resetCache?: boolean;
-  watchFolders?: string[];
-  sourceExts?: string[];
-  reporter?: any;
-  config?: string;
-}
-
 /**
  * Load Metro config.
  *
@@ -85,12 +75,9 @@ export interface ConfigOptionsT {
  */
 export default async function loadMetroConfig(
   ctx: ConfigLoadingContext,
-  options: ConfigOptionsT = {},
+  options: YargArguments = {},
 ): Promise<ConfigT> {
   const overrideConfig = getOverrideConfig(ctx);
-  if (options.reporter) {
-    overrideConfig.reporter = options.reporter;
-  }
 
   const projectConfig = await resolveConfig(undefined, ctx.root);
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
closes #2020

User-defined reporter on the current implementation will definitely be overridden.

Reimplemented `eventsSocketEndpoint.reportEvent`. If the customLogReporterPath does not exist, the reporter is not overwritten and only the `update` method of the `reporter` is modified.

Also modified some type definitions.
<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

- [x] If I customize the reporter, the corresponding method will be called normally
```js
const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');

/**
 * Metro configuration
 * https://facebook.github.io/metro/docs/configuration
 *
 * @type {import('metro-config').MetroConfig}
 */
const config = {
  reporter: {
    update: (event) => {
      console.log(1, event);
    },
  },
};

module.exports = mergeConfig(getDefaultConfig(__dirname), config);
```

- [x] `eventsSocketEndpoint.reportEvent(event)` called as before.
- [x] `customLogReporterPath` as effective as before.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
