### PR TITLE
fix: Workaround JSON.stringify failing on large arrays with the error…

### DIFF
--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -28,6 +28,16 @@ function execSyncWithLog(command: string) {
 }
 
 /**
+ * A wrapper that converts an object to JSON with 4 spaces for indentation.
+ *
+ * @param obj Any object that can be represented as JSON
+ * @returns A JSON string
+ */
+function jsonStringify(obj: any) {
+  return JSON.stringify(obj, undefined, 4);
+}
+
+/**
  * Pull and convert a Hermes tracing profile to Chrome tracing profile
  * @param ctx
  * @param dstPath
@@ -123,11 +133,12 @@ export async function downloadProfile(
         file,
         '.cpuprofile',
       )}-converted.json`;
-      fs.writeFileSync(
-        transformedFilePath,
-        JSON.stringify(events, undefined, 4),
-        'utf-8',
-      );
+
+      // Convert to JSON in chunks because JSON.stringify() will fail for large
+      // arrays with the error "RangeError: Invalid string length"
+      const out = events.map(jsonStringify).join(',');
+
+      fs.writeFileSync(transformedFilePath, '[' + out + ']', 'utf-8');
       logger.success(
         `Successfully converted to Chrome tracing format and pulled the file to ${transformedFilePath}`,
       );


### PR DESCRIPTION
…geError: Invalid string length" when downloading profiling

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2050


Test Plan:
----------

Follow steps in issue 2050

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
