### PR TITLE
Update remote debugging deprecation notice

### DIFF
--- a/packages/cli-debugger-ui/src/ui/index.html
+++ b/packages/cli-debugger-ui/src/ui/index.html
@@ -18,13 +18,23 @@
         <p>
           Remote JavaScript debugging (this workflow) is
           <strong>deprecated</strong> in React Native 0.73 and will be removed
-          in React Native 0.74.
+          in a future release.
         </p>
         <p>
           Please use the
-          <strong>Open Debugger</strong> workflow to debug apps using Hermes
-          directly. This can be accessed from the Dev Menu or by pressing
-          <kbd class="shortcut">j</kbd> in the CLI.
+          <a
+            href="https://reactnative.dev/docs/next/debugging#opening-the-debugger"
+            ><strong>Open Debugger</strong></a
+          >
+          workflow to debug apps using Hermes directly. This can be accessed
+          from the Dev Menu, or by pressing <kbd class="shortcut">j</kbd> in the
+          CLI (when run with <code>--experimental-debugger</code>).
+        </p>
+        <p>
+          If your app is using JSC, please use
+          <a href="https://reactnative.dev/docs/next/other-debugging-methods"
+            >direct debugging via Safari</a
+          >.
         </p>
         <p>
           Learn more about debugging in React Native in the
@@ -32,7 +42,8 @@
             ><a href="https://reactnative.dev/docs/debugging"
               >refreshed docs</a
             ></strong
-          > 📖.
+          >
+          📖.
         </p>
       </div>
       <label for="dark">


### PR DESCRIPTION
## Summary

Follows https://github.com/react-native-community/cli/pull/2081.

Tweak details related to 0.73 debugger launch:
- Maintains "Open Debugger workflow" guidance: referring to Flipper or the experimental new debugger.
- Qualifies "pressing `j` in the CLI" with the `--experimental-debugger` flag.
- Adds JSC direct debugging link.

## Test Plan

| Before | After |
|--------|--------|
| <img width="821" alt="image" src="https://github.com/react-native-community/cli/assets/2547783/6c06667d-14ca-4dd8-b484-810616e4bdc8"> | <img width="820" alt="image" src="https://github.com/react-native-community/cli/assets/2547783/5232c888-e49c-42bf-9372-3e95ea99122e"> | 
