### PR TITLE
fix: add missing shebang to `launchPackager.command`

### DIFF
--- a/packages/cli-tools/src/launchPackager.command
+++ b/packages/cli-tools/src/launchPackager.command
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 
 source "$THIS_DIR/.packager.env"


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes #2095 

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command in Bash:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```

 


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
