### PR TITLE
feat: handle better canceling prompts

### DIFF
--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -10,8 +10,7 @@
   "dependencies": {
     "@react-native-community/cli-tools": "12.0.0-alpha.18",
     "chalk": "^4.1.2",
-    "execa": "^5.0.0",
-    "prompts": "^2.4.2"
+    "execa": "^5.0.0"
   },
   "files": [
     "build",

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -1,11 +1,10 @@
-import {getLoader} from '@react-native-community/cli-tools';
+import {getLoader, prompt} from '@react-native-community/cli-tools';
 import type {Config as CLIConfig} from '@react-native-community/cli-types';
 import chalk from 'chalk';
 import execa from 'execa';
 import {existsSync as fileExists, rmdir} from 'fs';
 import os from 'os';
 import path from 'path';
-import prompts from 'prompts';
 import {promisify} from 'util';
 
 type Args = {
@@ -53,7 +52,7 @@ function findPath(startPath: string, files: string[]): string | undefined {
 async function promptForCaches(
   groups: CleanGroups,
 ): Promise<string[] | undefined> {
-  const {caches} = await prompts({
+  const {caches} = await prompt({
     type: 'multiselect',
     name: 'caches',
     message: 'Select all caches to clean',

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -21,7 +21,6 @@
     "ip": "^1.1.5",
     "node-stream-zip": "^1.9.1",
     "ora": "^5.4.1",
-    "prompts": "^2.4.2",
     "semver": "^7.5.2",
     "strip-ansi": "^5.2.0",
     "wcwidth": "^1.0.1",

--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/listAndroidTasks.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/listAndroidTasks.test.ts
@@ -5,7 +5,7 @@ import {
   parseTasksFromGradleFile,
   promptForTaskSelection,
 } from '../listAndroidTasks';
-
+import tools from '@react-native-community/cli-tools';
 const gradleTaskOutput = `
 > Task :tasks
 
@@ -111,9 +111,11 @@ describe('promptForTaskSelection', () => {
       }),
     );
 
+    const promptSpy = jest.spyOn(tools, 'prompt');
+
     promptForTaskSelection('install', 'sourceDir');
 
-    expect(prompts).toHaveBeenCalledWith({
+    expect(promptSpy).toHaveBeenCalledWith({
       choices: tasksList.map((t) => ({
         title: `${chalk.bold(t.task)} - ${t.description}`,
         value: t.task,

--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidDevices.ts
@@ -4,9 +4,8 @@ import getAdbPath from './getAdbPath';
 import {getEmulators} from './tryLaunchEmulator';
 import {toPascalCase} from './toPascalCase';
 import os from 'os';
-import prompts from 'prompts';
 import chalk from 'chalk';
-import {CLIError} from '@react-native-community/cli-tools';
+import {CLIError, prompt} from '@react-native-community/cli-tools';
 
 type DeviceData = {
   deviceId: string | undefined;
@@ -56,7 +55,7 @@ async function promptForDeviceSelection(
       'No devices and/or emulators connected. Please create emulator with Android Studio or connect Android device.',
     );
   }
-  const {device} = await prompts({
+  const {device} = await prompt({
     type: 'select',
     name: 'device',
     message: 'Select the device / emulator you want to use',

--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidTasks.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidTasks.ts
@@ -1,7 +1,6 @@
-import {CLIError} from '@react-native-community/cli-tools';
+import {CLIError, prompt} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
 import execa from 'execa';
-import prompts from 'prompts';
 
 type GradleTask = {
   task: string;
@@ -48,7 +47,7 @@ export const promptForTaskSelection = async (
   if (!tasks.length) {
     throw new CLIError(`No actionable ${taskType} tasks were found...`);
   }
-  const {task}: {task: string} = await prompts({
+  const {task}: {task: string} = await prompt({
     type: 'select',
     name: 'task',
     message: `Select ${taskType} task you want to perform`,

--- a/packages/cli-platform-android/src/commands/runAndroid/listAndroidUsers.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/listAndroidUsers.ts
@@ -1,6 +1,5 @@
-import {logger} from '@react-native-community/cli-tools';
 import execa from 'execa';
-import prompts from 'prompts';
+import {logger, prompt} from '@react-native-community/cli-tools';
 
 type User = {
   id: string;
@@ -42,7 +41,7 @@ export function checkUsers(device: string, adbPath: string) {
 }
 
 export async function promptForUser(users: User[]) {
-  const {selectedUser}: {selectedUser: User} = await prompts({
+  const {selectedUser}: {selectedUser: User} = await prompt({
     type: 'select',
     name: 'selectedUser',
     message: 'Which profile would you like to launch your app into?',

--- a/packages/cli-platform-ios/src/commands/logIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/logIOS/index.ts
@@ -9,11 +9,10 @@
 import {spawnSync} from 'child_process';
 import os from 'os';
 import path from 'path';
-import {logger} from '@react-native-community/cli-tools';
+import {logger, prompt} from '@react-native-community/cli-tools';
 import listIOSDevices from '../../tools/listIOSDevices';
 import getSimulators from '../../tools/getSimulators';
 import {Config} from '@react-native-community/cli-types';
-import prompts from 'prompts';
 
 /**
  * Starts iOS device syslog tail
@@ -49,7 +48,7 @@ async function logIOS(_argv: Array<string>, _ctx: Config, args: Args) {
   }
 
   if (args.interactive && bootedAndAvailableSimulators.length > 1) {
-    const {udid} = await prompts({
+    const {udid} = await prompt({
       type: 'select',
       name: 'udid',
       message: 'Select iOS simulators to tail logs from',

--- a/packages/cli-platform-ios/src/tools/prompts.ts
+++ b/packages/cli-platform-ios/src/tools/prompts.ts
@@ -1,11 +1,11 @@
 import chalk from 'chalk';
-import prompts from 'prompts';
 import {Device} from '../types';
+import {prompt} from '@react-native-community/cli-tools';
 
 export async function promptForSchemeSelection(
   schemes: string[],
 ): Promise<string> {
-  const {scheme} = await prompts({
+  const {scheme} = await prompt({
     name: 'scheme',
     type: 'select',
     message: 'Select the scheme you want to use',
@@ -21,7 +21,7 @@ export async function promptForSchemeSelection(
 export async function promptForConfigurationSelection(
   configurations: string[],
 ): Promise<string> {
-  const {configuration} = await prompts({
+  const {configuration} = await prompt({
     name: 'configuration',
     type: 'select',
     message: 'Select the configuration you want to use',
@@ -37,7 +37,7 @@ export async function promptForConfigurationSelection(
 export async function promptForDeviceSelection(
   availableDevices: Device[],
 ): Promise<Device | undefined> {
-  const {device} = await prompts({
+  const {device} = await prompt({
     type: 'select',
     name: 'device',
     message: 'Select the device you want to use',

--- a/packages/cli-tools/src/prompt.ts
+++ b/packages/cli-tools/src/prompt.ts
@@ -9,10 +9,10 @@ type InteractionCallback = (options: InteractionOptions) => void;
 /** Interaction observers for detecting when keystroke tracking should pause/resume. */
 const listeners: InteractionCallback[] = [];
 
-export async function prompt(
+export async function prompt<T extends string>(
   question: PromptObject,
   options: PromptOptions = {},
-) {
+): Promise<prompts.Answers<T>> {
   pauseInteractions();
   try {
     const results = await prompts(question, {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -2,7 +2,6 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import {validateProjectName} from './validate';
-import {prompt} from 'prompts';
 import chalk from 'chalk';
 import DirectoryAlreadyExistsError from './errors/DirectoryAlreadyExistsError';
 import printRunInstructions from './printRunInstructions';
@@ -12,6 +11,7 @@ import {
   getLoader,
   Loader,
   cacheManager,
+  prompt,
 } from '@react-native-community/cli-tools';
 import {installPods} from '@react-native-community/cli-platform-ios';
 import {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In this PR I moved all prompts to use internal wrapper that we have in `cli-tools` that overwrites `onCancel` method with relevant error. 

| Before | After |
|--------|--------|
| ![CleanShot 2023-10-27 at 16 45 59@2x](https://github.com/react-native-community/cli/assets/63900941/dce67187-273c-4b67-9ba1-f5e01d197a97)| ![CleanShot 2023-10-27 at 16 45 39@2x](https://github.com/react-native-community/cli/assets/63900941/3534da5c-bd5e-43a5-9b94-a1081752cb43)|


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
3. Press `ctrl + c` and you should see "Prompt cancelled." error message.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
