### PR TITLE
feat: log files in selected directory and add option to replace them

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -66,11 +66,11 @@ test('init should ask and print files in directory if exist', () => {
 
   const {stdout, stderr} = runCLI(DIR, ['init', PROJECT_NAME]);
 
+  expect(stdout).toContain(`Do you want to replace existing files?`);
   expect(stderr).toContain(
     `warn The directory ${PROJECT_NAME} contains files that will be overwritten:`,
   );
-  expect(stdout).toContain(`package.json`);
-  expect(stdout).toContain(`Do you want to replace existing files?`);
+  expect(stderr).toContain(`package.json`);
 });
 
 test('init should prompt for the project name', () => {

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -46,13 +46,31 @@ if (process.platform === 'win32') {
   templatePath = `file://${templatePath}`;
 }
 
-test('init fails if the directory already exists', () => {
+test('init fails if the directory already exists and --replace-directory false', () => {
   fs.mkdirSync(path.join(DIR, PROJECT_NAME));
 
-  const {stderr} = runCLI(DIR, ['init', PROJECT_NAME], {expectedFailure: true});
+  const {stderr} = runCLI(
+    DIR,
+    ['init', PROJECT_NAME, '--replace-directory', 'false'],
+    {expectedFailure: true},
+  );
+
   expect(stderr).toContain(
     `error Cannot initialize new project because directory "${PROJECT_NAME}" already exists.`,
   );
+});
+
+test('init should ask and print files in directory if exist', () => {
+  fs.mkdirSync(path.join(DIR, PROJECT_NAME));
+  fs.writeFileSync(path.join(DIR, PROJECT_NAME, 'package.json'), '{}');
+
+  const {stdout, stderr} = runCLI(DIR, ['init', PROJECT_NAME]);
+
+  expect(stderr).toContain(
+    `warn The directory ${PROJECT_NAME} contains files that will be overwritten:`,
+  );
+  expect(stdout).toContain(`package.json`);
+  expect(stdout).toContain(`Do you want to replace existing files?`);
 });
 
 test('init should prompt for the project name', () => {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -101,6 +101,7 @@ Skip dependencies installation
 Determine if CocoaPods should be installed when initializing a project. If set to `true` it will install pods, if set to `false`, it will skip the step entirely. If not used, prompt will be displayed
 
 #### `--npm`
+
 > [!WARNING]  
 > `--npm` is deprecated and will be removed in the future. Please use `--pm npm` instead.
 
@@ -120,6 +121,10 @@ Create project with custom package name for Android and bundle identifier for iO
 #### `--skip-git-init <boolean>`
 
 Skip git repository initialization.
+
+#### `--replace-directory <string>`
+
+Replaces the directory if it already exists
 
 ### `upgrade`
 

--- a/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
@@ -1,0 +1,9 @@
+import {CLIError} from '@react-native-community/cli-tools';
+
+export default class DirectoryAlreadyExistsError extends CLIError {
+  constructor(directory: string) {
+    super(
+      `Cannot initialize new project because directory "${directory}" already exists. Please remove or rename the directory and try again.`,
+    );
+  }
+}

--- a/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
+++ b/packages/cli/src/commands/init/errors/DirectoryAlreadyExistsError.ts
@@ -1,9 +1,0 @@
-import {CLIError} from '@react-native-community/cli-tools';
-
-export default class DirectoryAlreadyExistsError extends CLIError {
-  constructor(directory: string) {
-    super(
-      `Cannot initialize new project because directory "${directory}" already exists.`,
-    );
-  }
-}

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -56,5 +56,9 @@ export default {
       name: '--skip-git-init',
       description: 'Skip git repository initialization',
     },
+    {
+      name: '--replace-directory [boolean]',
+      description: 'Replaces the directory if it already exists.',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -126,15 +126,15 @@ async function setProjectDirectory(
     const conflicts = getConflictsForDirectory(directory);
 
     if (conflicts.length > 0) {
-      logger.warn(
-        `The directory ${chalk.bold(
-          directory,
-        )} contains files that will be overwritten:`,
-      );
+      let warnMessage = `The directory ${chalk.bold(
+        directory,
+      )} contains files that will be overwritten:\n`;
 
       for (const conflict of conflicts) {
-        logger.log(`  ${conflict}`);
+        warnMessage += `   ${conflict}\n`;
       }
+
+      logger.warn(warnMessage);
 
       const {replace} = await prompt({
         type: 'confirm',

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -1,9 +1,8 @@
 import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
+import fs, {readdirSync} from 'fs-extra';
 import {validateProjectName} from './validate';
 import chalk from 'chalk';
-import DirectoryAlreadyExistsError from './errors/DirectoryAlreadyExistsError';
 import printRunInstructions from './printRunInstructions';
 import {
   CLIError,
@@ -101,8 +100,50 @@ function doesDirectoryExist(dir: string) {
   return fs.existsSync(dir);
 }
 
+function getConflictsForDirectory(directory: string) {
+  return readdirSync(directory);
+}
+
 async function setProjectDirectory(directory: string) {
+  const directoryExists = doesDirectoryExist(directory);
+  let deleteDirectory = false;
+
+  if (directoryExists) {
+    const conflicts = getConflictsForDirectory(directory);
+
+    if (conflicts.length > 0) {
+      logger.warn(
+        `The directory ${chalk.bold(
+          directory,
+        )} contains files that will be overwritten:`,
+      );
+
+      for (const conflict of conflicts) {
+        logger.log(`  ${conflict}`);
+      }
+
+      const {replace} = await prompt({
+        type: 'confirm',
+        name: 'replace',
+        message: 'Do you want to replace existing files?',
+      });
+
+      deleteDirectory = replace;
+
+      if (!replace) {
+        throw new CLIError(
+          'Please remove files manually, or choose other directory.',
+        );
+      }
+    }
+  }
+
   try {
+    if (deleteDirectory) {
+      fs.removeSync(directory);
+    }
+
+    fs.mkdirSync(directory, {recursive: true});
     process.chdir(directory);
   } catch (error) {
     throw new CLIError(
@@ -404,12 +445,6 @@ export default (async function initialize(
       'Seems like the package manager you want to use is not installed. Please install it or choose another package manager.',
     );
     return;
-  }
-
-  if (doesDirectoryExist(projectFolder)) {
-    throw new DirectoryAlreadyExistsError(directoryName);
-  } else {
-    fs.mkdirSync(projectFolder, {recursive: true});
   }
 
   let shouldBumpYarnVersion = true;


### PR DESCRIPTION
Summary:
---------

In this PR I added option to replace existing files in the selected directory.
Related https://github.com/react-native-community/cli/pull/1591

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create a directory `hello` with few files
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init hello
```
4. Should ask do user want to replace existing files.
5. If yes, it deletes directory.
6. If not, it prints an error.
 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
