### PR TITLE
fix: Fix loading Metro config from alternative config path

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -92,10 +92,11 @@ export default async function loadMetroConfig(
     overrideConfig.reporter = options.reporter;
   }
 
-  const projectConfig = await resolveConfig(undefined, ctx.root);
+  const cwd = ctx.root;
+  const projectConfig = await resolveConfig(options.config, cwd);
 
   if (projectConfig.isEmpty) {
-    throw new CLIError(`No metro config found in ${ctx.root}`);
+    throw new CLIError(`No Metro config found in ${cwd}`);
   }
 
   logger.debug(`Reading Metro config from ${projectConfig.filepath}`);
@@ -119,7 +120,10 @@ This warning will be removed in future (https://github.com/facebook/metro/issues
   }
 
   return mergeConfig(
-    await loadConfig({cwd: ctx.root, ...options}),
+    await loadConfig({
+      cwd,
+      ...options,
+    }),
     overrideConfig,
   );
 }


### PR DESCRIPTION
## Summary

Resolves #2042. Config validation within `loadMetroConfig` was not passing `options.config` to Metro's `resolveConfig` function — where this is done later for `loadConfig`.

## Test Plan

**No `--config` arg (Unchanged)**

![image](https://github.com/react-native-community/cli/assets/2547783/ea1d5662-5f33-4ce3-8486-0073a0c37abe)

✅ Implicitly loads `./metro.config.js`

**With `--config` specified**

![image](https://github.com/react-native-community/cli/assets/2547783/681c4e82-0941-41c7-9942-5d291c933267)

✅ Loads `metro.config.js` file from alternative file path

**With `--config` specified, file does not exist**

![image](https://github.com/react-native-community/cli/assets/2547783/023a6651-2a9e-4e16-9e66-520fd10cda5c)

✅ Throws underlying error from Metro

(Note: This error message could be improved in Metro's source — to keep CLI lean I'm not wrapping this with anything now as the error is just about clear enough, cc @robhogan)

