### PR TITLE
fix: avoid chmod on read stream close

### DIFF
--- a/packages/cli/src/tools/copyFiles.ts
+++ b/packages/cli/src/tools/copyFiles.ts
@@ -69,7 +69,7 @@ function copyBinaryFile(
   let cbCalled = false;
   const {mode} = fs.statSync(srcPath);
   const readStream = fs.createReadStream(srcPath);
-  const writeStream = fs.createWriteStream(destPath);
+  const writeStream = fs.createWriteStream(destPath, {mode});
   readStream.on('error', (err) => {
     done(err);
   });
@@ -78,7 +78,6 @@ function copyBinaryFile(
   });
   readStream.on('close', () => {
     done();
-    fs.chmodSync(destPath, mode);
   });
   readStream.pipe(writeStream);
   function done(err?: Error) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
Recently the Babel react-native e2e test is breaking:

https://github.com/babel/babel/actions/runs/6345671251/job/17316512072#step:10:82
```
Error: ENOENT: no such file or directory, chmod '/tmp/rnbabel/ios/HelloWorld/Images.xcassets/Contents.json'
    at Object.chmodSync (node:fs:1991:3)
    at Object.chmodSync (/home/runner/.npm/_npx/[79](https://github.com/babel/babel/actions/runs/6345671251/job/17316512072#step:10:80)30a8670f922cdb/node_modules/graceful-fs/polyfills.js:263:21)
    at ReadStream.<anonymous> (/home/runner/.npm/_npx/7930a8670f922cdb/node_modules/@react-native-community/cli/build/tools/copyFiles.js:83:19)
    at ReadStream.emit (node:events:517:28)
    at emitCloseNT (node:internal/streams/destroy:132:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:81:21)
```
The exact ENOENT file seems random, e.g. it could also be `/tmp/rnbabel/App.tsx` in another [CI job result](https://github.com/babel/babel/actions/runs/6350045546/job/17249518727?pr=16012). It occurs in other projects unrelated to Babel as well: https://github.com/akveo/react-native-ui-kitten/issues/1630

The issue is likely due to a race conditions in

https://github.com/react-native-community/cli/blob/0e0801e09210ab713f4984f727c6e54366ff3e9c/packages/cli/src/tools/copyFiles.ts#L79-L82

When the read stream is closed, the write stream might not have been closed yet so `chmod` is racing with the write stream.

Here we avoid the `chmodSync` call and instead provide the desired mode upfront to the write stream so that the copied file will inherit the source file's mode.


Test Plan:
----------

Manual test. 

Create a file named `./test.js`

```js
'use strict';
const fs = require('node:fs');
function copyBinaryFile(srcPath, destPath, cb) {
  let cbCalled = false;
  const {mode} = fs.statSync(srcPath);
  const readStream = fs.createReadStream(srcPath);
  const writeStream = fs.createWriteStream(destPath, {mode});
  readStream.on('error', (err) => {
    done(err);
  });
  writeStream.on('error', (err) => {
    done(err);
  });
  readStream.on('close', () => {
    done();
  });
  readStream.pipe(writeStream);
  function done(err) {
    if (!cbCalled) {
      cb(err);
      cbCalled = true;
    }
  }
}

copyBinaryFile('./foo', './bar', () => {});
```

Run the following commands in shell
```sh
touch ./foo
echo "foo" > ./foo
chmod 0400 ./foo
node ./test.js
stat ./bar
```

Expect: The `./bar` should be created with `0400` mode with the content "foo"

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
