### PR TITLE
feat: upgrade Android Studio version when installing on Windows

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
@@ -48,7 +48,7 @@ export default {
   win32AutomaticFix: async ({loader}) => {
     // Need a GitHub action to update automatically. See #1180
     const androidStudioUrl =
-      'https://redirector.gvt1.com/edgedl/android/studio/ide-zips/3.6.3.0/android-studio-ide-192.6392135-windows.zip';
+      'https://redirector.gvt1.com/edgedl/android/studio/ide-zips/2022.3.1.18/android-studio-2022.3.1.18-windows.zip';
 
     const installPath = getUserAndroidPath();
     await downloadAndUnzip({


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

https://github.com/react-native-community/cli/issues/2068

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js doctor
```

3. Check if Android Studio is installing correctly on Windows when using automatic fix.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
