### PR TITLE
fix: force users to use `nodeLinker: node-modules` when installing template packages

### DIFF
--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -6,6 +6,8 @@ import copyFiles from '../../tools/copyFiles';
 import replacePathSepForRegex from '../../tools/replacePathSepForRegex';
 import fs from 'fs';
 import chalk from 'chalk';
+import {getYarnVersionIfAvailable} from '../../tools/yarn';
+import {executeCommand} from '../../tools/packageManager';
 
 export type TemplateConfig = {
   placeholderName: string;
@@ -26,6 +28,15 @@ export async function installTemplatePackage(
     silent: true,
     root,
   });
+
+  // React Native doesn't support PnP, so we need to set nodeLinker to node-modules. Read more here: https://github.com/react-native-community/cli/issues/27#issuecomment-1772626767
+
+  if (packageManager === 'yarn' && getYarnVersionIfAvailable() !== null) {
+    executeCommand('yarn', ['config', 'set', 'nodeLinker', 'node-modules'], {
+      root,
+      silent: true,
+    });
+  }
 
   return PackageManager.install([templateName], {
     packageManager,

--- a/packages/cli/src/tools/packageManager.ts
+++ b/packages/cli/src/tools/packageManager.ts
@@ -65,10 +65,13 @@ function configurePackageManager(
   return executeCommand(pm, args, options);
 }
 
-function executeCommand(
+export function executeCommand(
   command: string,
   args: Array<string>,
-  options: Options,
+  options: {
+    root: string;
+    silent?: boolean;
+  },
 ) {
   return execa(command, args, {
     stdio: options.silent && !logger.isVerbose() ? 'pipe' : 'inherit',


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/1637

We need to be sure that `node_modules` directory exists, because then we're getting template from it. I tested and that command works in v1, v2, v3. 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
