### PR TITLE
feat: Enable New Architecture with react-native.config.js

### DIFF
--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -156,6 +156,7 @@ export const projectConfig = t
               .array()
               .items(t.string())
               .default([]),
+            newArchEnabled: t.bool().default(false),
           })
           .default({}),
         android: t

--- a/packages/cli-doctor/src/commands/info.ts
+++ b/packages/cli-doctor/src/commands/info.ts
@@ -6,7 +6,11 @@
  */
 
 import getEnvironmentInfo from '../tools/envinfo';
-import {logger, version} from '@react-native-community/cli-tools';
+import {
+  getArchitectureForIos,
+  logger,
+  version,
+} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
 import {readFile} from 'fs-extra';
 import path from 'path';
@@ -41,12 +45,9 @@ const info = async function getInfo(_argv: Array<string>, ctx: Config) {
 
     if (process.platform !== 'win32' && ctx.project.ios?.sourceDir) {
       try {
-        const podfile = await readFile(
-          path.join(ctx.project.ios.sourceDir, '/Podfile.lock'),
-          'utf8',
+        platforms.iOS.hermesEnabled = await getArchitectureForIos(
+          ctx.project.ios.sourceDir,
         );
-
-        platforms.iOS.hermesEnabled = podfile.includes('hermes-engine');
       } catch (e) {
         platforms.iOS.hermesEnabled = notFound;
       }

--- a/packages/cli-doctor/src/commands/info.ts
+++ b/packages/cli-doctor/src/commands/info.ts
@@ -45,24 +45,22 @@ const info = async function getInfo(_argv: Array<string>, ctx: Config) {
 
     if (process.platform !== 'win32' && ctx.project.ios?.sourceDir) {
       try {
-        platforms.iOS.hermesEnabled = await getArchitectureForIos(
-          ctx.project.ios.sourceDir,
+        const podfile = await readFile(
+          path.join(ctx.project.ios.sourceDir, '/Podfile.lock'),
+          'utf8',
         );
+
+        platforms.iOS.hermesEnabled = podfile.includes('hermes-engine');
       } catch (e) {
         platforms.iOS.hermesEnabled = notFound;
       }
 
       try {
-        const project = await readFile(
-          path.join(
-            ctx.project.ios.sourceDir,
-            '/Pods/Pods.xcodeproj/project.pbxproj',
-          ),
+        const isNewArchitecture = await getArchitectureForIos(
+          ctx.project.ios.sourceDir,
         );
 
-        platforms.iOS.newArchEnabled = project.includes(
-          '-DRCT_NEW_ARCH_ENABLED=1',
-        );
+        platforms.iOS.newArchEnabled = isNewArchitecture;
       } catch {
         platforms.iOS.newArchEnabled = notFound;
       }

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -12,12 +12,24 @@ import {BuildFlags, buildOptions} from './buildOptions';
 import {getConfiguration} from './getConfiguration';
 import {getXcodeProjectAndDir} from './getXcodeProjectAndDir';
 import resolvePods from '../../tools/pods';
+import {getArchitectureForIos} from '@react-native-community/cli-tools';
 
 async function buildIOS(_: Array<string>, ctx: Config, args: BuildFlags) {
   const {xcodeProject, sourceDir} = getXcodeProjectAndDir(ctx.project.ios);
 
+  const isAppRunningNewArchitecture = ctx.project.ios?.sourceDir
+    ? await getArchitectureForIos(ctx.project.ios?.sourceDir)
+    : undefined;
+
   // check if pods need to be installed
-  await resolvePods(ctx.root, ctx.dependencies, {forceInstall: args.forcePods});
+  await resolvePods(ctx.root, ctx.dependencies, {
+    forceInstall: args.forcePods,
+    enableNewArchitecture:
+      ctx.project.ios?.newArchEnabled !== undefined
+        ? ctx.project.ios?.newArchEnabled
+        : isAppRunningNewArchitecture,
+    isRunningNewArchitecture: isAppRunningNewArchitecture,
+  });
 
   process.chdir(sourceDir);
 

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -21,6 +21,7 @@ import {
   isPackagerRunning,
   logAlreadyRunningBundler,
   handlePortUnavailable,
+  getArchitectureForIos,
 } from '@react-native-community/cli-tools';
 import {buildProject} from '../buildIOS/buildProject';
 import {BuildFlags, buildOptions} from '../buildIOS/buildOptions';
@@ -46,10 +47,19 @@ export interface FlagsT extends BuildFlags {
 async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   link.setPlatform('ios');
   let {packager, port} = args;
+
+  const isAppRunningNewArchitecture = ctx.project.ios?.sourceDir
+    ? await getArchitectureForIos(ctx.project.ios?.sourceDir)
+    : undefined;
+
   // check if pods need to be installed
   await resolvePods(ctx.root, ctx.dependencies, {
     forceInstall: args.forcePods,
-    newArchEnabled: ctx.project.ios?.newArchEnabled,
+    enableNewArchitecture:
+      ctx.project.ios?.newArchEnabled !== undefined
+        ? ctx.project.ios?.newArchEnabled
+        : isAppRunningNewArchitecture,
+    isRunningNewArchitecture: isAppRunningNewArchitecture,
   });
 
   const packagerStatus = await isPackagerRunning(port);

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -45,7 +45,6 @@ export interface FlagsT extends BuildFlags {
 
 async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   link.setPlatform('ios');
-
   let {packager, port} = args;
   // check if pods need to be installed
   await resolvePods(ctx.root, ctx.dependencies, {

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -47,9 +47,11 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   link.setPlatform('ios');
 
   let {packager, port} = args;
-
   // check if pods need to be installed
-  await resolvePods(ctx.root, ctx.dependencies, {forceInstall: args.forcePods});
+  await resolvePods(ctx.root, ctx.dependencies, {
+    forceInstall: args.forcePods,
+    newArchEnabled: ctx.project.ios?.newArchEnabled,
+  });
 
   const packagerStatus = await isPackagerRunning(port);
 

--- a/packages/cli-platform-ios/src/config/__tests__/getProjectConfig.test.ts
+++ b/packages/cli-platform-ios/src/config/__tests__/getProjectConfig.test.ts
@@ -25,6 +25,7 @@ describe('ios::getProjectConfig', () => {
     });
     expect(projectConfig('/', {})).toMatchInlineSnapshot(`
       Object {
+        "newArchEnabled": undefined,
         "sourceDir": "/ios",
         "watchModeCommandParams": undefined,
         "xcodeProject": null,
@@ -45,6 +46,7 @@ describe('ios::getProjectConfig', () => {
     });
     expect(projectConfig('/', {})).toMatchInlineSnapshot(`
       Object {
+        "newArchEnabled": undefined,
         "sourceDir": "/ios",
         "watchModeCommandParams": undefined,
         "xcodeProject": null,

--- a/packages/cli-platform-ios/src/config/index.ts
+++ b/packages/cli-platform-ios/src/config/index.ts
@@ -51,6 +51,7 @@ export function projectConfig(
     sourceDir,
     watchModeCommandParams: userConfig.watchModeCommandParams,
     xcodeProject,
+    newArchEnabled: userConfig.newArchEnabled,
   };
 }
 

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -4,7 +4,12 @@ import os from 'os';
 import appDirs from 'appdirsjs';
 import logger from './logger';
 
-type CacheKey = 'eTag' | 'lastChecked' | 'latestVersion' | 'dependencies';
+type CacheKey =
+  | 'eTag'
+  | 'lastChecked'
+  | 'latestVersion'
+  | 'dependencies'
+  | 'newArchEnabled';
 type Cache = {[key in CacheKey]?: string};
 
 function loadCache(name: string): Cache | undefined {

--- a/packages/cli-tools/src/getArchitectureForIos.ts
+++ b/packages/cli-tools/src/getArchitectureForIos.ts
@@ -3,12 +3,11 @@ import path from 'path';
 
 export default async function getArchitectureForIos(iosSourceDir: string) {
   try {
-    const podfile = await readFile(
-      path.join(iosSourceDir, '/Podfile.lock'),
-      'utf8',
+    const project = await readFile(
+      path.join(iosSourceDir, '/Pods/Pods.xcodeproj/project.pbxproj'),
     );
 
-    return podfile.includes('hermes-engine');
+    return project.includes('-DRCT_NEW_ARCH_ENABLED=1');
   } catch {
     return false;
   }

--- a/packages/cli-tools/src/getArchitectureForIos.ts
+++ b/packages/cli-tools/src/getArchitectureForIos.ts
@@ -1,0 +1,15 @@
+import {readFile} from 'fs-extra';
+import path from 'path';
+
+export default async function getArchitectureForIos(iosSourceDir: string) {
+  try {
+    const podfile = await readFile(
+      path.join(iosSourceDir, '/Podfile.lock'),
+      'utf8',
+    );
+
+    return podfile.includes('hermes-engine');
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -17,5 +17,6 @@ export {default as handlePortUnavailable} from './handlePortUnavailable';
 export * from './port';
 export {default as cacheManager} from './cacheManager';
 export {default as runSudo} from './runSudo';
+export {default as getArchitectureForIos} from './getArchitectureForIos';
 
 export * from './errors';

--- a/packages/cli-types/src/ios.ts
+++ b/packages/cli-types/src/ios.ts
@@ -6,6 +6,7 @@
 export interface IOSProjectParams {
   sourceDir?: string;
   watchModeCommandParams?: string[];
+  newArchEnabled?: boolean;
 }
 
 export type IOSProjectInfo = {
@@ -17,6 +18,7 @@ export interface IOSProjectConfig {
   sourceDir: string;
   xcodeProject: IOSProjectInfo | null;
   watchModeCommandParams?: string[];
+  newArchEnabled?: boolean;
 }
 
 export interface IOSDependencyConfig {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
Currently, to enable New Architecture, there is a need of running `RCT_NEW_ARCH_ENABLED=1 pod install`. This change introduces new param in config file: `project.ios.newArchEnabled`which forces to run app with a given architecture. This change is caused by enabling pods installation in `run-ios` and `build-ios` commands (#2077) - currently, if someone ran `RCT_NEW_ARCH_ENABLED=1 pod install` and then added a package with native code, the script would disable New Arch. This PR allows to:
1. Install pods in run/build commands with an Architecture the project is using based on a value from `Pods.xcodeproj/project.pbxproj`
2. Force using the given architecture on iOS based on the `project.ios.newArchEnabled` field. In case anyone change the architecture by using a RCT_NEW_ARCH_ENABLED flag and the param in config is set, it will install the pods accordingly to the Architecture set in the config 

Test Plan:
----------
1. Init new project with nightly
2. Use `run-ios` and check if project ran correctly
3. Use `RCT_NEW_ARCH_ENABLED=1 pod install` and `run-ios` and verify if `fabric: true` in Metro console
4. Create `react-native.config.js` with the following content:
```
module.exports = {
  project: {
    ios: {
      newArchEnabled: false,
    },
  },
};

```
5. Run `run-ios` and verify `fabric: true` is not visible in Metro logs
6. Change value to `true` and run `run-ios` again - verify `fabric: true` is visible in Metro logs
7. Add a dependency containing native code e.g. `react-native-gesture-handler` to the project
8. Run `run-ios` again, let the pods install and verify `fabric: true` is set in the Metro logs
9. Run `pod install` in `ios` folder and run `run-ios` again, verify that pods are installed again and `fabric: true` is visible in Metro logs
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
