### PR TITLE
fix(e2e): correctly link packages

### DIFF
--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -6,13 +6,17 @@ import {
   getTempDirectory,
   cleanup,
   writeFiles,
+  addRNCPrefix,
+  getAllPackages,
 } from '../jest/helpers';
 
 const cwd = getTempDirectory('test_different_roots');
 
 beforeAll(() => {
+  const packages = getAllPackages();
+
   // Register all packages to be linked
-  for (const pkg of ['cli-platform-ios', 'cli-platform-android']) {
+  for (const pkg of packages) {
     spawnScript('yarn', ['link'], {
       cwd: path.join(__dirname, `../packages/${pkg}`),
     });
@@ -23,14 +27,11 @@ beforeAll(() => {
   writeFiles(cwd, {});
 
   // Initialise React Native project
-  runCLI(cwd, ['init', 'TestProject', '--install-pods']);
-  // Link CLI to the project
-  const pkgs = [
-    '@react-native-community/cli-platform-ios',
-    '@react-native-community/cli-platform-android',
-  ];
+  runCLI(cwd, ['init', 'TestProject']);
 
-  spawnScript('yarn', ['link', ...pkgs], {
+  // Link CLI to the project
+
+  spawnScript('yarn', ['link', ...addRNCPrefix(packages)], {
     cwd: path.join(cwd, 'TestProject'),
   });
 });

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -207,3 +207,11 @@ export function replaceProjectRootInOutput(output: string, testFolder: string) {
   const regex = new RegExp(`(:\\s").*(${slash(testFolder)})`, 'g');
   return slash(output).replace(regex, '$1<<REPLACED_ROOT>>');
 }
+
+export function getAllPackages() {
+  return fs.readdirSync(path.resolve(__dirname, '../packages'));
+}
+
+export function addRNCPrefix(packages: string[]) {
+  return packages.map((p) => `@react-native-community/${p}`);
+}

--- a/packages/cli-platform-ios/src/tools/installPods.ts
+++ b/packages/cli-platform-ios/src/tools/installPods.ts
@@ -37,6 +37,7 @@ async function runPodInstall(loader: Ora, options?: RunPodInstallOptions) {
       },
     });
   } catch (error) {
+    logger.debug(error as string);
     // "pod" command outputs errors to stdout (at least some of them)
     const stderr = (error as any).stderr || (error as any).stdout;
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In this PR I changed to link all packages before running testes. Recently there was introduced change to `init` which creates `react-native.config.js` with some flag. But in tests we were only linking `cli-platform-android` and `cli-platform-ios` so creating project was failing since it installs Pods, and during installing Pods we call `use_native_modules` which executes `config` command that was outdated. And it was giving error: 
![CleanShot 2023-11-01 at 13 01 54](https://github.com/react-native-community/cli/assets/63900941/f95b4471-8067-45c2-81c6-296fee48eae7)



Test Plan:
----------

CI Green 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
