### PR TITLE
fix: install pods on ios-commands with New Arch

### DIFF
--- a/packages/cli-doctor/src/commands/info.ts
+++ b/packages/cli-doctor/src/commands/info.ts
@@ -8,6 +8,7 @@
 import getEnvironmentInfo from '../tools/envinfo';
 import {logger, version} from '@react-native-community/cli-tools';
 import {Config} from '@react-native-community/cli-types';
+import {getArchitecture} from '@react-native-community/cli-platform-ios';
 import {readFile} from 'fs-extra';
 import path from 'path';
 import {stringify} from 'yaml';
@@ -52,16 +53,11 @@ const info = async function getInfo(_argv: Array<string>, ctx: Config) {
       }
 
       try {
-        const project = await readFile(
-          path.join(
-            ctx.project.ios.sourceDir,
-            '/Pods/Pods.xcodeproj/project.pbxproj',
-          ),
+        const isNewArchitecture = await getArchitecture(
+          ctx.project.ios.sourceDir,
         );
 
-        platforms.iOS.newArchEnabled = project.includes(
-          '-DRCT_NEW_ARCH_ENABLED=1',
-        );
+        platforms.iOS.newArchEnabled = isNewArchitecture;
       } catch {
         platforms.iOS.newArchEnabled = notFound;
       }

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -12,12 +12,20 @@ import {BuildFlags, buildOptions} from './buildOptions';
 import {getConfiguration} from './getConfiguration';
 import {getXcodeProjectAndDir} from './getXcodeProjectAndDir';
 import resolvePods from '../../tools/pods';
+import getArchitecture from '../../tools/getArchitecture';
 
 async function buildIOS(_: Array<string>, ctx: Config, args: BuildFlags) {
   const {xcodeProject, sourceDir} = getXcodeProjectAndDir(ctx.project.ios);
 
+  const isAppRunningNewArchitecture = ctx.project.ios?.sourceDir
+    ? await getArchitecture(ctx.project.ios?.sourceDir)
+    : undefined;
+
   // check if pods need to be installed
-  await resolvePods(ctx.root, ctx.dependencies, {forceInstall: args.forcePods});
+  await resolvePods(ctx.root, ctx.dependencies, {
+    forceInstall: args.forcePods,
+    newArchEnabled: isAppRunningNewArchitecture,
+  });
 
   process.chdir(sourceDir);
 

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -31,6 +31,7 @@ import {promptForDeviceSelection} from '../../tools/prompts';
 import getSimulators from '../../tools/getSimulators';
 import {getXcodeProjectAndDir} from '../buildIOS/getXcodeProjectAndDir';
 import resolvePods from '../../tools/pods';
+import getArchitecture from '../../tools/getArchitecture';
 
 export interface FlagsT extends BuildFlags {
   simulator?: string;
@@ -48,8 +49,15 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
 
   let {packager, port} = args;
 
+  const isAppRunningNewArchitecture = ctx.project.ios?.sourceDir
+    ? await getArchitecture(ctx.project.ios?.sourceDir)
+    : undefined;
+
   // check if pods need to be installed
-  await resolvePods(ctx.root, ctx.dependencies, {forceInstall: args.forcePods});
+  await resolvePods(ctx.root, ctx.dependencies, {
+    forceInstall: args.forcePods,
+    newArchEnabled: isAppRunningNewArchitecture,
+  });
 
   const packagerStatus = await isPackagerRunning(port);
 

--- a/packages/cli-platform-ios/src/index.ts
+++ b/packages/cli-platform-ios/src/index.ts
@@ -4,4 +4,5 @@
 
 export {default as commands} from './commands';
 export {projectConfig, dependencyConfig, findPodfilePaths} from './config';
+export {default as getArchitecture} from './tools/getArchitecture';
 export {default as installPods} from './tools/installPods';

--- a/packages/cli-platform-ios/src/tools/getArchitecture.ts
+++ b/packages/cli-platform-ios/src/tools/getArchitecture.ts
@@ -1,0 +1,14 @@
+import {readFile} from 'fs-extra';
+import path from 'path';
+
+export default async function getArchitecture(iosSourceDir: string) {
+  try {
+    const project = await readFile(
+      path.join(iosSourceDir, '/Pods/Pods.xcodeproj/project.pbxproj'),
+    );
+
+    return project.includes('-DRCT_NEW_ARCH_ENABLED=1');
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli-platform-ios/src/tools/installPods.ts
+++ b/packages/cli-platform-ios/src/tools/installPods.ts
@@ -14,6 +14,7 @@ import runBundleInstall from './runBundleInstall';
 interface PodInstallOptions {
   skipBundleInstall?: boolean;
   newArchEnabled?: boolean;
+  iosFolderPath?: string;
 }
 
 interface RunPodInstallOptions {
@@ -121,18 +122,14 @@ async function installCocoaPods(loader: Ora) {
   }
 }
 
-async function installPods(
-  loader?: Ora,
-  iosFolderPath?: string,
-  options?: PodInstallOptions,
-) {
+async function installPods(loader?: Ora, options?: PodInstallOptions) {
   loader = loader || new NoopLoader();
   try {
-    if (!iosFolderPath && !fs.existsSync('ios')) {
+    if (!options?.iosFolderPath && !fs.existsSync('ios')) {
       return;
     }
 
-    process.chdir(iosFolderPath ?? 'ios');
+    process.chdir(options?.iosFolderPath ?? 'ios');
 
     const hasPods = fs.existsSync('Podfile');
 

--- a/packages/cli-platform-ios/src/tools/installPods.ts
+++ b/packages/cli-platform-ios/src/tools/installPods.ts
@@ -25,9 +25,9 @@ async function runPodInstall(loader: Ora, options?: RunPodInstallOptions) {
   const shouldHandleRepoUpdate = options?.shouldHandleRepoUpdate || true;
   try {
     loader.start(
-      `Installing CocoaPods dependencies ${chalk.dim(
-        '(this may take a few minutes)',
-      )}`,
+      `Installing CocoaPods dependencies ${chalk.bold(
+        options?.newArchEnabled ? 'with New Architecture' : '',
+      )} ${chalk.dim('(this may take a few minutes)')}`,
     );
 
     await execa('bundle', ['exec', 'pod', 'install'], {

--- a/packages/cli-platform-ios/src/tools/installPods.ts
+++ b/packages/cli-platform-ios/src/tools/installPods.ts
@@ -13,12 +13,16 @@ import runBundleInstall from './runBundleInstall';
 
 interface PodInstallOptions {
   skipBundleInstall?: boolean;
+  newArchEnabled?: boolean;
 }
 
-async function runPodInstall(
-  loader: Ora,
-  shouldHandleRepoUpdate: boolean = true,
-) {
+interface RunPodInstallOptions {
+  shouldHandleRepoUpdate?: boolean;
+  newArchEnabled?: boolean;
+}
+
+async function runPodInstall(loader: Ora, options?: RunPodInstallOptions) {
+  const shouldHandleRepoUpdate = options?.shouldHandleRepoUpdate || true;
   try {
     loader.start(
       `Installing CocoaPods dependencies ${chalk.dim(
@@ -26,7 +30,11 @@ async function runPodInstall(
       )}`,
     );
 
-    await execa('bundle', ['exec', 'pod', 'install']);
+    await execa('bundle', ['exec', 'pod', 'install'], {
+      env: {
+        RCT_NEW_ARCH_ENABLED: options?.newArchEnabled ? '1' : '0',
+      },
+    });
   } catch (error) {
     // "pod" command outputs errors to stdout (at least some of them)
     const stderr = (error as any).stderr || (error as any).stdout;
@@ -40,7 +48,10 @@ async function runPodInstall(
      */
     if (stderr.includes('pod repo update') && shouldHandleRepoUpdate) {
       await runPodUpdate(loader);
-      await runPodInstall(loader, false);
+      await runPodInstall(loader, {
+        shouldHandleRepoUpdate: false,
+        newArchEnabled: options?.newArchEnabled,
+      });
     } else {
       loader.fail();
       logger.error(stderr);
@@ -143,7 +154,7 @@ async function installPods(
       await installCocoaPods(loader);
     }
 
-    await runPodInstall(loader);
+    await runPodInstall(loader, {newArchEnabled: options?.newArchEnabled});
   } finally {
     process.chdir('..');
   }

--- a/packages/cli-platform-ios/src/tools/pods.ts
+++ b/packages/cli-platform-ios/src/tools/pods.ts
@@ -16,6 +16,7 @@ import {
 
 interface ResolvePodsOptions {
   forceInstall?: boolean;
+  newArchEnabled?: boolean;
 }
 
 interface NativeDependencies {
@@ -114,11 +115,25 @@ export default async function resolvePods(
     !compareMd5Hashes(currentDependenciesHash, cachedDependenciesHash) ||
     !arePodsInstalled
   ) {
-    await install(
-      packageJson,
-      cachedDependenciesHash,
-      currentDependenciesHash,
-      iosFolderPath,
-    );
+    const loader = getLoader('Installing CocoaPods...');
+    try {
+      await installPods(loader, {
+        skipBundleInstall: !!cachedDependenciesHash,
+        newArchEnabled: options?.newArchEnabled,
+      });
+      cacheManager.set(
+        packageJson.name,
+        'dependencies',
+        currentDependenciesHash,
+      );
+      loader.succeed();
+    } catch {
+      loader.fail();
+      throw new CLIError(
+        `Something when wrong while installing CocoaPods. Please run ${chalk.bold(
+          'pod install',
+        )} manually`,
+      );
+    }
   }
 }

--- a/packages/cli-platform-ios/src/tools/pods.ts
+++ b/packages/cli-platform-ios/src/tools/pods.ts
@@ -66,8 +66,9 @@ async function install(
 ) {
   const loader = getLoader('Installing CocoaPods...');
   try {
-    await installPods(loader, iosFolderPath, {
+    await installPods(loader, {
       skipBundleInstall: !!cachedDependenciesHash,
+      iosFolderPath,
     });
     cacheManager.set(packageJson.name, 'dependencies', currentDependenciesHash);
     loader.succeed();
@@ -120,6 +121,7 @@ export default async function resolvePods(
       await installPods(loader, {
         skipBundleInstall: !!cachedDependenciesHash,
         newArchEnabled: options?.newArchEnabled,
+        iosFolderPath,
       });
       cacheManager.set(
         packageJson.name,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Coming from #2091. Currently, when installed pods with New Architecture manually, added new package and used `run-ios`, it installed pods with old Architecture again. This change checks if the New Architecture is enabled and installs it with/without a flag.
<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
1. Init new project and install pods during the init
2. Add a library containing native code e.g. `react-native-gesture-handler`
3. Run `run-ios` and verify it installed pods and ran the app
4. Go to `ios` folder and install pods with New Arch manually, `RCT_NEW_ARCH_ENABLED=1 pod install`
5. Add another library, e.g. `react-native-reanimated`
6. Run `run-ios` and verify pods are being installed with a `with New Architecture` message
7. When app is running, verify `fabric: true` is visible in Metro console
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
