### PR TITLE
fix: change request response in `/status` endpoint

### DIFF
--- a/packages/cli-server-api/src/__tests__/statusPageMiddleware.test.ts
+++ b/packages/cli-server-api/src/__tests__/statusPageMiddleware.test.ts
@@ -1,0 +1,20 @@
+import http from 'http';
+import statusPageMiddleware from './../statusPageMiddleware';
+
+describe('statusPageMiddleware', () => {
+  it('should set headers and end the response', () => {
+    process.cwd = () => '/mocked/path';
+
+    const res: http.ServerResponse = {
+      setHeader: jest.fn(),
+      end: jest.fn(),
+    } as any;
+
+    const mockReq: http.IncomingMessage = {} as any;
+    statusPageMiddleware(mockReq, res);
+
+    // We're strictly checking response here, because React Native is strongly depending on this response. Changing the response might be a breaking change.
+    expect(res.setHeader).toHaveBeenCalledWith('Project-Root', '/mocked/path');
+    expect(res.end).toHaveBeenCalledWith('packager-status:running');
+  });
+});

--- a/packages/cli-server-api/src/statusPageMiddleware.ts
+++ b/packages/cli-server-api/src/statusPageMiddleware.ts
@@ -14,10 +14,6 @@ export default function statusPageMiddleware(
   _req: http.IncomingMessage,
   res: http.ServerResponse,
 ) {
-  res.end(
-    JSON.stringify({
-      status: 'running',
-      root: process.cwd(),
-    }),
-  );
+  res.setHeader('Project-Root', process.cwd());
+  res.end('packager-status:running');
 }

--- a/packages/cli-tools/src/isPackagerRunning.ts
+++ b/packages/cli-tools/src/isPackagerRunning.ts
@@ -26,11 +26,16 @@ async function isPackagerRunning(
   | 'unrecognized'
 > {
   try {
-    const {data} = await fetch(`http://localhost:${packagerPort}/status`);
+    const {data, headers} = await fetch(
+      `http://localhost:${packagerPort}/status`,
+    );
 
     try {
-      if (data.status === 'running') {
-        return data;
+      if (data === 'packager-status:running') {
+        return {
+          status: 'running',
+          root: headers.get('Project-Root') ?? '',
+        };
       }
     } catch (_error) {
       return 'unrecognized';


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Recently in https://github.com/react-native-community/cli/pull/2021 I changed the response in `/status` endpoint. It worked out that it was breaking change, and React Native depends internally on this response. In this PR I moved passing this information to header, and that's perfect for us because we don't create breaking change and we can make the same logic as before. 

Test Plan:
----------

Everything described in #2021 should work the same after changes in this PR.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
