### PR TITLE
fix: Creating cache for scoped packages

### DIFF
--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -28,10 +28,7 @@ function loadCache(name: string): Cache | undefined {
 function saveCache(name: string, cache: Cache) {
   const fullPath = path.resolve(getCacheRootPath(), name);
 
-  const dir = path.dirname(fullPath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
-  }
+  fs.mkdirSync(path.dirname(fullPath), {recursive: true});
   fs.writeFileSync(fullPath, JSON.stringify(cache, null, 2));
 }
 

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -26,10 +26,13 @@ function loadCache(name: string): Cache | undefined {
 }
 
 function saveCache(name: string, cache: Cache) {
-  fs.writeFileSync(
-    path.resolve(getCacheRootPath(), name),
-    JSON.stringify(cache, null, 2),
-  );
+  const fullPath = path.resolve(getCacheRootPath(), name);
+
+  const dir = path.dirname(fullPath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir);
+  }
+  fs.writeFileSync(fullPath, JSON.stringify(cache, null, 2));
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
If `package.json` had scoped package name, e.g. `@react-native/tester`, it was unable to create CLI cache since `fs.writeFileSync` could not create it in a path that does not exist. With this PR it will recursively create necessary folder for scoped packages before trying to save the cache file.

<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
1. Follow the contributing guide
2. run `node ./path/to/cli init AppName`
3. Run `yarn ios` and make sure app runs correctly
4. Change `name` in `package.json` to `@react-native/tester`
5. Run `yarn ios` and make sure app runs correctly
6. Open `~/Library/Caches/react-native-cli/@react-native` folder and make sure `tester` file exists

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
