### PR TITLE
fix: Adjust wording for dev server port taken messages

### DIFF
--- a/packages/cli-tools/src/handlePortUnavailable.ts
+++ b/packages/cli-tools/src/handlePortUnavailable.ts
@@ -27,7 +27,7 @@ const handlePortUnavailable = async (
       port = nextPort;
     } else {
       packager = false;
-      logChangePortInstructions(port);
+      logChangePortInstructions();
     }
   }
 

--- a/packages/cli-tools/src/port.ts
+++ b/packages/cli-tools/src/port.ts
@@ -1,11 +1,8 @@
 import {prompt} from './prompt';
 import logger from './logger';
-import chalk from 'chalk';
 
 export const askForPortChange = async (port: number, nextPort: number) => {
-  logger.info(
-    `Metro is already running on port ${chalk.bold(port)} in another project.`,
-  );
+  logger.info(`Another process is running on port ${port}.`);
   return await prompt({
     name: 'change',
     type: 'select',
@@ -18,11 +15,13 @@ export const askForPortChange = async (port: number, nextPort: number) => {
 };
 
 export const logAlreadyRunningBundler = (port: number) => {
-  logger.info(`Metro Bundler is already for this project on port ${port}.`);
+  logger.info(
+    `A dev server is already running for this project on port ${port}.`,
+  );
 };
 
-export const logChangePortInstructions = (port: number) => {
+export const logChangePortInstructions = () => {
   logger.info(
-    `Please close the other packager running on port ${port}, or select another port with "--port".`,
+    'Please terminate this process and try again, or use another port with "--port".',
   );
 };


### PR DESCRIPTION
## Summary

Simplifies "port taken" messages to replace `[packager|Metro|Metro Bundler]` with "dev server", matching recent changes in `@react-native/community-cli-plugin`.