### PR TITLE
fix: Fix loading Metro config from alternative config path (11.x)

### DIFF
--- a/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
+++ b/packages/cli-plugin-metro/src/tools/loadMetroConfig.ts
@@ -94,10 +94,11 @@ export default async function loadMetroConfig(
     overrideConfig.reporter = options.reporter;
   }
 
-  const projectConfig = await resolveConfig(undefined, ctx.root);
+  const cwd = ctx.root;
+  const projectConfig = await resolveConfig(options.config, cwd);
 
   if (projectConfig.isEmpty) {
-    throw new CLIError(`No metro config found in ${ctx.root}`);
+    throw new CLIError(`No Metro config found in ${cwd}`);
   }
 
   logger.debug(`Reading Metro config from ${projectConfig.filepath}`);
@@ -128,7 +129,10 @@ export default async function loadMetroConfig(
   }
 
   return mergeConfig(
-    await loadConfig({cwd: ctx.root, ...options}),
+    await loadConfig({
+      cwd,
+      ...options,
+    }),
     overrideConfig,
   );
 }


### PR DESCRIPTION
# Summary

Picks https://github.com/react-native-community/cli/pull/2043 targeting 11.x.

**Targets the `11.x` branch (React Native 0.72).**

## Test Plan

See https://github.com/react-native-community/cli/pull/2043.
