### PR TITLE
fix: add missing `--force-pods` flag for `run-ios` and `build-ios`

### DIFF
--- a/packages/cli-platform-ios/src/commands/buildIOS/buildOptions.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/buildOptions.ts
@@ -52,4 +52,8 @@ export const buildOptions = [
     description:
       'Explicitly select which scheme and configuration to use before running a build',
   },
+  {
+    name: '--force-pods',
+    description: 'Force CocoaPods installation',
+  },
 ];


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->

Noticed that during resolving merge conflicts the `--force-pods` flag got lost because of moving the build options to `buildOptions.ts` file. 

Test Plan:
----------
Run `run-ios --force-pods` to run pods installation
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
