### PR TITLE
chore(e2e): check for undefined code before printing fail

### DIFF
--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -194,7 +194,11 @@ function handleTestFailure(
   result: {[key: string]: any},
   args: string[] | undefined,
 ) {
-  if (!options.expectedFailure && result.code !== 0) {
+  if (
+    !options.expectedFailure &&
+    result.code !== undefined &&
+    result.code !== 0
+  ) {
     console.log(`Running ${cmd} command failed for unexpected reason. Here's more info:
 ${chalk.bold('cmd:')}     ${cmd}
 ${chalk.bold('options:')} ${JSON.stringify(options)}


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Execa returns code as undefined when there are no issues. Let's not print errors in such case to avoid obscuring the output


Test Plan:
----------

CI

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
