### PR TITLE
fix: prevent booting already booted simulators

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -278,7 +278,7 @@ async function runOnSimulator(
     selectedSimulator.udid,
   ]);
 
-  if (!selectedSimulator.booted) {
+  if (selectedSimulator.state !== 'Booted') {
     bootSimulator(selectedSimulator);
   }
 

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -226,7 +226,6 @@ async function runOnSimulator(
   args: FlagsT,
   simulator?: Device,
 ) {
-  // let selectedSimulator;
   /**
    * If provided simulator does not exist, try simulators in following order
    * - iPhone 14

--- a/packages/cli-platform-ios/src/tools/__tests__/findMatchingSimulator.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/findMatchingSimulator.test.ts
@@ -56,7 +56,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
       name: 'iPhone 6',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 9.2',
     });
   });
@@ -108,7 +108,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
       name: 'iPhone 6',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 12.1',
     });
   });
@@ -201,7 +201,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
       name: 'iPhone 5',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 9.2',
     });
   });
@@ -276,7 +276,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: '1CCBBF8B-5773-4EA6-BD6F-C308C87A1ADB',
       name: 'iPhone 5',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 9.2',
     });
   });
@@ -325,7 +325,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
       name: 'iPhone 6s',
-      booted: true,
+      state: 'Booted',
       version: 'iOS 9.2',
     });
   });
@@ -374,7 +374,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
       name: 'iPhone 6',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 9.2',
     });
   });
@@ -449,7 +449,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: '3A409DC5-5188-42A6-8598-3AA6F34607A5',
       name: 'iPhone 7',
-      booted: true,
+      state: 'Booted',
       version: 'iOS 10.0',
     });
   });
@@ -524,7 +524,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'D0F29BE7-CC3C-4976-888D-C739B4F50508',
       name: 'iPhone 6s',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 9.2',
     });
   });
@@ -599,7 +599,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'CBBB8FB8-77AB-49A9-8297-4CCFE3189C22',
       name: 'iPhone 6s',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 10.0',
     });
   });
@@ -738,7 +738,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
       name: 'iPad Pro (9.7-inch)',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 12.0',
     });
   });
@@ -813,7 +813,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'B2141C1E-86B7-4A10-82A7-4956799526DF',
       name: 'iPad Pro (9.7-inch)',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 12.2',
     });
   });
@@ -935,7 +935,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: 'BA0D93BD-07E6-4182-9B0A-F60A2474139C',
       name: 'iPhone 6',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 12.1',
     });
   });
@@ -979,7 +979,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: '3AA90A75-D9C3-41A6-8DE1-43BE74A0C32B',
       name: 'iPhone 14',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 16.0',
     });
   });
@@ -1023,7 +1023,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: '6F2FA108-AC7D-4D3C-BD13-56C5E7FCEDFE',
       name: 'iPhone 14 Plus',
-      booted: false,
+      state: 'Shutdown',
       version: 'iOS 16.0',
     });
   });
@@ -1060,7 +1060,7 @@ describe('findMatchingSimulator', () => {
     ).toEqual({
       udid: '816C30EA-38EA-41AC-BFDA-96FB632D522E',
       name: 'Apple TV',
-      booted: true,
+      state: 'Booted',
       version: 'tvOS 11.2',
     });
   });

--- a/packages/cli-platform-ios/src/tools/findMatchingSimulator.ts
+++ b/packages/cli-platform-ios/src/tools/findMatchingSimulator.ts
@@ -83,12 +83,11 @@ function findMatchingSimulator(
       ) {
         continue;
       }
-      const booted = simulator.state === 'Booted';
       const lastBootedAt = simulator.lastBootedAt;
-      const simulatorDescriptor = {
+      const simulatorDescriptor: Device = {
         udid: simulator.udid,
         name: simulator.name,
-        booted,
+        state: simulator.state,
         version,
       };
       if (findOptions && findOptions.udid) {
@@ -96,7 +95,7 @@ function findMatchingSimulator(
           return simulatorDescriptor;
         }
       } else {
-        if (booted && simulatorName === null) {
+        if (simulator.state === 'Booted' && simulatorName === null) {
           return simulatorDescriptor;
         }
         if (simulator.name === simulatorName && !match) {

--- a/packages/cli-platform-ios/src/types.ts
+++ b/packages/cli-platform-ios/src/types.ts
@@ -1,13 +1,12 @@
 export interface Device {
-  availability?: string;
-  state?: string;
-  isAvailable?: boolean;
   name: string;
   udid: string;
+  state?: string;
+  availability?: string;
+  isAvailable?: boolean;
   version?: string;
   availabilityError?: string;
   type?: 'simulator' | 'device' | 'catalyst';
-  booted?: boolean;
   lastBootedAt?: string;
 }
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes: #2032 

The `if` statement was checking `booted` value, but in some code path, the `booted` value didn't exist. I unified this, to use `state` field. 

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Boot iOS simulator
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```

You should see booted simulator, and this simulator shouldn't boot another time.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
