### PR TITLE
fix: remove hardcoded android path

### DIFF
--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -37,18 +37,6 @@ function cleanDir(directory: string): Promise<void> {
   return rmdirAsync(directory, {maxRetries: 3, recursive: true});
 }
 
-function findPath(startPath: string, files: string[]): string | undefined {
-  // TODO: Find project files via `@react-native-community/cli`
-  for (const file of files) {
-    const filename = path.resolve(startPath, file);
-    if (fileExists(filename)) {
-      return filename;
-    }
-  }
-
-  return undefined;
-}
-
 async function promptForCaches(
   groups: CleanGroups,
 ): Promise<string[] | undefined> {
@@ -68,7 +56,7 @@ async function promptForCaches(
 
 export async function clean(
   _argv: string[],
-  _config: CLIConfig,
+  ctx: CLIConfig,
   cleanOptions: Args,
 ): Promise<void> {
   const {include, projectRoot, verifyCache} = cleanOptions;
@@ -83,12 +71,18 @@ export async function clean(
         {
           label: 'Clean Gradle cache',
           action: async () => {
-            const candidates =
+            const gradlew =
               os.platform() === 'win32'
-                ? ['android/gradlew.bat', 'gradlew.bat']
-                : ['android/gradlew', 'gradlew'];
-            const gradlew = findPath(projectRoot, candidates);
-            if (gradlew) {
+                ? path.join(
+                    ctx.project.android?.sourceDir ?? 'android',
+                    'gradlew.bat',
+                  )
+                : path.join(
+                    ctx.project.android?.sourceDir ?? 'android',
+                    'gradlew',
+                  );
+
+            if (fileExists(gradlew)) {
               const script = path.basename(gradlew);
               await execa(
                 os.platform() === 'win32' ? script : `./${script}`,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

By using `ctx.project.android?.sourceDir` `clean` command will work when Android project is under different path.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Change `android` folder name and specify in `react-native.config.js` new path.
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js clean
```

Choose `android` cache to clean, and command should be executed in correct place.
 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
