### PR TITLE
breaking: remove `--configuration` option from `build/run-ios`

### DIFF
--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -43,10 +43,6 @@ Example: this will launch your project directly onto the iPhone 14 simulator:
 react-native run-ios --simulator "iPhone 14"
 ```
 
-#### `--configuration <string>`
-
-[Deprecated] Explicitly set the scheme configuration to use default: 'Debug'.
-
 #### `--mode <string>`
 
 Explicitly set the scheme configuration to use. This option is case sensitive.
@@ -140,10 +136,6 @@ Example: this will launch your project directly onto the iPhone 14 simulator:
 ```sh
 react-native build-ios --simulator "iPhone 14"
 ```
-
-#### `--configuration <string>`
-
-[Deprecated] Explicitly set the scheme configuration to use default: 'Debug'.
 
 #### `--mode <string>`
 

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -24,7 +24,6 @@ import {getConfigurationScheme} from '../../tools/getConfigurationScheme';
 import listIOSDevices from '../../tools/listIOSDevices';
 
 export interface FlagsT extends BuildFlags {
-  configuration?: string;
   simulator?: string;
   device?: string | true;
   udid?: string;
@@ -47,14 +46,6 @@ async function buildIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   }
 
   process.chdir(sourceDir);
-
-  if (args.configuration) {
-    logger.warn('--configuration has been deprecated. Use --mode instead.');
-    logger.warn(
-      'Parameters were automatically reassigned to --mode on this run.',
-    );
-    args.mode = args.configuration;
-  }
 
   const projectInfo = getProjectInfo();
 
@@ -214,10 +205,6 @@ export const iosBuildOptions = [
     name: '--mode <string>',
     description:
       'Explicitly set the scheme configuration to use. This option is case sensitive.',
-  },
-  {
-    name: '--configuration <string>',
-    description: '[Deprecated] Explicitly set the scheme configuration to use',
   },
   {
     name: '--scheme <string>',

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -26,7 +26,6 @@ import getSimulators from '../../tools/getSimulators';
 
 export interface FlagsT extends BuildFlags {
   simulator?: string;
-  configuration: string;
   scheme?: string;
   projectPath: string;
   device?: string | true;
@@ -68,14 +67,6 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
         'binary-path was specified, but the file was not found.',
       );
     }
-  }
-
-  if (args.configuration) {
-    logger.warn('--configuration has been deprecated. Use --mode instead.');
-    logger.warn(
-      'Parameters were automatically reassigned to --mode on this run.',
-    );
-    args.mode = args.configuration;
   }
 
   const projectInfo = getProjectInfo();
@@ -293,7 +284,7 @@ async function runOnSimulator(
 
     appPath = await getBuildPath(
       xcodeProject,
-      args.mode || args.configuration,
+      args.mode,
       buildOutput,
       scheme,
       args.target,
@@ -375,7 +366,7 @@ async function runOnDevice(
 
     const appPath = await getBuildPath(
       xcodeProject,
-      args.mode || args.configuration,
+      args.mode,
       buildOutput,
       scheme,
       args.target,
@@ -398,7 +389,7 @@ async function runOnDevice(
 
       appPath = await getBuildPath(
         xcodeProject,
-        args.mode || args.configuration,
+        args.mode,
         buildOutput,
         scheme,
         args.target,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Removed `--configuration` options which was deprecated some time ago. 


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --configuration "Release"
```
Shouldn't work. ❌

3. Run this command: 

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --mode "Release"
```
Should work. ✅


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
