### PR TITLE
ci: properly cache gradle

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 17
-          cache: 'gradle'
 
       - uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,11 +49,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      
       - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: 17
           cache: 'gradle'
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.0.1
 
       - uses: ruby/setup-ruby@v1
         if: runner.os == 'macOS'

--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -53,14 +53,14 @@ test('works when Gradle is run outside of the project hierarchy', async () => {
    */
   const gradleWrapper = path.join(androidProjectRoot, 'gradlew');
 
-  // Make sure that we use `-bin` distribution of Gradle
-  await spawnScript(
-    gradleWrapper,
-    ['wrapper', '--gradle-version=8.0.1', '--distribution-type', 'bin'],
-    {
-      cwd: androidProjectRoot,
-    },
-  );
+  // // Make sure that we use `-bin` distribution of Gradle
+  // await spawnScript(
+  //   gradleWrapper,
+  //   ['wrapper', '--gradle-version=8.0.1', '--distribution-type', 'bin'],
+  //   {
+  //     cwd: androidProjectRoot,
+  //   },
+  // );
 
   // Execute `gradle` with `-p` flag and `cwd` outside of project hierarchy
   const {stdout} = spawnScript(gradleWrapper, ['-p', androidProjectRoot], {

--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -40,7 +40,7 @@ afterAll(() => {
   cleanup(cwd);
 });
 
-test('works when Gradle is run outside of the project hierarchy', () => {
+test('works when Gradle is run outside of the project hierarchy', async () => {
   /**
    * Location of Android project
    */
@@ -52,6 +52,15 @@ test('works when Gradle is run outside of the project hierarchy', () => {
    * Gradle globally
    */
   const gradleWrapper = path.join(androidProjectRoot, 'gradlew');
+
+  // Make sure that we use `-bin` distribution of Gradle
+  await spawnScript(
+    gradleWrapper,
+    ['wrapper', '--gradle-version=8.0.1', '--distribution-type', 'bin'],
+    {
+      cwd: androidProjectRoot,
+    },
+  );
 
   // Execute `gradle` with `-p` flag and `cwd` outside of project hierarchy
   const {stdout} = spawnScript(gradleWrapper, ['-p', androidProjectRoot], {

--- a/__e2e__/root.test.ts
+++ b/__e2e__/root.test.ts
@@ -53,14 +53,14 @@ test('works when Gradle is run outside of the project hierarchy', async () => {
    */
   const gradleWrapper = path.join(androidProjectRoot, 'gradlew');
 
-  // // Make sure that we use `-bin` distribution of Gradle
-  // await spawnScript(
-  //   gradleWrapper,
-  //   ['wrapper', '--gradle-version=8.0.1', '--distribution-type', 'bin'],
-  //   {
-  //     cwd: androidProjectRoot,
-  //   },
-  // );
+  // Make sure that we use `-bin` distribution of Gradle
+  await spawnScript(
+    gradleWrapper,
+    ['wrapper', '--gradle-version=8.0.1', '--distribution-type', 'bin'],
+    {
+      cwd: androidProjectRoot,
+    },
+  );
 
   // Execute `gradle` with `-p` flag and `cwd` outside of project hierarchy
   const {stdout} = spawnScript(gradleWrapper, ['-p', androidProjectRoot], {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Every time we're running `root.test.ts` it downloads Gradle. In template there's specified Gradle's `-all` distribution, but with `gradle/gradle-build-action` we can't specify it :( So we need to overwrite to `-bin`.

Test Plan:
----------

CI should cache Gradle version.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
