### PR TITLE
Rename /status project root header

### DIFF
--- a/packages/cli-server-api/src/__tests__/statusPageMiddleware.test.ts
+++ b/packages/cli-server-api/src/__tests__/statusPageMiddleware.test.ts
@@ -14,7 +14,10 @@ describe('statusPageMiddleware', () => {
     statusPageMiddleware(mockReq, res);
 
     // We're strictly checking response here, because React Native is strongly depending on this response. Changing the response might be a breaking change.
-    expect(res.setHeader).toHaveBeenCalledWith('Project-Root', '/mocked/path');
+    expect(res.setHeader).toHaveBeenCalledWith(
+      'X-React-Native-Project-Root',
+      '/mocked/path',
+    );
     expect(res.end).toHaveBeenCalledWith('packager-status:running');
   });
 });

--- a/packages/cli-server-api/src/statusPageMiddleware.ts
+++ b/packages/cli-server-api/src/statusPageMiddleware.ts
@@ -14,6 +14,6 @@ export default function statusPageMiddleware(
   _req: http.IncomingMessage,
   res: http.ServerResponse,
 ) {
-  res.setHeader('Project-Root', process.cwd());
+  res.setHeader('X-React-Native-Project-Root', process.cwd());
   res.end('packager-status:running');
 }

--- a/packages/cli-tools/src/isPackagerRunning.ts
+++ b/packages/cli-tools/src/isPackagerRunning.ts
@@ -34,7 +34,7 @@ async function isPackagerRunning(
       if (data === 'packager-status:running') {
         return {
           status: 'running',
-          root: headers.get('Project-Root') ?? '',
+          root: headers.get('X-React-Native-Project-Root') ?? '',
         };
       }
     } catch (_error) {


### PR DESCRIPTION
## Summary

Small rename to formalise the custom header added in https://github.com/react-native-community/cli/pull/2056.

## Test plan

Updated test case.