### PR TITLE
Clean command does not clean metro-cache on win32

### DIFF
--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@react-native-community/cli-tools": "12.0.0",
     "chalk": "^4.1.2",
-    "execa": "^5.0.0"
+    "execa": "^5.0.0",
+    "fast-glob": "^3.3.1"
   },
   "files": [
     "build",


### PR DESCRIPTION
Summary:
---------

The fs.rm function on win32 does not expand *'s, so the code to delete the metro cache using fs.rm('<tempdir>/metro-*') does not delete anything on win32.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
