### PR TITLE
breaking: remove `--variant` option from `run/build-android` command

### DIFF
--- a/packages/cli-platform-android/README.md
+++ b/packages/cli-platform-android/README.md
@@ -28,14 +28,6 @@ Builds your app and starts it on a connected Android emulator or device.
 
 Override the root directory for the Android build (which contains the android directory)'.
 
-#### `--variant <string>`
-
-> **DEPRECATED** – use "mode" instead
-
-> default: 'debug'
-
-Specify your app's build variant.
-
 #### `--appFolder <string>`
 
 > **DEPRECATED** – use "project.android.appName" in react-native.config.js
@@ -129,6 +121,7 @@ Installs passed binary instead of building a fresh one. This command is not comp
 #### `--user` <number | string>
 
 Id of the User Profile you want to install the app on.
+
 ### `log-android`
 
 Usage:

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -16,7 +16,6 @@ import {promptForTaskSelection} from '../runAndroid/listAndroidTasks';
 
 export interface BuildFlags {
   mode?: string;
-  variant?: string;
   activeArchOnly?: boolean;
   packager?: boolean;
   port: number;
@@ -63,12 +62,6 @@ async function buildAndroid(
 ) {
   const androidProject = getAndroidProject(config);
 
-  if (args.variant) {
-    logger.warn(
-      '"variant" flag is deprecated and will be removed in future release. Please switch to "mode" flag.',
-    );
-  }
-
   if (args.tasks && args.mode) {
     logger.warn(
       'Both "tasks" and "mode" parameters were passed to "build" command. Using "tasks" for building the app.',
@@ -89,7 +82,7 @@ async function buildAndroid(
 
   let gradleArgs = getTaskNames(
     androidProject.appName,
-    args.mode || args.variant,
+    args.mode,
     tasks,
     'bundle',
     androidProject.sourceDir,
@@ -111,7 +104,7 @@ async function buildAndroid(
       );
     if (architectures.length > 0) {
       logger.info(`Detected architectures ${architectures.join(', ')}`);
-      // `reactNativeDebugArchitectures` was renamed to `reactNativeArchitectures` in 0.68.
+      // `reactNativeDebugArchitectures` was renamed to `reactNativeArchitectures` in 0.68.
       // Can be removed when 0.67 no longer needs to be supported.
       gradleArgs.push(
         '-PreactNativeDebugArchitectures=' + architectures.join(','),
@@ -143,11 +136,6 @@ export const options = [
   {
     name: '--mode <string>',
     description: "Specify your app's build variant",
-  },
-  {
-    name: '--variant <string>',
-    description:
-      "Specify your app's build variant. Deprecated! Use 'mode' instead",
   },
   {
     name: '--no-packager',

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -188,7 +188,7 @@ function runOnSpecificDevice(
     if (devices.indexOf(deviceId) !== -1) {
       let gradleArgs = getTaskNames(
         androidProject.appName,
-        args.mode || args.variant,
+        args.mode,
         args.tasks ?? buildTask,
         'install',
         androidProject.sourceDir,

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -47,17 +47,12 @@ async function runOnAllDevices(
       );
     }
   }
-  if (args.variant) {
-    logger.warn(
-      '"variant" flag is deprecated and will be removed in future release. Please switch to "mode" flag.',
-    );
-  }
 
   try {
     if (!args.binaryPath) {
       let gradleArgs = getTaskNames(
         androidProject.appName,
-        args.mode || args.variant,
+        args.mode,
         args.tasks,
         'install',
         androidProject.sourceDir,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Some time ago, we deprecated `--variant` option from `run/build-android`, now I deleted this option. Now everyone should use `--mode` option. 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
