### PR TITLE
fix: remove hardcoded path to iOS folder

### DIFF
--- a/packages/cli-platform-ios/src/tools/installPods.ts
+++ b/packages/cli-platform-ios/src/tools/installPods.ts
@@ -110,14 +110,18 @@ async function installCocoaPods(loader: Ora) {
   }
 }
 
-async function installPods(loader?: Ora, options?: PodInstallOptions) {
+async function installPods(
+  loader?: Ora,
+  iosFolderPath?: string,
+  options?: PodInstallOptions,
+) {
   loader = loader || new NoopLoader();
   try {
-    if (!fs.existsSync('ios')) {
+    if (!iosFolderPath && !fs.existsSync('ios')) {
       return;
     }
 
-    process.chdir('ios');
+    process.chdir(iosFolderPath ?? 'ios');
 
     const hasPods = fs.existsSync('Podfile');
 

--- a/packages/cli-platform-ios/src/tools/pods.ts
+++ b/packages/cli-platform-ios/src/tools/pods.ts
@@ -61,10 +61,13 @@ async function install(
   packageJson: Record<string, any>,
   cachedDependenciesHash: string | undefined,
   currentDependenciesHash: string,
+  iosFolderPath: string,
 ) {
   const loader = getLoader('Installing CocoaPods...');
   try {
-    await installPods(loader, {skipBundleInstall: !!cachedDependenciesHash});
+    await installPods(loader, iosFolderPath, {
+      skipBundleInstall: !!cachedDependenciesHash,
+    });
     cacheManager.set(packageJson.name, 'dependencies', currentDependenciesHash);
     loader.succeed();
   } catch {
@@ -106,6 +109,11 @@ export default async function resolvePods(
     !compareMd5Hashes(currentDependenciesHash, cachedDependenciesHash) ||
     !arePodsInstalled
   ) {
-    await install(packageJson, cachedDependenciesHash, currentDependenciesHash);
+    await install(
+      packageJson,
+      cachedDependenciesHash,
+      currentDependenciesHash,
+      iosFolderPath,
+    );
   }
 }

--- a/packages/cli-platform-ios/src/tools/pods.ts
+++ b/packages/cli-platform-ios/src/tools/pods.ts
@@ -101,7 +101,12 @@ export default async function resolvePods(
   );
 
   if (options?.forceInstall) {
-    await install(packageJson, cachedDependenciesHash, currentDependenciesHash);
+    await install(
+      packageJson,
+      cachedDependenciesHash,
+      currentDependenciesHash,
+      iosFolderPath,
+    );
   } else if (arePodsInstalled && cachedDependenciesHash === undefined) {
     cacheManager.set(packageJson.name, 'dependencies', currentDependenciesHash);
   } else if (


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

We get path to iOS folder by looking for `Podfile`, even if we rename folder containing iOS files it should work, but by hardcoding it will break.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Rename `ios` folder -> `mv ios fios`,
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```
4. Install library (to get new hash)
```sh
yarn install react-native-slider
```
6. Should detect change in `package.json` and install install pods in new folder.
```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
