### PR TITLE
feat: enable pausing handling keystrokes in watch mode

### DIFF
--- a/packages/cli-plugin-metro/src/commands/start/watchMode.ts
+++ b/packages/cli-plugin-metro/src/commands/start/watchMode.ts
@@ -4,7 +4,6 @@ import execa from 'execa';
 import chalk from 'chalk';
 import {Config} from '@react-native-community/cli-types';
 import {KeyPressHandler} from '../../tools/KeyPressHandler';
-import {addInteractionListener} from '@react-native-community/cli-tools';
 
 const CTRL_C = '\u0003';
 const CTRL_Z = '\u0026';
@@ -42,7 +41,7 @@ function enableWatchMode(messageSocket: any, ctx: Config) {
     }
   });
 
-  const onPressAsync = async (key: string) => {
+  const onPress = (key: string) => {
     switch (key) {
       case 'r':
         messageSocket.broadcast('reload', null);
@@ -76,9 +75,8 @@ function enableWatchMode(messageSocket: any, ctx: Config) {
     }
   };
 
-  const keyPressHandler = new KeyPressHandler(onPressAsync);
-  const listener = keyPressHandler.createInteractionListener();
-  addInteractionListener(listener);
+  const keyPressHandler = new KeyPressHandler(onPress);
+  keyPressHandler.createInteractionListener();
   keyPressHandler.startInterceptingKeyStrokes();
 }
 

--- a/packages/cli-plugin-metro/src/commands/start/watchMode.ts
+++ b/packages/cli-plugin-metro/src/commands/start/watchMode.ts
@@ -3,6 +3,11 @@ import {logger, hookStdout} from '@react-native-community/cli-tools';
 import execa from 'execa';
 import chalk from 'chalk';
 import {Config} from '@react-native-community/cli-types';
+import {KeyPressHandler} from '../../tools/KeyPressHandler';
+import {addInteractionListener} from '@react-native-community/cli-tools';
+
+const CTRL_C = '\u0003';
+const CTRL_Z = '\u0026';
 
 function printWatchModeInstructions() {
   logger.log(
@@ -37,38 +42,44 @@ function enableWatchMode(messageSocket: any, ctx: Config) {
     }
   });
 
-  process.stdin.on('keypress', (_key, data) => {
-    const {ctrl, name} = data;
-    if (ctrl === true) {
-      switch (name) {
-        case 'c':
-          process.exit();
-          break;
-        case 'z':
-          process.emit('SIGTSTP', 'SIGTSTP');
-          break;
-      }
-    } else if (name === 'r') {
-      messageSocket.broadcast('reload', null);
-      logger.info('Reloading app...');
-    } else if (name === 'd') {
-      messageSocket.broadcast('devMenu', null);
-      logger.info('Opening developer menu...');
-    } else if (name === 'i' || name === 'a') {
-      logger.info(`Opening the app on ${name === 'i' ? 'iOS' : 'Android'}...`);
-      const params =
-        name === 'i'
-          ? ctx.project.ios?.watchModeCommandParams
-          : ctx.project.android?.watchModeCommandParams;
-      execa('npx', [
-        'react-native',
-        name === 'i' ? 'run-ios' : 'run-android',
-        ...(params ?? []),
-      ]).stdout?.pipe(process.stdout);
-    } else {
-      console.log(_key);
+  const onPressAsync = async (key: string) => {
+    switch (key) {
+      case 'r':
+        messageSocket.broadcast('reload', null);
+        logger.info('Reloading app...');
+        break;
+      case 'd':
+        messageSocket.broadcast('devMenu', null);
+        logger.info('Opening Dev Menu...');
+        break;
+      case 'i':
+        logger.info('Opening app on iOS...');
+        execa('npx', [
+          'react-native',
+          'run-ios',
+          ...(ctx.project.ios?.watchModeCommandParams ?? []),
+        ]).stdout?.pipe(process.stdout);
+        break;
+      case 'a':
+        logger.info('Opening app on Android...');
+        execa('npx', [
+          'react-native',
+          'run-android',
+          ...(ctx.project.android?.watchModeCommandParams ?? []),
+        ]).stdout?.pipe(process.stdout);
+        break;
+      case CTRL_Z:
+        process.emit('SIGTSTP', 'SIGTSTP');
+        break;
+      case CTRL_C:
+        process.exit();
     }
-  });
+  };
+
+  const keyPressHandler = new KeyPressHandler(onPressAsync);
+  const listener = keyPressHandler.createInteractionListener();
+  addInteractionListener(listener);
+  keyPressHandler.startInterceptingKeyStrokes();
 }
 
 export default enableWatchMode;

--- a/packages/cli-plugin-metro/src/tools/KeyPressHandler.ts
+++ b/packages/cli-plugin-metro/src/tools/KeyPressHandler.ts
@@ -1,0 +1,73 @@
+import {CLIError, logger} from '@react-native-community/cli-tools';
+
+const CTRL_C = '\u0003';
+
+/** An abstract key stroke interceptor. */
+export class KeyPressHandler {
+  private isInterceptingKeyStrokes = false;
+  private isHandlingKeyPress = false;
+
+  constructor(public onPress: (key: string) => Promise<any>) {}
+
+  /** Start observing interaction pause listeners. */
+  createInteractionListener() {
+    // Support observing prompts.
+    let wasIntercepting = false;
+
+    const listener = ({pause}: {pause: boolean}) => {
+      if (pause) {
+        // Track if we were already intercepting key strokes before pausing, so we can
+        // resume after pausing.
+        wasIntercepting = this.isInterceptingKeyStrokes;
+        this.stopInterceptingKeyStrokes();
+      } else if (wasIntercepting) {
+        // Only start if we were previously intercepting.
+        this.startInterceptingKeyStrokes();
+      }
+    };
+
+    return listener;
+  }
+
+  private handleKeypress = async (key: string) => {
+    // Prevent sending another event until the previous event has finished.
+    if (this.isHandlingKeyPress && key !== CTRL_C) {
+      return;
+    }
+    this.isHandlingKeyPress = true;
+    try {
+      logger.debug(`Key pressed: ${key}`);
+      await this.onPress(key);
+    } catch (error) {
+      return new CLIError('There was an error with the key press handler.');
+    } finally {
+      this.isHandlingKeyPress = false;
+      return;
+    }
+  };
+
+  /** Start intercepting all key strokes and passing them to the input `onPress` method. */
+  startInterceptingKeyStrokes() {
+    if (this.isInterceptingKeyStrokes) {
+      return;
+    }
+    this.isInterceptingKeyStrokes = true;
+    const {stdin} = process;
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+    stdin.on('data', this.handleKeypress);
+  }
+
+  /** Stop intercepting all key strokes. */
+  stopInterceptingKeyStrokes() {
+    if (!this.isInterceptingKeyStrokes) {
+      return;
+    }
+    this.isInterceptingKeyStrokes = false;
+    const {stdin} = process;
+    stdin.removeListener('data', this.handleKeypress);
+    stdin.setRawMode(false);
+    stdin.resume();
+  }
+}

--- a/packages/cli-plugin-metro/src/tools/KeyPressHandler.ts
+++ b/packages/cli-plugin-metro/src/tools/KeyPressHandler.ts
@@ -1,13 +1,14 @@
-import {CLIError, logger} from '@react-native-community/cli-tools';
-
-const CTRL_C = '\u0003';
+import {
+  CLIError,
+  addInteractionListener,
+  logger,
+} from '@react-native-community/cli-tools';
 
 /** An abstract key stroke interceptor. */
 export class KeyPressHandler {
   private isInterceptingKeyStrokes = false;
-  private isHandlingKeyPress = false;
 
-  constructor(public onPress: (key: string) => Promise<any>) {}
+  constructor(public onPress: (key: string) => void) {}
 
   /** Start observing interaction pause listeners. */
   createInteractionListener() {
@@ -26,25 +27,19 @@ export class KeyPressHandler {
       }
     };
 
-    return listener;
+    addInteractionListener(listener);
   }
 
   private handleKeypress = async (key: string) => {
-    // Prevent sending another event until the previous event has finished.
-    if (this.isHandlingKeyPress && key !== CTRL_C) {
-      return;
-    }
-    this.isHandlingKeyPress = true;
     try {
       logger.debug(`Key pressed: ${key}`);
-      await this.onPress(key);
+      this.onPress(key);
     } catch (error) {
       return new CLIError(
         'There was an error with the key press handler.',
         (error as Error).message,
       );
     } finally {
-      this.isHandlingKeyPress = false;
       return;
     }
   };

--- a/packages/cli-plugin-metro/src/tools/KeyPressHandler.ts
+++ b/packages/cli-plugin-metro/src/tools/KeyPressHandler.ts
@@ -39,7 +39,10 @@ export class KeyPressHandler {
       logger.debug(`Key pressed: ${key}`);
       await this.onPress(key);
     } catch (error) {
-      return new CLIError('There was an error with the key press handler.');
+      return new CLIError(
+        'There was an error with the key press handler.',
+        (error as Error).message,
+      );
     } finally {
       this.isHandlingKeyPress = false;
       return;

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -12,5 +12,6 @@ export {getLoader, NoopLoader, Loader} from './loader';
 export {default as findProjectRoot} from './findProjectRoot';
 export {default as printRunDoctorTip} from './printRunDoctorTip';
 export * as link from './doclink';
+export * from './prompt';
 
 export * from './errors';

--- a/packages/cli-tools/src/prompt.ts
+++ b/packages/cli-tools/src/prompt.ts
@@ -1,0 +1,53 @@
+import prompts, {Options, PromptObject} from 'prompts';
+import {CLIError} from './errors';
+import logger from './logger';
+
+type PromptOptions = {nonInteractiveHelp?: string} & Options;
+type InteractionOptions = {pause: boolean; canEscape?: boolean};
+type InteractionCallback = (options: InteractionOptions) => void;
+
+/** Interaction observers for detecting when keystroke tracking should pause/resume. */
+const listeners: InteractionCallback[] = [];
+
+export async function prompt(
+  question: PromptObject,
+  options: PromptOptions = {},
+) {
+  pauseInteractions();
+  try {
+    const results = await prompts(question, {
+      onCancel() {
+        throw new CLIError('Prompt cancelled.');
+      },
+      ...options,
+    });
+
+    return results;
+  } finally {
+    resumeInteractions();
+  }
+}
+
+export function pauseInteractions(
+  options: Omit<InteractionOptions, 'pause'> = {},
+) {
+  logger.debug('Interaction observers paused');
+  for (const listener of listeners) {
+    listener({pause: true, ...options});
+  }
+}
+
+/** Notify all listeners that keypress observations can start.. */
+export function resumeInteractions(
+  options: Omit<InteractionOptions, 'pause'> = {},
+) {
+  logger.debug('Interaction observers resumed');
+  for (const listener of listeners) {
+    listener({pause: false, ...options});
+  }
+}
+
+/** Used to pause/resume interaction observers while prompting (made for TerminalUI). */
+export function addInteractionListener(callback: InteractionCallback) {
+  listeners.push(callback);
+}


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In this PR I created `KeyPressHandler` that allows us to pause handling keystrokes because in nearest future we will add interactive prompts to `start` command, so they will run in watch mode. If we do not pause the handling keystrokes, the "focus" will be on the prompt. I created a function that wraps `prompts` and pauses and resumes interactivity in watchMode. 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js start
```
3. Press key that we're handling (`a`,` i`, `d`, `r`) and check if keystrokes are properly handled. 
 


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
