### PR TITLE
fix: get only tasks for passed type

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidTasks.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidTasks.ts
@@ -34,7 +34,7 @@ export const getGradleTasks = (
 ) => {
   const cmd = process.platform.startsWith('win') ? 'gradlew.bat' : './gradlew';
 
-  const out = execa.sync(cmd, ['tasks'], {
+  const out = execa.sync(cmd, ['tasks', '--group', taskType], {
     cwd: sourceDir,
   }).stdout;
   return parseTasksFromGradleFile(taskType, out);


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Related https://github.com/react-native-community/cli/issues/2012. Few months ago we introduced fetching gradle tasks to validate them and for `--interactive` flag - and it turned out that it takes a lot of time (especially in large projects). So right now we're downloading tasks only for right type (so either `build` or `install`). 

Test Plan:
----------

CI Green

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
