### PR TITLE
chore: replace `fs.rmdir` with `fs.rm`

### DIFF
--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -2,7 +2,7 @@ import {getLoader, prompt} from '@react-native-community/cli-tools';
 import type {Config as CLIConfig} from '@react-native-community/cli-types';
 import chalk from 'chalk';
 import execa from 'execa';
-import {existsSync as fileExists, rmdir} from 'fs';
+import {existsSync as fileExists, rm} from 'fs';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
@@ -27,14 +27,14 @@ type CleanGroups = {
 
 const DEFAULT_GROUPS = ['metro', 'watchman'];
 
-const rmdirAsync = promisify(rmdir);
+const rmAsync = promisify(rm);
 
 function cleanDir(directory: string): Promise<void> {
   if (!fileExists(directory)) {
     return Promise.resolve();
   }
 
-  return rmdirAsync(directory, {maxRetries: 3, recursive: true});
+  return rmAsync(directory, {maxRetries: 3, recursive: true});
 }
 
 function findPath(startPath: string, files: string[]): string | undefined {

--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -34,7 +34,7 @@ function cleanDir(directory: string): Promise<void> {
     return Promise.resolve();
   }
 
-  return rmAsync(directory, {maxRetries: 3, recursive: true});
+  return rmAsync(directory, {maxRetries: 3, recursive: true, force: true});
 }
 
 function findPath(startPath: string, files: string[]): string | undefined {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

According to Node docs, `fs.rmdir(path, { recursive: true })` [will be deprecated](https://nodejs.org/api/deprecations.html#dep0147-fsrmdirpath--recursive-true-) and right now `fs.rm` is a right choice.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js clean
```

Works in the same way as before.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
