### PR TITLE
fix(android): properly handle errors

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -140,6 +140,8 @@ function createInstallError(error: Error & {stderr: string}) {
         guide: 'native',
       }),
     )} and follow the React Native CLI QuickStart guide to install the compatible version of JDK.`;
+  } else {
+    message = error.message;
   }
 
   return new CLIError(


### PR DESCRIPTION
Summary:
---------

Currently we're not displaying errors if they other than we expect, so even we're not showing errors that we return inside CLI - which leads to situations like this one https://github.com/react-native-community/cli/issues/2105, when user don't know what to do because the error is only "**error** Failed to install the app". 


Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-android --mode=randomMode
```


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
