### PR TITLE
docs: fix link to `profile-hermes` command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,7 @@ React Native CLI comes with following commands:
 - [`build-ios`](/packages/cli-platform-ios/README.md#build-ios)
 - [`start`](/packages/cli-plugin-metro/README.md#start)
 - [`upgrade`](#upgrade)
-- [`profile-hermes`](/packages/cli-platform-android/README.md#profile-hermes)
+- [`profile-hermes`](/packages/cli-hermes/README.md#profile-hermes)
 
 ### `init`
 


### PR DESCRIPTION

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Fix profile-hermes link
As is: Link to cli-android
To be: Link to cli-hermes

<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
