### PR TITLE
fix: do not ask for port change when `--no-packager` provided 

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -56,25 +56,25 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
 
   let {packager, port} = args;
 
-  const packagerStatus = await isPackagerRunning(port);
+  if (packager) {
+    const packagerStatus = await isPackagerRunning(port);
 
-  if (
-    typeof packagerStatus === 'object' &&
-    packagerStatus.status === 'running'
-  ) {
-    if (packagerStatus.root === config.root) {
-      packager = false;
-      logAlreadyRunningBundler(port);
-    } else {
+    if (
+      typeof packagerStatus === 'object' &&
+      packagerStatus.status === 'running'
+    ) {
+      if (packagerStatus.root === config.root) {
+        packager = false;
+        logAlreadyRunningBundler(port);
+      } else {
+        const result = await handlePortUnavailable(port, config.root, packager);
+        [port, packager] = [result.port, result.packager];
+      }
+    } else if (packagerStatus === 'unrecognized') {
       const result = await handlePortUnavailable(port, config.root, packager);
       [port, packager] = [result.port, result.packager];
     }
-  } else if (packagerStatus === 'unrecognized') {
-    const result = await handlePortUnavailable(port, config.root, packager);
-    [port, packager] = [result.port, result.packager];
-  }
 
-  if (packager) {
     await startServerInNewWindow(
       port,
       config.root,

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -51,25 +51,25 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
   // check if pods need to be installed
   await resolvePods(ctx.root, ctx.dependencies, {forceInstall: args.forcePods});
 
-  const packagerStatus = await isPackagerRunning(port);
+  if (packager) {
+    const packagerStatus = await isPackagerRunning(port);
 
-  if (
-    typeof packagerStatus === 'object' &&
-    packagerStatus.status === 'running'
-  ) {
-    if (packagerStatus.root === ctx.root) {
-      packager = false;
-      logAlreadyRunningBundler(port);
-    } else {
+    if (
+      typeof packagerStatus === 'object' &&
+      packagerStatus.status === 'running'
+    ) {
+      if (packagerStatus.root === ctx.root) {
+        packager = false;
+        logAlreadyRunningBundler(port);
+      } else {
+        const result = await handlePortUnavailable(port, ctx.root, packager);
+        [port, packager] = [result.port, result.packager];
+      }
+    } else if (packagerStatus === 'unrecognized') {
       const result = await handlePortUnavailable(port, ctx.root, packager);
       [port, packager] = [result.port, result.packager];
     }
-  } else if (packagerStatus === 'unrecognized') {
-    const result = await handlePortUnavailable(port, ctx.root, packager);
-    [port, packager] = [result.port, result.packager];
-  }
 
-  if (packager) {
     await startServerInNewWindow(
       port,
       ctx.root,

--- a/packages/cli-tools/src/findDevServerPort.ts
+++ b/packages/cli-tools/src/findDevServerPort.ts
@@ -3,14 +3,16 @@ import isPackagerRunning from './isPackagerRunning';
 import {logAlreadyRunningBundler} from './port';
 
 const findDevServerPort = async (
-  port: number,
+  initialPort: number,
   root: string,
 ): Promise<{
   port: number;
   startPackager: boolean;
 }> => {
-  const packagerStatus = await isPackagerRunning(port);
+  let port = initialPort;
   let startPackager = false;
+
+  const packagerStatus = await isPackagerRunning(port);
 
   if (
     typeof packagerStatus === 'object' &&

--- a/packages/cli-tools/src/findDevServerPort.ts
+++ b/packages/cli-tools/src/findDevServerPort.ts
@@ -1,0 +1,37 @@
+import handlePortUnavailable from './handlePortUnavailable';
+import isPackagerRunning from './isPackagerRunning';
+import {logAlreadyRunningBundler} from './port';
+
+const findDevServerPort = async (
+  port: number,
+  root: string,
+): Promise<{
+  port: number;
+  startPackager: boolean;
+}> => {
+  const packagerStatus = await isPackagerRunning(port);
+  let startPackager = false;
+
+  if (
+    typeof packagerStatus === 'object' &&
+    packagerStatus.status === 'running'
+  ) {
+    if (packagerStatus.root === root) {
+      startPackager = false;
+      logAlreadyRunningBundler(port);
+    } else {
+      const result = await handlePortUnavailable(port, root);
+      [port, startPackager] = [result.port, result.packager];
+    }
+  } else if (packagerStatus === 'unrecognized') {
+    const result = await handlePortUnavailable(port, root);
+    [port, startPackager] = [result.port, result.packager];
+  }
+
+  return {
+    port,
+    startPackager,
+  };
+};
+
+export default findDevServerPort;

--- a/packages/cli-tools/src/handlePortUnavailable.ts
+++ b/packages/cli-tools/src/handlePortUnavailable.ts
@@ -8,13 +8,12 @@ import {
 const handlePortUnavailable = async (
   initialPort: number,
   projectRoot: string,
-  initialPackager?: boolean,
 ): Promise<{
   port: number;
   packager: boolean;
 }> => {
   const {nextPort, start} = await getNextPort(initialPort, projectRoot);
-  let packager = initialPackager === true;
+  let packager = true;
   let port = initialPort;
 
   if (!start) {

--- a/packages/cli-tools/src/index.ts
+++ b/packages/cli-tools/src/index.ts
@@ -13,7 +13,7 @@ export {default as printRunDoctorTip} from './printRunDoctorTip';
 export * from './prompt';
 export * as link from './doclink';
 export {default as startServerInNewWindow} from './startServerInNewWindow';
-export {default as handlePortUnavailable} from './handlePortUnavailable';
+export {default as findDevServerPort} from './findDevServerPort';
 export * from './port';
 export {default as cacheManager} from './cacheManager';
 export {default as runSudo} from './runSudo';


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Hides prompt when port is busy when provided `--no-packager` flag.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Start packager in other app on 8081 port
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --no-packager
```
Shouldn't prompt for port change.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
