### PR TITLE
fix: delete useless mocking in e2e tests

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -7,9 +7,6 @@ import {
   writeFiles,
 } from '../jest/helpers';
 import slash from 'slash';
-import prompts from 'prompts';
-
-jest.mock('prompts', () => jest.fn());
 
 const DIR = getTempDirectory('command-init');
 
@@ -60,22 +57,9 @@ test('init fails if the directory already exists', () => {
 });
 
 test('init should prompt for the project name', () => {
-  createCustomTemplateFiles();
-  const {stdout} = runCLI(DIR, [
-    'init',
-    'test',
-    '--template',
-    templatePath,
-    '--install-pods',
-    'false',
-  ]);
+  const {stdout} = runCLI(DIR, ['init']);
 
-  (prompts as jest.MockedFunction<typeof prompts>).mockReturnValue(
-    Promise.resolve({
-      name: 'TestInit',
-    }),
-  );
-  expect(stdout).toContain('Run instructions');
+  expect(stdout).toContain('How would you like to name the app?');
 });
 
 test('init --template filepath', () => {

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -9,6 +9,7 @@ import {
 import slash from 'slash';
 
 const DIR = getTempDirectory('command-init');
+const PROJECT_NAME = 'TestInit';
 
 function createCustomTemplateFiles() {
   writeFiles(DIR, {
@@ -48,11 +49,11 @@ if (process.platform === 'win32') {
 }
 
 test('init fails if the directory already exists', () => {
-  fs.mkdirSync(path.join(DIR, 'TestInit'));
+  fs.mkdirSync(path.join(DIR, PROJECT_NAME));
 
-  const {stderr} = runCLI(DIR, ['init', 'TestInit'], {expectedFailure: true});
+  const {stderr} = runCLI(DIR, ['init', PROJECT_NAME], {expectedFailure: true});
   expect(stderr).toContain(
-    'error Cannot initialize new project because directory "TestInit" already exists.',
+    `error Cannot initialize new project because directory "${PROJECT_NAME}" already exists.`,
   );
 });
 
@@ -69,7 +70,7 @@ test('init --template filepath', () => {
     'init',
     '--template',
     templatePath,
-    'TestInit',
+    PROJECT_NAME,
     '--install-pods',
     'false',
   ]);
@@ -79,21 +80,20 @@ test('init --template filepath', () => {
   // make sure we don't leave garbage
   expect(fs.readdirSync(DIR)).toContain('custom');
 
-  let dirFiles = fs.readdirSync(path.join(DIR, 'TestInit'));
+  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
 
   expect(dirFiles).toEqual(customTemplateCopiedFiles);
 });
 
 test('init --template file with custom directory', () => {
   createCustomTemplateFiles();
-  const projectName = 'TestInit';
   const customPath = 'custom-path';
 
   const {stdout} = runCLI(DIR, [
     'init',
     '--template',
     templatePath,
-    projectName,
+    PROJECT_NAME,
     '--directory',
     'custom-path',
     '--install-pods',
@@ -117,7 +117,7 @@ test('init skips installation of dependencies with --skip-install', () => {
     'init',
     '--template',
     templatePath,
-    'TestInit',
+    PROJECT_NAME,
     '--skip-install',
   ]);
 
@@ -126,7 +126,7 @@ test('init skips installation of dependencies with --skip-install', () => {
   // make sure we don't leave garbage
   expect(fs.readdirSync(DIR)).toContain('custom');
 
-  let dirFiles = fs.readdirSync(path.join(DIR, 'TestInit'));
+  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
 
   expect(dirFiles).toEqual(
     customTemplateCopiedFiles.filter(
@@ -142,7 +142,7 @@ test('init uses npm as the package manager with --npm', () => {
     'init',
     '--template',
     templatePath,
-    'TestInit',
+    PROJECT_NAME,
     '--npm',
     '--install-pods',
     'false',
@@ -153,7 +153,7 @@ test('init uses npm as the package manager with --npm', () => {
   // make sure we don't leave garbage
   expect(fs.readdirSync(DIR)).toContain('custom');
 
-  const initDirPath = path.join(DIR, 'TestInit');
+  const initDirPath = path.join(DIR, PROJECT_NAME);
 
   // Remove yarn.lock and node_modules
   const filteredFiles = customTemplateCopiedFiles.filter(


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Mocking `prompts` doesn't change anything if we're running command in real world scenario with `runCLI` function. 

Test Plan:
----------

CI Green.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
