### PR TITLE
fix: improve providing project name in `init` command

### DIFF
--- a/__e2e__/__snapshots__/default.test.ts.snap
+++ b/__e2e__/__snapshots__/default.test.ts.snap
@@ -8,8 +8,9 @@ Options:
   -h, --help                    display help for command
 
 Commands:
-  init [options] <projectName>  Initialize a new React Native project named
-                                <projectName> in a directory of the same name.
+  init [options] [projectName]  New app will be initialized in the directory of
+                                the same name. Android and iOS projects will
+                                use this name for publishing setup.
   doctor [options]              Diagnose and fix common Node.js, iOS, Android &
                                 React Native issues.
   help [command]                display help for command"

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -7,6 +7,9 @@ import {
   writeFiles,
 } from '../jest/helpers';
 import slash from 'slash';
+import prompts from 'prompts';
+
+jest.mock('prompts', () => jest.fn());
 
 const DIR = getTempDirectory('command-init');
 
@@ -56,13 +59,16 @@ test('init fails if the directory already exists', () => {
   );
 });
 
-test('init --template fails without package name', () => {
-  const {stderr} = runCLI(
-    DIR,
-    ['init', '--template', 'react-native-new-template'],
-    {expectedFailure: true},
+test('init should prompt for the project name', () => {
+  createCustomTemplateFiles();
+  const {stdout} = runCLI(DIR, ['init', 'test', '--template', templatePath]);
+
+  (prompts as jest.MockedFunction<typeof prompts>).mockReturnValue(
+    Promise.resolve({
+      name: 'TestInit',
+    }),
   );
-  expect(stderr).toContain('missing required argument');
+  expect(stdout).toContain('Run instructions');
 });
 
 test('init --template filepath', () => {

--- a/packages/cli-clean/src/__tests__/clean.test.ts
+++ b/packages/cli-clean/src/__tests__/clean.test.ts
@@ -18,7 +18,11 @@ describe('clean', () => {
   });
 
   it('prompts if `--include` is omitted', async () => {
-    prompts.mockReturnValue({cache: []});
+    (prompts as jest.MockedFunction<typeof prompts>).mockReturnValue(
+      Promise.resolve({
+        cache: [],
+      }),
+    );
 
     await clean([], mockConfig, {include: '', projectRoot: process.cwd()});
 

--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/listAndroidTasks.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/listAndroidTasks.test.ts
@@ -105,7 +105,11 @@ jest.mock('prompts', () => jest.fn());
 describe('promptForTaskSelection', () => {
   it('should prompt with correct tasks', () => {
     (execa.sync as jest.Mock).mockReturnValueOnce({stdout: gradleTaskOutput});
-    prompts.mockReturnValue({task: []});
+    (prompts as jest.MockedFunction<typeof prompts>).mockReturnValue(
+      Promise.resolve({
+        task: [],
+      }),
+    );
 
     promptForTaskSelection('install', 'sourceDir');
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -3,9 +3,9 @@ import init from './init';
 export default {
   func: init,
   detached: true,
-  name: 'init <projectName>',
+  name: 'init [projectName]',
   description:
-    'Initialize a new React Native project named <projectName> in a directory of the same name.',
+    'Initialize a new React Native project in a directory of the same name.',
   options: [
     {
       name: '--version <string>',

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -5,7 +5,7 @@ export default {
   detached: true,
   name: 'init [projectName]',
   description:
-    'Initialize a new React Native project in a directory of the same name.',
+    'New app will be initialized in the directory of the same name. Android and iOS projects will use this name for publishing setup.',
   options: [
     {
       name: '--version <string>',

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -279,7 +279,7 @@ export default (async function initialize(
     const {projName} = await prompts({
       type: 'text',
       name: 'projName',
-      message: 'What is the project name?',
+      message: 'How would you like to name the app?',
     });
     projectName = projName;
   }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -24,6 +24,7 @@ import TemplateAndVersionError from './errors/TemplateAndVersionError';
 import {getBunVersionIfAvailable} from '../../tools/bun';
 import {getNpmVersionIfAvailable} from '../../tools/npm';
 import {getYarnVersionIfAvailable} from '../../tools/yarn';
+import prompts from 'prompts';
 
 const DEFAULT_VERSION = 'latest';
 
@@ -274,6 +275,15 @@ export default (async function initialize(
   [projectName]: Array<string>,
   options: Options,
 ) {
+  if (!projectName) {
+    const {projName} = await prompts({
+      type: 'text',
+      name: 'projName',
+      message: 'What is the project name?',
+    });
+    projectName = projName;
+  }
+
   validateProjectName(projectName);
 
   if (!!options.template && !!options.version) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Closes https://github.com/react-native-community/cli/issues/2063

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init 
```

Should prompt user for the project name. 

 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
