### PR TITLE
refactor: rename generatedFileContentsTemplate to packageListTemplate

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -2,10 +2,8 @@ import groovy.json.JsonSlurper
 import org.gradle.initialization.DefaultSettings
 import org.apache.tools.ant.taskdefs.condition.Os
 
-def generatedFileName = "PackageList.java"
-def generatedFilePackage = "com.facebook.react"
-def generatedFileContentsTemplate = """
-package $generatedFilePackage;
+def packageListTemplate = """
+package com.facebook.react;
 
 import android.app.Application;
 import android.content.Context;
@@ -523,12 +521,12 @@ ext.applyNativeModulesAppBuildGradle = { Project project, String root = null ->
   autoModules.addReactNativeModuleDependencies(project)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
-  def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))
+  def generatedCodeDir = new File(generatedSrcDir, "com/facebook/react")
   def generatedJniDir = new File(buildDir, "generated/rncli/src/main/jni")
 
   task generatePackageList {
     doLast {
-      autoModules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
+      autoModules.generatePackagesFile(generatedCodeDir, "PackageList.java", packageListTemplate)
     }
   }
 


### PR DESCRIPTION
Summary:
---------

Rename `generatedFileContentsTemplate` to `packageListTemplate` and inline related variables


Test Plan:
----------

None

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
