### PR TITLE
feat: use Yarn v3 with `nodeLinker: node-modules` for new projects

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -22,6 +22,8 @@ function createCustomTemplateFiles() {
 
 const customTemplateCopiedFiles = [
   '.git',
+  '.yarn',
+  '.yarnrc.yml',
   'dir',
   'file',
   'node_modules',

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -157,9 +157,10 @@ test('init uses npm as the package manager with --npm', () => {
 
   const initDirPath = path.join(DIR, PROJECT_NAME);
 
-  // Remove yarn.lock and node_modules
+  // Remove yarn specific files and node_modules
   const filteredFiles = customTemplateCopiedFiles.filter(
-    (file) => !['yarn.lock', 'node_modules'].includes(file),
+    (file) =>
+      !['yarn.lock', 'node_modules', '.yarnrc.yml', '.yarn'].includes(file),
   );
 
   // Add package-lock.json

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -121,20 +121,14 @@ function getExecaOptions(options: SpawnOptions) {
 
   const cwd = isRelative ? path.resolve(__dirname, options.cwd) : options.cwd;
 
-  let env = Object.assign({}, process.env, {FORCE_COLOR: '0'});
+  let env = Object.assign({}, process.env, {FORCE_COLOR: '0'}, options.env);
 
   if (options.nodeOptions) {
     env.NODE_OPTIONS = options.nodeOptions;
   }
+
   if (options.nodePath) {
     env.NODE_PATH = options.nodePath;
-  }
-
-  if (options.env) {
-    env = {
-      ...env,
-      ...options.env,
-    };
   }
 
   return {

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -28,6 +28,9 @@ export function runCLI(
   return spawnScript(process.execPath, [CLI_PATH, ...(args || [])], {
     ...options,
     cwd: dir,
+    env: {
+      YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+    },
   });
 }
 
@@ -92,6 +95,7 @@ export const getTempDirectory = (name: string) =>
 
 type SpawnOptions = RunOptions & {
   cwd: string;
+  env?: {[key: string]: string | undefined};
 };
 
 type SpawnFunction<T> = (
@@ -117,13 +121,20 @@ function getExecaOptions(options: SpawnOptions) {
 
   const cwd = isRelative ? path.resolve(__dirname, options.cwd) : options.cwd;
 
-  const env = Object.assign({}, process.env, {FORCE_COLOR: '0'});
+  let env = Object.assign({}, process.env, {FORCE_COLOR: '0'});
 
   if (options.nodeOptions) {
     env.NODE_OPTIONS = options.nodeOptions;
   }
   if (options.nodePath) {
     env.NODE_PATH = options.nodePath;
+  }
+
+  if (options.env) {
+    env = {
+      ...env,
+      ...options.env,
+    };
   }
 
   return {

--- a/packages/cli/src/commands/init/git.ts
+++ b/packages/cli/src/commands/init/git.ts
@@ -3,26 +3,31 @@ import execa from 'execa';
 import fs from 'fs';
 import path from 'path';
 
-const createGitRepository = async (folder: string) => {
-  const loader = getLoader();
-
+export const checkGitInstallation = async (): Promise<boolean> => {
   try {
     await execa('git', ['--version'], {stdio: 'ignore'});
+    return true;
   } catch {
-    loader.fail('Unable to initialize Git repo. `git` not in $PATH.');
-    return;
+    return false;
   }
+};
 
+export const checkIfFolderIsGitRepo = async (
+  folder: string,
+): Promise<boolean> => {
   try {
     await execa('git', ['rev-parse', '--is-inside-work-tree'], {
       stdio: 'ignore',
       cwd: folder,
     });
-    loader.succeed(
-      'New project is already inside of a Git repo, skipping git init.',
-    );
-    return;
-  } catch {}
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const createGitRepository = async (folder: string) => {
+  const loader = getLoader();
 
   loader.start('Initializing Git repository');
 
@@ -63,5 +68,3 @@ const createGitRepository = async (folder: string) => {
     );
   }
 };
-
-export default createGitRepository;

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -66,6 +66,7 @@ interface TemplateReturnType {
   didInstallPods?: boolean;
 }
 
+// Here we are defining explicit version of Yarn to be used in the new project because in some cases providing `3.x` don't work.
 const YARN_VERSION = '3.6.4';
 
 const bumpYarnVersion = async (silent: boolean, root: string) => {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -77,7 +77,8 @@ const YARN_VERSION = '3.6.4';
 const bumpYarnVersion = async (silent: boolean, root: string) => {
   try {
     let yarnVersion = semver.parse(getYarnVersionIfAvailable());
-    if (yarnVersion && semver.major(yarnVersion) === 1) {
+
+    if (yarnVersion) {
       await executeCommand('yarn', ['set', 'version', YARN_VERSION], {
         root,
         silent,
@@ -406,7 +407,7 @@ export default (async function initialize(
   }
 
   if (doesDirectoryExist(projectFolder)) {
-    throw new DirectoryAlreadyExistsError(projectFolder);
+    throw new DirectoryAlreadyExistsError(directoryName);
   } else {
     fs.mkdirSync(projectFolder, {recursive: true});
   }

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -29,13 +29,24 @@ export async function installTemplatePackage(
     root,
   });
 
-  // React Native doesn't support PnP, so we need to set nodeLinker to node-modules. Read more here: https://github.com/react-native-community/cli/issues/27#issuecomment-1772626767
-
   if (packageManager === 'yarn' && getYarnVersionIfAvailable() !== null) {
-    executeCommand('yarn', ['config', 'set', 'nodeLinker', 'node-modules'], {
+    const options = {
       root,
       silent: true,
-    });
+    };
+
+    // React Native doesn't support PnP, so we need to set nodeLinker to node-modules. Read more here: https://github.com/react-native-community/cli/issues/27#issuecomment-1772626767
+    executeCommand(
+      'yarn',
+      ['config', 'set', 'nodeLinker', 'node-modules'],
+      options,
+    );
+
+    executeCommand(
+      'yarn',
+      ['config', 'set', 'nmHoistingLimits', 'workspaces'],
+      options,
+    );
   }
 
   return PackageManager.install([templateName], {

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -7,7 +7,7 @@ import replacePathSepForRegex from '../../tools/replacePathSepForRegex';
 import fs from 'fs';
 import chalk from 'chalk';
 import {getYarnVersionIfAvailable} from '../../tools/yarn';
-import {executeCommand} from '../../tools/packageManager';
+import {executeCommand} from '../../tools/executeCommand';
 
 export type TemplateConfig = {
   placeholderName: string;

--- a/packages/cli/src/tools/executeCommand.ts
+++ b/packages/cli/src/tools/executeCommand.ts
@@ -1,0 +1,16 @@
+import {logger} from '@react-native-community/cli-tools';
+import execa from 'execa';
+
+export function executeCommand(
+  command: string,
+  args: Array<string>,
+  options: {
+    root: string;
+    silent?: boolean;
+  },
+) {
+  return execa(command, args, {
+    stdio: options.silent && !logger.isVerbose() ? 'pipe' : 'inherit',
+    cwd: options.root,
+  });
+}

--- a/packages/cli/src/tools/packageManager.ts
+++ b/packages/cli/src/tools/packageManager.ts
@@ -1,8 +1,7 @@
-import execa from 'execa';
-import {logger} from '@react-native-community/cli-tools';
 import {getYarnVersionIfAvailable, isProjectUsingYarn} from './yarn';
 import {getBunVersionIfAvailable, isProjectUsingBun} from './bun';
 import {getNpmVersionIfAvailable, isProjectUsingNpm} from './npm';
+import {executeCommand} from './executeCommand';
 
 export type PackageManager = keyof typeof packageManagers;
 
@@ -63,20 +62,6 @@ function configurePackageManager(
   const [executable, ...flags] = packageManagers[pm][action];
   const args = [executable, ...flags, ...packageNames];
   return executeCommand(pm, args, options);
-}
-
-export function executeCommand(
-  command: string,
-  args: Array<string>,
-  options: {
-    root: string;
-    silent?: boolean;
-  },
-) {
-  return execa(command, args, {
-    stdio: options.silent && !logger.isVerbose() ? 'pipe' : 'inherit',
-    cwd: options.root,
-  });
 }
 
 export function shouldUseYarn(options: Options) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Closes https://github.com/react-native-community/cli/pull/1931 

When creating new project we'll try to bump Yarn version to v3. We'll only do this if:
- the project is initialised in fresh environment (not in existing Git repo),
- and the Yarn version in the location is Yarn Classic

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
3. Should use Yarn v3 🎉



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
