### PR TITLE
docs: add `npx` prefix before `react-native` command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,14 +6,13 @@ labels: 'bug report'
 
 ## Environment
 
-<!-- Run `react-native info` in your terminal and paste its contents here. -->
+<!-- Run `npx react-native info` in your terminal and paste its contents here. -->
 
 ## Description
 
 <!--
   Describe your issue in detail. Include screenshots if needed. If this is a regression, let us know.
 -->
-
 
 ## Reproducible Demo
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ All work on React Native CLI happens directly on GitHub. Contributors send pull 
 > Please make sure the version of React Native matches the one present in devDependencies of the CLI. Otherwise, you may get unexpected errors.
 
 _Note: you must use the `--watchFolders` flag with the `start` command when testing the CLI with `yarn link` like this. Otherwise Metro can't find the symlinked folder and this may result in errors such as `ReferenceError: SHA-1 for file ... is not computed`. If you are experiencing this error while using Release configuration, please add `watchFolders: ["path/to/cloned/cli/"]` to your `metro.config.js` file._
+
 ### Setup
 
 Because of a modular design of the CLI, we recommend developing using symbolic links to its packages. This way you can use it seamlessly in the tested project, as you'd use the locally installed CLI. Here's what you need to run in the terminal:
@@ -66,7 +67,7 @@ First make sure you have RN repo checked out and CLI repo checked out and built.
 
 1. Check out `react-native` repo. Then update template in local `react-native/template/package.json`, replacing dependency version of `react-native` with the absolute path of the react native repo, for example: "react-native": "file:///Users/username/react-native" (you can find the absolute path using `pwd` command)
 
-1. Go back up and create a new RN project: `node ./cli/packages/cli/build/bin.js init --template=file:///path/to/local/react-native RNTestProject`
+1. Go back up and create a new RN project: `node ./cli/packages/cli/build/bin.js init --template=file:///path/to/local/react-native/RNTestProject`
 
 1. To work with android, update gradle config in the newly created project following the second part of [Christoph's instructions](https://gist.github.com/cpojer/38a91f90614f35769e88410e3a387b48)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This monorepository contains tools and helpers for React Native projects in form
 Run the following command in your terminal prompt:
 
 ```sh
-npx react-native init MyApp
+npx react-native@latest init MyApp
 ```
 
 ## Usage in an existing React Native project

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,7 +28,7 @@ React Native CLI comes with following commands:
 Usage (with `npx`):
 
 ```sh
-npx react-native init <projectName> [options]
+npx react-native@latest init <projectName> [options]
 ```
 
 Initialize a new React Native project named <projectName> in a directory of the same name. You can find out more use cases in [init docs](./init.md).
@@ -59,10 +59,10 @@ Uses a custom template. Accepts following template sources:
 Example:
 
 ```sh
-npx react-native init MyApp --template react-native-custom-template
-npx react-native init MyApp --template file:///Users/name/template-path
-npx react-native init MyApp --template file:///Users/name/template-name-1.0.0.tgz
-npx react-native init MyApp --template Esemesek/react-native-new-template
+npx react-native@latest init MyApp --template react-native-custom-template
+npx react-native@latest init MyApp --template file:///Users/name/template-path
+npx react-native@latest init MyApp --template file:///Users/name/template-name-1.0.0.tgz
+npx react-native@latest init MyApp --template Esemesek/react-native-new-template
 ```
 
 A template is any directory or npm package that contains a `template.config.js` file in the root with the following type:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -112,7 +112,7 @@ Create project with custom package name for Android and bundle identifier for iO
 Usage:
 
 ```sh
-react-native upgrade
+npx react-native upgrade
 ```
 
 This command generates a relevant link to the [Upgrade Helper](https://react-native-community.github.io/upgrade-helper/) to help you upgrade manually.

--- a/docs/healthChecks.md
+++ b/docs/healthChecks.md
@@ -1,6 +1,6 @@
 # Health Check Plugins
 
-Plugins can be used to extend the health checks that `react-native doctor` runs.  This can be used to add additional checks for out of tree platforms, or other checks that are specific to a community module.
+Plugins can be used to extend the health checks that `npx react-native doctor` runs.  This can be used to add additional checks for out of tree platforms, or other checks that are specific to a community module.
 
 See [`Plugins`](./plugins.md) for information about how plugins work.  
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -7,7 +7,7 @@ There are couple of ways to initialize new React Native projects.
 #### Using `npx` utility
 
 ```sh
-npx react-native init ProjectName
+npx react-native@latest init ProjectName
 ```
 
 > Note: If you have both `yarn` and `npm` installed on your machine, React Native CLI will always try to use `yarn`, so even if you use `npx` utility, only `react-native` executable will be installed using `npm` and the rest of the work will be delegated to `yarn`. You can force usage of `npm` adding `--npm` flag to the command.
@@ -24,7 +24,7 @@ yarn init && yarn add react-native && yarn react-native init ProjectName
 
 ```sh
 # This will use the latest init command but will install react-native@VERSION and use its template
-npx react-native init ProjectName --version ${VERSION}
+npx react-native@latest init ProjectName --version ${VERSION}
 
 # This will use init command from react-native@VERSION
 npx react-native@${VERSION} init ProjectName
@@ -47,7 +47,7 @@ For all available options, please check [Yarn documentation](https://classic.yar
 
 ```sh
 # This will initialize new project using template from `react-native-template-typescript` package
-npx react-native init ProjectName --template ${TEMPLATE_NAME}
+npx react-native@latest init ProjectName --template ${TEMPLATE_NAME}
 
 # This will initialize new project using init command from react-native@VERSION but will use a custom template
 npx react-native@${VERSION} init ProjectName --template ${TEMPLATE_NAME}
@@ -56,7 +56,7 @@ npx react-native@${VERSION} init ProjectName --template ${TEMPLATE_NAME}
 You can force usage of `npm` if you have both `yarn` and `npm` installed on your machine:
 
 ```sh
-npx react-native init ProjectName --npm
+npx react-native@latest init ProjectName --npm
 ```
 
 ### For older `react-native` versions
@@ -65,7 +65,7 @@ Using legacy `react-native-cli` package:
 
 ```sh
 yarn global add react-native-cli
-npx react-native init ProjectName
+npx react-native@latest init ProjectName
 ```
 
 > Note: It is not recommended, but you can also use legacy `react-native-cli` package to initialize projects using latest `react-native` versions.

--- a/docs/init.md
+++ b/docs/init.md
@@ -4,7 +4,7 @@ There are couple of ways to initialize new React Native projects.
 
 ### For `react-native@0.60.0` or greater
 
-#### Using `npx` utility:
+#### Using `npx` utility
 
 ```sh
 npx react-native init ProjectName
@@ -14,13 +14,13 @@ npx react-native init ProjectName
 
 > Note: for Yarn users, `yarn dlx` command similar to `npx` will be featured in Yarn 2.0: <https://github.com/yarnpkg/berry/pull/40> so we’ll be able to use it in a similar fashion.
 
-#### Installing `react-native` and invoking `init` command:
+#### Installing `react-native` and invoking `init` command
 
 ```sh
 yarn init && yarn add react-native && yarn react-native init ProjectName
 ```
 
-#### Initializing project with custom version of `react-native`:
+#### Initializing project with custom version of `react-native`
 
 ```sh
 # This will use the latest init command but will install react-native@VERSION and use its template
@@ -65,7 +65,7 @@ Using legacy `react-native-cli` package:
 
 ```sh
 yarn global add react-native-cli
-react-native init ProjectName
+npx react-native init ProjectName
 ```
 
 > Note: It is not recommended, but you can also use legacy `react-native-cli` package to initialize projects using latest `react-native` versions.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -2,7 +2,7 @@
 
 Plugin is a JavaScript package that extends built-in React Native CLI features. It can provide an array of additional commands to run or platforms to target.
 
-For example, `react-native-windows` package is a plugin that provides `react-native run-windows` command and `windows` platform.
+For example, `react-native-windows` package is a plugin that provides `run-windows` command and `windows` platform.
 
 Details of this particular integration as well as how to provide an additional platform for React Native were described in a [`dedicated section`](./platforms.md) about platforms.
 
@@ -21,13 +21,13 @@ module.exports = {
 };
 ```
 
-> Above is an example of a plugin that exports a command named `foo-command` that can be executed with `react-native foo-command` and logs "It worked" and exits.
+> Above is an example of a plugin that exports a command named `foo-command` that can be executed with `npx react-native foo-command` and logs "It worked" and exits.
 
 At the startup, React Native CLI reads configuration from all dependencies listed in `package.json` and reduces them into a single configuration.
 
 At the end, an array of commands concatenated from all plugins is passed on to the CLI to be loaded after built-in commands.
 
-> See [`healthChecks`](./healthChecks.md) for information on how plugins can provide additional health checks for `react-native doctor`.
+> See [`healthChecks`](./healthChecks.md) for information on how plugins can provide additional health checks for `npx react-native doctor`.
 
 ## Command interface
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -86,7 +86,7 @@ multiple `Podfile` files in your project.
 
 #### project.ios.watchModeCommandParams
 
-Array of strings that will be passed to the `react-native run-ios` command when running in watch mode.
+Array of strings that will be passed to the `npx react-native run-ios` command when running in watch mode.
 
 #### project.ios.unstable_reactLegacyComponentNames
 
@@ -122,7 +122,7 @@ See [`dependency.platforms.android.configuration`](dependencies.md#platformsandr
 
 #### project.android.watchModeCommandParams
 
-Array of strings that will be passed to the `react-native run-android` command when running in watch mode.
+Array of strings that will be passed to the `npx react-native run-android` command when running in watch mode.
 
 #### project.android.unstable_reactLegacyComponentNames
 

--- a/packages/cli-clean/README.md
+++ b/packages/cli-clean/README.md
@@ -15,7 +15,7 @@ yarn add @react-native-community/cli-clean
 Usage:
 
 ```sh
-react-native clean
+npx react-native clean
 ```
 
 Cleans caches. Commonly used to ensure build failures are not due to stale cache. By default, it will prompt which caches to purge, with Watchman and Metro already checked. To omit interactive prompt (e.g. in scripts), please use `--include` flag.

--- a/packages/cli-config/README.md
+++ b/packages/cli-config/README.md
@@ -15,7 +15,7 @@ yarn add @react-native-community/cli-config
 Usage:
 
 ```sh
-react-native config
+npx react-native config
 ```
 
 Output project and dependencies configuration in JSON format to stdout. Used by [autolinking](./../../docs/autolinking.md).

--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -73,7 +73,7 @@ Object {
 }
 `;
 
-exports[`should not skip packages that have invalid configuration (to avoid breaking users): logged warning 1`] = `"warn Package react-native contains invalid configuration: \\"dependency.invalidProperty\\" is not allowed. Please verify it's properly linked using \\"react-native config\\" command and contact the package maintainers about this."`;
+exports[`should not skip packages that have invalid configuration (to avoid breaking users): logged warning 1`] = `"warn Package react-native contains invalid configuration: \\"dependency.invalidProperty\\" is not allowed. Please verify it's properly linked using \\"npx react-native config\\" command and contact the package maintainers about this."`;
 
 exports[`should read a config of a dependency and use it to load other settings 1`] = `
 Object {

--- a/packages/cli-config/src/readConfigFromDisk.ts
+++ b/packages/cli-config/src/readConfigFromDisk.ts
@@ -62,7 +62,7 @@ export function readDependencyConfigFromDisk(
         validationError.message,
       )}.
       
-      Please verify it's properly linked using "react-native config" command and contact the package maintainers about this.`),
+      Please verify it's properly linked using "npx react-native config" command and contact the package maintainers about this.`),
     );
   }
 

--- a/packages/cli-doctor/README.md
+++ b/packages/cli-doctor/README.md
@@ -15,7 +15,7 @@ yarn add @react-native-community/cli-doctor
 Usage:
 
 ```sh
-react-native doctor
+npx react-native doctor
 ```
 
 Diagnose and fix common Node.js, iOS, Android & React Native issues.
@@ -25,7 +25,7 @@ Diagnose and fix common Node.js, iOS, Android & React Native issues.
 Usage:
 
 ```sh
-react-native info
+npx react-native info
 ```
 
 Get relevant version info about OS, toolchain and libraries. Useful when sending bug reports.

--- a/packages/cli-doctor/src/tools/healthchecks/packager.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/packager.ts
@@ -42,12 +42,12 @@ export default {
       }
       return logManualInstallation({
         message:
-          'Could not start the bundler. Please run "react-native start" command manually.',
+          'Could not start the bundler. Please run "npx react-native start" command manually.',
       });
     } catch (error) {
       return logManualInstallation({
         message:
-          'Could not start the bundler. Please run "react-native start" command manually.',
+          'Could not start the bundler. Please run "npx react-native start" command manually.',
       });
     }
   },

--- a/packages/cli-hermes/README.md
+++ b/packages/cli-hermes/README.md
@@ -15,7 +15,7 @@ yarn add @react-native-community/cli-hermes
 Usage:
 
 ```sh
-react-native profile-hermes [destinationDir] <flag>
+npx react-native profile-hermes [destinationDir] <flag>
 ```
 
 Pull and convert a Hermes tracing profile to Chrome tracing profile, then store it in the directory <destinationDir> of the local machine.

--- a/packages/cli-platform-android/README.md
+++ b/packages/cli-platform-android/README.md
@@ -15,7 +15,7 @@ yarn add @react-native-community/cli-platform-android
 Usage:
 
 ```sh
-react-native run-android [options]
+npx react-native run-android [options]
 ```
 
 Builds your app and starts it on a connected Android emulator or device.
@@ -78,7 +78,7 @@ List all available Android devices and simulators and let you choose one to run 
 Usage:
 
 ```sh
-react-native build-android [options]
+npx react-native build-android [options]
 ```
 
 Builds Android app.
@@ -97,7 +97,7 @@ Custom params that will be passed to gradle build command.
 Example:
 
 ```sh
-react-native build-android --extra-params "-x lint -x test"
+npx react-native build-android --extra-params "-x lint -x test"
 ```
 
 #### `--binary-path <path>`
@@ -113,7 +113,7 @@ Id of the User Profile you want to install the app on.
 Usage:
 
 ```sh
-react-native log-android
+npx react-native log-android
 ```
 
 Starts [`logkitty`](https://github.com/zamotany/logkitty) displaying pretty Android logs.

--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -15,7 +15,7 @@ yarn add @react-native-community/cli-platform-ios
 Usage:
 
 ```sh
-react-native run-ios [options]
+npx react-native run-ios [options]
 ```
 
 Builds your app and starts it on iOS simulator.
@@ -40,7 +40,7 @@ Notes: `simulator_name` must be a valid iOS simulator name. If in doubt, open yo
 Example: this will launch your project directly onto the iPhone 14 simulator:
 
 ```sh
-react-native run-ios --simulator "iPhone 14"
+npx react-native run-ios --simulator "iPhone 14"
 ```
 
 #### `--mode <string>`
@@ -50,7 +50,7 @@ Explicitly set the scheme configuration to use. This option is case sensitive.
 Example:
 
 ```sh
-react-native run-ios --mode "Release"
+npx react-native run-ios --mode "Release"
 ```
 
 #### `--scheme <string>`
@@ -101,7 +101,7 @@ Custom params that will be passed to `xcodebuild` command.
 Example:
 
 ```sh
-react-native run-ios --extra-params "-jobs 4"
+npx react-native run-ios --extra-params "-jobs 4"
 ```
 
 ### `build-ios`
@@ -109,7 +109,7 @@ react-native run-ios --extra-params "-jobs 4"
 Usage:
 
 ```sh
-react-native build-ios [options]
+npx react-native build-ios [options]
 ```
 
 Builds IOS app.
@@ -134,7 +134,7 @@ Notes: `simulator_name` must be a valid iOS simulator name. If in doubt, open yo
 Example: this will launch your project directly onto the iPhone 14 simulator:
 
 ```sh
-react-native build-ios --simulator "iPhone 14"
+npx react-native build-ios --simulator "iPhone 14"
 ```
 
 #### `--mode <string>`
@@ -144,7 +144,7 @@ Explicitly set the scheme configuration to use. This option is case sensitive.
 Example:
 
 ```sh
-react-native build-ios --mode "Release"
+npx react-native build-ios --mode "Release"
 ```
 
 #### `--scheme <string>`
@@ -201,7 +201,7 @@ Custom params that will be passed to `xcodebuild` command.
 Example:
 
 ```sh
-react-native build-ios --extra-params "-jobs 4"
+npx react-native build-ios --extra-params "-jobs 4"
 ```
 
 ### log-ios
@@ -211,7 +211,7 @@ react-native build-ios --extra-params "-jobs 4"
 Usage:
 
 ```sh
-react-native log-ios
+npx react-native log-ios
 ```
 
 Starts iOS device syslog tail.

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -245,15 +245,15 @@ export default {
   examples: [
     {
       desc: 'Build the app for the IOS simulator',
-      cmd: 'react-native build-ios',
+      cmd: 'npx react-native build-ios',
     },
     {
       desc: 'Build the app for all IOS devices',
-      cmd: 'react-native build-ios --mode "Release"',
+      cmd: 'npx react-native build-ios --mode "Release"',
     },
     {
       desc: 'Build the app for a specific IOS device',
-      cmd: 'react-native build-ios --simulator "IPhone 11"',
+      cmd: 'npx react-native build-ios --simulator "IPhone 11"',
     },
   ],
   options: [

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -623,16 +623,16 @@ export default {
   examples: [
     {
       desc: 'Run on a different simulator, e.g. iPhone SE (2nd generation)',
-      cmd: 'react-native run-ios --simulator "iPhone SE (2nd generation)"',
+      cmd: 'npx react-native run-ios --simulator "iPhone SE (2nd generation)"',
     },
     {
       desc: "Run on a connected device, e.g. Max's iPhone",
-      cmd: 'react-native run-ios --device "Max\'s iPhone"',
+      cmd: 'npx react-native run-ios --device "Max\'s iPhone"',
     },
     {
       desc: 'Run on the AppleTV simulator',
       cmd:
-        'react-native run-ios --simulator "Apple TV"  --scheme "helloworld-tvOS"',
+        'npx react-native run-ios --simulator "Apple TV"  --scheme "helloworld-tvOS"',
     },
   ],
   options: [

--- a/packages/cli-plugin-metro/README.md
+++ b/packages/cli-plugin-metro/README.md
@@ -16,7 +16,7 @@ yarn add @react-native-community/cli-plugin-metro
 Usage:
 
 ```sh
-react-native start [option]
+npx react-native start [option]
 ```
 
 Starts the server that communicates with connected devices
@@ -84,7 +84,7 @@ Disables interactive mode
 Usage:
 
 ```sh
-react-native bundle <flag>
+npx react-native bundle <flag>
 ```
 
 Builds the JavaScript bundle for offline use.
@@ -120,7 +120,7 @@ File name where to store the resulting bundle, ex. `/tmp/groups.bundle`.
 If you are planning on building a debug APK, that will run without the packager, by invoking `./gradlew assembleDebug` you can simply set `bundleInDebug: true` in your app/build.gradle file, inside the `project.ext.react` map.
 
 <details>
-Alternatively if you want to run <code>react-native bundle</code> manually and then create the APK with <code>./gradlew assembleDebug</code> you have to make sure to put the bundle into the right directory and give it the right name, so that gradle can find it.
+Alternatively if you want to run <code>npx react-native bundle</code> manually and then create the APK with <code>./gradlew assembleDebug</code> you have to make sure to put the bundle into the right directory and give it the right name, so that gradle can find it.
 
 For react-native versions 0.57 and above the bundle output path should be:
 <code>android/app/build/generated/assets/react/debug/index.android.js</code>
@@ -162,7 +162,7 @@ Directory name where to store assets referenced in the bundle.
 If you are planning on building a debug APK that will run without the packager, see ([--bundle-output](https://github.com/react-native-community/cli/blob/main/packages/cli-plugin-metro/README.md#--bundle-output-string))
 
 <details>
-  Alternatively if you want to run <code>react-native bundle</code> manually and then create the APK with <code>./gradlew assembleDebug</code> you have to make sure to put the assets into the right directory, so that gradle can find them.
+  Alternatively if you want to run <code>npx react-native bundle</code> manually and then create the APK with <code>./gradlew assembleDebug</code> you have to make sure to put the assets into the right directory, so that gradle can find them.
 
 For react-native versions 0.57 and above the <code>--assets-dest</code> path should be:
 <code>android/app/build/generated/res/react/debug</code>
@@ -192,7 +192,7 @@ Path to the CLI configuration file.
 Usage:
 
 ```sh
-react-native ram-bundle [options]
+npx react-native ram-bundle [options]
 ```
 
 Builds JavaScript as a "Random Access Module" bundle for offline use.

--- a/packages/cli-tools/src/printRunDoctorTip.ts
+++ b/packages/cli-tools/src/printRunDoctorTip.ts
@@ -10,7 +10,7 @@ const printRunDoctorTip = () => {
     chalk.dim(
       `${chalk.dim(
         '💡 Tip: Make sure that you have set up your development environment correctly, by running',
-      )} ${chalk.reset(chalk.bold('react-native doctor'))}. ${chalk.dim(
+      )} ${chalk.reset(chalk.bold('npx react-native doctor'))}. ${chalk.dim(
         `To read more about doctor command visit: ${linkToDocs} \n`,
       )}`,
     ),


### PR DESCRIPTION
Summary:
---------

Closes https://github.com/react-native-community/cli/issues/2031

There are people who just copy and pastes commands from docs, and it is not allowed to have globally installed `react-native` package, so I synced every command  in docs, warning and errors - to have `npx` prefix before `react-native` for those who just copy and pastes commands into terminal :)

Test Plan:
----------
Just read it :)

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
