### PR TITLE
fix(ios): bring back --simulator flag for run-ios

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -620,5 +620,11 @@ export default {
       description:
         'List all available iOS devices and simulators and let you choose one to run the app. ',
     },
+    {
+      name: '--simulator <string>',
+      description:
+        'Explicitly set simulator to use. Optionally include iOS version between ' +
+        'parenthesis at the end to match an exact version: "iPhone 6 (10.0)"',
+    },
   ],
 };


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Removed accidentally in #2078


Test Plan:
----------
Running:
```
yarn react-native run-ios --simulator "iPhone 14"
```
works

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
