### PR TITLE
fix(cli-plugin-metro): ensure bundle destination directory exist

### DIFF
--- a/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
+++ b/packages/cli-plugin-metro/src/commands/bundle/buildBundle.ts
@@ -6,17 +6,18 @@
  *
  */
 
+import {logger} from '@react-native-community/cli-tools';
+import type {Config} from '@react-native-community/cli-types';
+import chalk from 'chalk';
+import fs from 'fs';
+import type {ConfigT} from 'metro-config';
 import Server from 'metro/src/Server';
 import outputBundle from 'metro/src/shared/output/bundle';
 import type {BundleOptions} from 'metro/src/shared/types';
-import type {ConfigT} from 'metro-config';
 import path from 'path';
-import chalk from 'chalk';
-import {CommandLineArgs} from './bundleCommandLineArgs';
-import type {Config} from '@react-native-community/cli-types';
-import saveAssets from './saveAssets';
 import {default as loadMetroConfig} from '../../tools/loadMetroConfig';
-import {logger} from '@react-native-community/cli-tools';
+import {CommandLineArgs} from './bundleCommandLineArgs';
+import saveAssets from './saveAssets';
 
 interface RequestOptions {
   entryFile: string;
@@ -90,6 +91,10 @@ export async function buildBundleWithConfig(
 
   try {
     const bundle = await output.build(server, requestOpts);
+
+    // Ensure destination directory exists before saving the bundle
+    const mkdirOptions = {recursive: true, mode: 0o755} as const;
+    fs.mkdirSync(path.dirname(args.bundleOutput), mkdirOptions);
 
     await output.save(bundle, args, logger.info);
 


### PR DESCRIPTION
Summary:
---------

`react-native bundle` currently fails if the bundle destination directory does not exist.

Example:

```
% yarn react-native bundle --entry-file index.js --platform android --dev true --bundle-output dist/main.android.jsbundle --assets-dest dist/res
                Welcome to Metro v0.73.10
              Fast - Scalable - Integrated


info Writing bundle output to:, dist/main.android.jsbundle
error ENOENT: no such file or directory, open 'dist/main.android.jsbundle'.
Error: ENOENT: no such file or directory, open 'dist/main.android.jsbundle'
```

Test Plan:
----------

Run `react-native bundle` before and after applying the changes in any app. In my case, I used [`react-native-test-app`](https://github.com/microsoft/react-native-test-app/tree/trunk/example).

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
