### PR TITLE
fix(ios): check if there are any available simulators or physical devices

### DIFF
--- a/packages/cli-platform-ios/src/commands/logIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/logIOS/index.ts
@@ -36,6 +36,11 @@ async function logIOS(_argv: Array<string>, _ctx: Config, args: Args) {
     ({type, isAvailable}) => type === 'simulator' && isAvailable,
   );
 
+  if (availableSimulators.length === 0) {
+    logger.error('No simulators detected. Install simulators via Xcode.');
+    return;
+  }
+
   const bootedAndAvailableSimulators = bootedSimulators.map((booted) => {
     const available = availableSimulators.find(
       ({udid}) => udid === booted.udid,
@@ -44,7 +49,7 @@ async function logIOS(_argv: Array<string>, _ctx: Config, args: Args) {
   });
 
   if (bootedAndAvailableSimulators.length === 0) {
-    logger.error('No active iOS device found');
+    logger.error('No booted and available iOS simulators found.');
     return;
   }
 

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -100,7 +100,18 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   const {mode, scheme} = await getConfiguration(xcodeProject, sourceDir, args);
 
-  const availableDevices = await listIOSDevices();
+  const devices = await listIOSDevices();
+
+  const availableDevices = devices.filter(
+    ({isAvailable}) => isAvailable === true,
+  );
+
+  if (availableDevices.length === 0) {
+    return logger.error(
+      'iOS devices or simulators not detected. Install simulators via Xcode or connect a physical iOS device',
+    );
+  }
+
   if (args.listDevices || args.interactive) {
     if (args.device || args.udid) {
       logger.warn(
@@ -126,7 +137,7 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   if (!args.device && !args.udid && !args.simulator) {
     const bootedDevices = availableDevices.filter(
-      ({type, isAvailable}) => type === 'device' && isAvailable,
+      ({type}) => type === 'device',
     );
 
     const simulators = getSimulators();


### PR DESCRIPTION

Summary:
---------

In this PR I added condition which check if there are any simulators / physical devices available. 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Uninstall simulators and unpair physical devices
3. Command `xcrun xcdevice list` should list only your computer
4. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```
It should give an error.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
