### PR TITLE
fix: fallback first to `yarn` when `bun` not available

### DIFF
--- a/packages/cli/src/tools/packageManager.ts
+++ b/packages/cli/src/tools/packageManager.ts
@@ -49,8 +49,10 @@ function configurePackageManager(
   if (options.packageManager === 'bun') {
     if (bunAvailable) {
       pm = 'bun';
+    } else if (yarnAvailable) {
+      pm = 'yarn';
     } else {
-      pm = yarnAvailable ? 'yarn' : 'npm';
+      pm = 'npm';
     }
   }
 

--- a/packages/cli/src/tools/packageManager.ts
+++ b/packages/cli/src/tools/packageManager.ts
@@ -41,9 +41,21 @@ function configurePackageManager(
   action: 'init' | 'install' | 'installDev' | 'installAll' | 'uninstall',
   options: Options,
 ) {
-  let pm: PackageManager = shouldUseYarn(options) ? 'yarn' : 'npm';
+  let yarnAvailable = shouldUseYarn(options);
+  let bunAvailable = shouldUseBun(options);
+
+  let pm: PackageManager = 'npm';
+
   if (options.packageManager === 'bun') {
-    pm = shouldUseBun(options) ? 'bun' : 'npm';
+    if (bunAvailable) {
+      pm = 'bun';
+    } else {
+      pm = yarnAvailable ? 'yarn' : 'npm';
+    }
+  }
+
+  if (options.packageManager === 'yarn' && yarnAvailable) {
+    pm = 'yarn';
   }
 
   const [executable, ...flags] = packageManagers[pm][action];


### PR DESCRIPTION

Summary:
---------

When bun is not available, check if yarn is available in fist place. 

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
