### PR TITLE
fix: get scheme from `xcodeProject` name

### DIFF
--- a/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import {IOSProjectInfo} from '@react-native-community/cli-types';
 import {logger} from '@react-native-community/cli-tools';
 import {selectFromInteractiveMode} from '../../tools/selectFromInteractiveMode';
-import {getProjectInfo} from '../../tools/getProjectInfo';
+import {getInfo} from '../../tools/getInfo';
 import {checkIfConfigurationExists} from '../../tools/checkIfConfigurationExists';
 import type {BuildFlags} from './buildOptions';
 import {getBuildConfigurationFromXcScheme} from '../../tools/getBuildConfigurationFromXcScheme';
@@ -13,10 +13,13 @@ export async function getConfiguration(
   sourceDir: string,
   args: BuildFlags,
 ) {
-  const projectInfo = getProjectInfo();
+  const info = getInfo();
 
   if (args.mode) {
-    checkIfConfigurationExists(projectInfo, args.mode);
+    if (!info || !info.configurations) {
+      throw new Error('Cannot determine Xcode project configuration.');
+    }
+    checkIfConfigurationExists(info.configurations, args.mode);
   }
 
   let scheme =
@@ -24,13 +27,13 @@ export async function getConfiguration(
     path.basename(xcodeProject.name, path.extname(xcodeProject.name));
   let mode =
     args.mode ||
-    getBuildConfigurationFromXcScheme(scheme, 'Debug', sourceDir, projectInfo);
+    getBuildConfigurationFromXcScheme(scheme, 'Debug', sourceDir, info);
 
   if (args.interactive) {
     const selection = await selectFromInteractiveMode({
       scheme,
       mode,
-      projectInfo,
+      info,
     });
 
     if (selection.scheme) {

--- a/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
@@ -16,10 +16,7 @@ export async function getConfiguration(
   const info = getInfo();
 
   if (args.mode) {
-    if (!info || !info.configurations) {
-      throw new Error('Cannot determine Xcode project configuration.');
-    }
-    checkIfConfigurationExists(info.configurations, args.mode);
+    checkIfConfigurationExists((info && info.configurations) ?? [], args.mode);
   }
 
   let scheme =

--- a/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
@@ -16,7 +16,7 @@ export async function getConfiguration(
   const info = getInfo();
 
   if (args.mode) {
-    checkIfConfigurationExists((info && info.configurations) ?? [], args.mode);
+    checkIfConfigurationExists(info?.configurations ?? [], args.mode);
   }
 
   let scheme =

--- a/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/getConfiguration.ts
@@ -6,6 +6,7 @@ import {getProjectInfo} from '../../tools/getProjectInfo';
 import {checkIfConfigurationExists} from '../../tools/checkIfConfigurationExists';
 import type {BuildFlags} from './buildOptions';
 import {getBuildConfigurationFromXcScheme} from '../../tools/getBuildConfigurationFromXcScheme';
+import path from 'path';
 
 export async function getConfiguration(
   xcodeProject: IOSProjectInfo,
@@ -18,7 +19,9 @@ export async function getConfiguration(
     checkIfConfigurationExists(projectInfo, args.mode);
   }
 
-  let scheme = args.scheme || projectInfo.schemes[0];
+  let scheme =
+    args.scheme ||
+    path.basename(xcodeProject.name, path.extname(xcodeProject.name));
   let mode =
     args.mode ||
     getBuildConfigurationFromXcScheme(scheme, 'Debug', sourceDir, projectInfo);

--- a/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/checkIfConfigurationExists.test.ts
@@ -1,19 +1,12 @@
-import type {IosProjectInfo} from '../../types';
 import {checkIfConfigurationExists} from '../checkIfConfigurationExists';
 
 const CONFIGURATIONS = ['Debug', 'Release'];
 const NON_EXISTING_CONFIG = 'Test';
-const PROJECT_INFO = {
-  configurations: CONFIGURATIONS,
-  name: 'MyApp',
-  schemes: ['MyApp', 'Scheme'],
-  targets: ['MyApp', 'MyAppTests'],
-};
 
 describe('checkIfConfigurationExists', () => {
   test('should throw an error if project info does not contain selected configuration', () => {
     const checkConfig = () =>
-      checkIfConfigurationExists(PROJECT_INFO, NON_EXISTING_CONFIG);
+      checkIfConfigurationExists(CONFIGURATIONS, NON_EXISTING_CONFIG);
 
     expect(checkConfig).toThrowError(
       `Configuration "${NON_EXISTING_CONFIG}" does not exist in your project. Please use one of the existing configurations: ${CONFIGURATIONS.join(
@@ -23,14 +16,14 @@ describe('checkIfConfigurationExists', () => {
   });
 
   test('should not throw an error if project info contains selected configuration', () => {
-    const checkConfig = () => checkIfConfigurationExists(PROJECT_INFO, 'Debug');
+    const checkConfig = () =>
+      checkIfConfigurationExists(CONFIGURATIONS, 'Debug');
 
     expect(checkConfig).not.toThrow();
   });
 
   test('should not throw an error if project could not be found', () => {
-    const checkConfig = () =>
-      checkIfConfigurationExists(undefined as IosProjectInfo, 'Debug');
+    const checkConfig = () => checkIfConfigurationExists([], 'Debug');
 
     expect(checkConfig).not.toThrow();
   });

--- a/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
+++ b/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
@@ -1,9 +1,14 @@
-import {CLIError} from '@react-native-community/cli-tools';
+import {CLIError, logger} from '@react-native-community/cli-tools';
 
 export function checkIfConfigurationExists(
   configurations: string[],
   mode: string,
 ) {
+  if (configurations.length === 0) {
+    logger.warn(`Unable to check whether "${mode}" exists in your project`);
+    return;
+  }
+
   if (!configurations.includes(mode)) {
     throw new CLIError(
       `Configuration "${mode}" does not exist in your project. Please use one of the existing configurations: ${configurations.join(

--- a/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
+++ b/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
@@ -2,7 +2,7 @@ import {CLIError, logger} from '@react-native-community/cli-tools';
 import {IosProjectInfo} from '../types';
 
 export function checkIfConfigurationExists(
-  project: IosProjectInfo,
+  project: IosProjectInfo | undefined,
   mode: string,
 ) {
   if (!project) {

--- a/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
+++ b/packages/cli-platform-ios/src/tools/checkIfConfigurationExists.ts
@@ -1,18 +1,12 @@
-import {CLIError, logger} from '@react-native-community/cli-tools';
-import {IosProjectInfo} from '../types';
+import {CLIError} from '@react-native-community/cli-tools';
 
 export function checkIfConfigurationExists(
-  project: IosProjectInfo | undefined,
+  configurations: string[],
   mode: string,
 ) {
-  if (!project) {
-    logger.warn(`Unable to check whether "${mode}" exists in your project`);
-    return;
-  }
-
-  if (!project.configurations.includes(mode)) {
+  if (!configurations.includes(mode)) {
     throw new CLIError(
-      `Configuration "${mode}" does not exist in your project. Please use one of the existing configurations: ${project.configurations.join(
+      `Configuration "${mode}" does not exist in your project. Please use one of the existing configurations: ${configurations.join(
         ', ',
       )}`,
     );

--- a/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
+++ b/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
@@ -11,7 +11,7 @@ export function getBuildConfigurationFromXcScheme(
   scheme: string,
   configuration: string,
   sourceDir: string,
-  projectInfo: IosProjectInfo,
+  projectInfo: IosProjectInfo | undefined,
 ): string {
   try {
     const xcProject = fs
@@ -37,10 +37,13 @@ export function getBuildConfigurationFromXcScheme(
       return Scheme.LaunchAction['@_buildConfiguration'];
     }
   } catch {
+    const availableSchemas = projectInfo
+      ? `Available schemas are: ${projectInfo.schemes
+          .map((name) => chalk.bold(name))
+          .join(', ')}'`
+      : '';
     throw new CLIError(
-      `Could not find scheme ${scheme}. Please make sure the schema you want to run exists. Available schemas are: ${projectInfo.schemes
-        .map((name) => chalk.bold(name))
-        .join(', ')}'`,
+      `Could not find scheme ${scheme}. Please make sure the schema you want to run exists. ${availableSchemas}`,
     );
   }
 

--- a/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
+++ b/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import {XMLParser} from 'fast-xml-parser';
 import fs from 'fs';
 import path from 'path';
-import {IosProjectInfo} from '../types';
+import {IosInfo} from '../types';
 
 const xmlParser = new XMLParser({ignoreAttributes: false});
 
@@ -11,7 +11,7 @@ export function getBuildConfigurationFromXcScheme(
   scheme: string,
   configuration: string,
   sourceDir: string,
-  projectInfo: IosProjectInfo | undefined,
+  projectInfo: IosInfo | undefined,
 ): string {
   try {
     const xcProject = fs
@@ -37,11 +37,13 @@ export function getBuildConfigurationFromXcScheme(
       return Scheme.LaunchAction['@_buildConfiguration'];
     }
   } catch {
-    const availableSchemas = projectInfo
-      ? `Available schemas are: ${projectInfo.schemes
-          .map((name) => chalk.bold(name))
-          .join(', ')}'`
-      : '';
+    const availableSchemas =
+      projectInfo && projectInfo.schemes && projectInfo.schemes.length > 0
+        ? `Available schemas are: ${projectInfo.schemes
+            .map((name) => chalk.bold(name))
+            .join(', ')}'`
+        : '';
+
     throw new CLIError(
       `Could not find scheme ${scheme}. Please make sure the schema you want to run exists. ${availableSchemas}`,
     );

--- a/packages/cli-platform-ios/src/tools/getInfo.ts
+++ b/packages/cli-platform-ios/src/tools/getInfo.ts
@@ -1,11 +1,19 @@
 import execa from 'execa';
-import {IosProjectInfo} from '../types';
+import {IosInfo} from '../types';
 
-export function getProjectInfo(): IosProjectInfo | undefined {
+export function getInfo(): IosInfo | undefined {
   try {
-    const out = execa.sync('xcodebuild', ['-list', '-json']).stdout;
-    const {project} = JSON.parse(out);
-    return project;
+    const value = JSON.parse(
+      execa.sync('xcodebuild', ['-list', '-json']).stdout,
+    );
+
+    if ('project' in value) {
+      return value.project;
+    } else if ('workspace' in value) {
+      return value.workspace;
+    }
+
+    return undefined;
   } catch (error) {
     if (
       (error as Error)?.message &&

--- a/packages/cli-platform-ios/src/tools/getProjectInfo.ts
+++ b/packages/cli-platform-ios/src/tools/getProjectInfo.ts
@@ -1,7 +1,7 @@
 import execa from 'execa';
 import {IosProjectInfo} from '../types';
 
-export function getProjectInfo(): IosProjectInfo {
+export function getProjectInfo(): IosProjectInfo | undefined {
   try {
     const out = execa.sync('xcodebuild', ['-list', '-json']).stdout;
     const {project} = JSON.parse(out);

--- a/packages/cli-platform-ios/src/tools/prompts.ts
+++ b/packages/cli-platform-ios/src/tools/prompts.ts
@@ -1,15 +1,15 @@
 import chalk from 'chalk';
 import prompts from 'prompts';
-import {Device, IosProjectInfo} from '../types';
+import {Device} from '../types';
 
 export async function promptForSchemeSelection(
-  project: IosProjectInfo,
+  schemes: string[],
 ): Promise<string> {
   const {scheme} = await prompts({
     name: 'scheme',
     type: 'select',
     message: 'Select the scheme you want to use',
-    choices: project.schemes.map((value) => ({
+    choices: schemes.map((value) => ({
       title: value,
       value: value,
     })),
@@ -19,13 +19,13 @@ export async function promptForSchemeSelection(
 }
 
 export async function promptForConfigurationSelection(
-  project: IosProjectInfo,
+  configurations: string[],
 ): Promise<string> {
   const {configuration} = await prompts({
     name: 'configuration',
     type: 'select',
     message: 'Select the configuration you want to use',
-    choices: project.configurations.map((value) => ({
+    choices: configurations.map((value) => ({
       title: value,
       value: value,
     })),

--- a/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
+++ b/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
@@ -9,7 +9,7 @@ import {
 interface Args {
   scheme?: string;
   mode?: string;
-  projectInfo: IosProjectInfo;
+  projectInfo: IosProjectInfo | undefined;
 }
 
 export async function selectFromInteractiveMode({
@@ -20,13 +20,13 @@ export async function selectFromInteractiveMode({
   let newScheme = scheme;
   let newMode = mode;
 
-  if (projectInfo.schemes.length > 1) {
+  if (projectInfo && projectInfo.schemes.length > 1) {
     newScheme = await promptForSchemeSelection(projectInfo);
   } else {
     logger.info(`Automatically selected ${chalk.bold(scheme)} scheme.`);
   }
 
-  if (projectInfo.configurations.length > 1) {
+  if (projectInfo && projectInfo.configurations.length > 1) {
     newMode = await promptForConfigurationSelection(projectInfo);
   } else {
     logger.info(`Automatically selected ${chalk.bold(mode)} configuration.`);

--- a/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
+++ b/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
@@ -1,6 +1,6 @@
 import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
-import {IosProjectInfo} from '../types';
+import {IosInfo} from '../types';
 import {
   promptForConfigurationSelection,
   promptForSchemeSelection,
@@ -9,25 +9,25 @@ import {
 interface Args {
   scheme?: string;
   mode?: string;
-  projectInfo: IosProjectInfo | undefined;
+  info: IosInfo | undefined;
 }
 
 export async function selectFromInteractiveMode({
   scheme,
   mode,
-  projectInfo,
+  info,
 }: Args): Promise<{scheme?: string; mode?: string}> {
   let newScheme = scheme;
   let newMode = mode;
 
-  if (projectInfo && projectInfo.schemes.length > 1) {
-    newScheme = await promptForSchemeSelection(projectInfo);
+  if (info && info?.schemes && info.schemes.length > 1) {
+    newScheme = await promptForSchemeSelection(info.schemes);
   } else {
     logger.info(`Automatically selected ${chalk.bold(scheme)} scheme.`);
   }
 
-  if (projectInfo && projectInfo.configurations.length > 1) {
-    newMode = await promptForConfigurationSelection(projectInfo);
+  if (info && info?.configurations && info?.configurations?.length > 1) {
+    newMode = await promptForConfigurationSelection(info.configurations);
   } else {
     logger.info(`Automatically selected ${chalk.bold(mode)} configuration.`);
   }

--- a/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
+++ b/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
@@ -20,8 +20,9 @@ export async function selectFromInteractiveMode({
   let newScheme = scheme;
   let newMode = mode;
 
-  if (info && info?.schemes && info.schemes.length > 1) {
-    newScheme = await promptForSchemeSelection(info.schemes);
+  const schemes = info?.schemes;
+  if (schemes && schemes.length > 1) {
+    newScheme = await promptForSchemeSelection(schemes);
   } else {
     logger.info(`Automatically selected ${chalk.bold(scheme)} scheme.`);
   }

--- a/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
+++ b/packages/cli-platform-ios/src/tools/selectFromInteractiveMode.ts
@@ -27,8 +27,9 @@ export async function selectFromInteractiveMode({
     logger.info(`Automatically selected ${chalk.bold(scheme)} scheme.`);
   }
 
-  if (info && info?.configurations && info?.configurations?.length > 1) {
-    newMode = await promptForConfigurationSelection(info.configurations);
+  const configurations = info?.configurations;
+  if (configurations && configurations.length > 1) {
+    newMode = await promptForConfigurationSelection(configurations);
   } else {
     logger.info(`Automatically selected ${chalk.bold(mode)} configuration.`);
   }

--- a/packages/cli-platform-ios/src/types.ts
+++ b/packages/cli-platform-ios/src/types.ts
@@ -10,9 +10,9 @@ export interface Device {
   lastBootedAt?: string;
 }
 
-export interface IosProjectInfo {
-  configurations: string[];
+export interface IosInfo {
   name: string;
-  schemes: string[];
-  targets: string[];
+  schemes?: string[];
+  configurations?: string[];
+  targets?: string[];
 }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2115
Regression introduced in https://github.com/react-native-community/cli/pull/2078

Reverts this code that was used in 0.72:
https://github.com/react-native-community/cli/blob/9d486c833d5af7f2e6fbf7bec046e54283ba140f/packages/cli-platform-ios/src/commands/runIOS/index.ts#L87-L92


Test Plan:
----------

```
git clone https://github.com/microsoft/react-native-test-app.git
cd react-native-test-app
npm run set-react-version 0.73 -- --core-only
yarn
cd example
pod install --project-directory=ios

# Link CLI locally following CONTRIBUTING.md
# Because of an issue with finding CocoaPods, you may have to remove line 51
# packages/cli-platform-ios/src/commands/runIOS/index.ts

yarn ios
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
