### PR TITLE
feat(ios): sort simulators to get iOS first

### DIFF
--- a/packages/cli-platform-ios/src/tools/__tests__/findMatchingSimulator.test.ts
+++ b/packages/cli-platform-ios/src/tools/__tests__/findMatchingSimulator.test.ts
@@ -1064,4 +1064,54 @@ describe('findMatchingSimulator', () => {
       version: 'tvOS 11.2',
     });
   });
+
+  it('should sort simulator to get iOS ones first', () => {
+    expect(
+      findMatchingSimulator({
+        devices: {
+          'com.apple.CoreSimulator.SimRuntime.tvOS-11-2': [
+            {
+              state: 'Shutdown',
+              availability: '(available)',
+              name: 'Apple TV',
+              udid: '816C30EA-38EA-41AC-BFDA-96FB632D522E',
+            },
+            {
+              state: 'Shutdown',
+              availability: '(available)',
+              name: 'Apple TV 4K',
+              udid: 'BCBB7E4B-D872-4D61-BC61-7C9805551075',
+            },
+            {
+              state: 'Shutdown',
+              availability: '(available)',
+              name: 'Apple TV 4K (at 1080p)',
+              udid: '1DE12308-1C14-4F0F-991E-A3ADC41BDFFC',
+            },
+          ],
+          'com.apple.CoreSimulator.SimRuntime.iOS-16-2': [
+            {
+              lastBootedAt: '2023-05-09T11:08:32Z',
+              udid: '54B1D3DE-A943-4867-BA6A-B82BFE3A7904',
+              availability: '(available)',
+              state: 'Shutdown',
+              name: 'iPhone 14',
+            },
+            {
+              lastBootedAt: '2023-04-06T12:34:01Z',
+              udid: '816A7D47-A205-4F57-AE19-E5CB842B6304',
+              availability: '(available)',
+              state: 'Shutdown',
+              name: 'iPhone 14 Plus',
+            },
+          ],
+        },
+      }),
+    ).toEqual({
+      udid: '54B1D3DE-A943-4867-BA6A-B82BFE3A7904',
+      name: 'iPhone 14',
+      state: 'Shutdown',
+      version: 'iOS 16.2',
+    });
+  });
 });

--- a/packages/cli-platform-ios/src/tools/findMatchingSimulator.ts
+++ b/packages/cli-platform-ios/src/tools/findMatchingSimulator.ts
@@ -53,8 +53,14 @@ function findMatchingSimulator(
   let match;
   let fallbackMatch;
 
-  for (const versionDescriptor in devices) {
-    const device = devices[versionDescriptor];
+  const sortedDevices = Object.fromEntries(
+    Object.entries(devices).sort(
+      (a, b) => Number(b[0].includes('iOS')) - Number(a[0].includes('iOS')),
+    ),
+  );
+
+  for (const versionDescriptor in sortedDevices) {
+    const device = sortedDevices[versionDescriptor];
     let version = versionDescriptor;
 
     if (/^com\.apple\.CoreSimulator\.SimRuntime\./g.test(version)) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Closes https://github.com/react-native-community/cli/issues/2143

In this PR I added sorting simulators to first run iOS ones, to avoid situation like this [one](https://github.com/software-mansion/react-native-reanimated/actions/runs/6692444414/job/18181645440).

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
