### PR TITLE
Do not attempt to search for manifest in test folders

### DIFF
--- a/packages/cli-platform-android/src/config/findManifest.ts
+++ b/packages/cli-platform-android/src/config/findManifest.ts
@@ -20,6 +20,8 @@ export default function findManifest(folder: string) {
       'examples/**',
       '**/Pods/**',
       '**/sdks/hermes/android/**',
+      '**/src/androidTest/**',
+      '**/src/test/**',
     ],
   })[0];
 


### PR DESCRIPTION
Summary:
---------

The CLI should not attempt to look into test folders to grab manifests from there.
Specifically this is broken in the `react-native` repo as we do have those two Manifests:

```
packages/rn-tester/android/app/src/debug/AndroidManifest.xml
packages/rn-tester/android/app/src/main/AndroidManifest.xml
```

With this change we prevent the CLI from searching inside `src/test/` and `src/androidTest`.

Test Plan:
----------

I've tested this on `main` of `react-native` and `yarn android` now works well.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
