### PR TITLE
feat(ios): cache last used device 

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -149,11 +149,13 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
         } command.`,
       );
     } else {
-      cacheManager.set(
-        packageJson.name,
-        'lastUsedDeviceId',
-        selectedDevice.udid,
-      );
+      if (selectedDevice.udid !== preferredDevice) {
+        cacheManager.set(
+          packageJson.name,
+          'lastUsedDeviceId',
+          selectedDevice.udid,
+        );
+      }
     }
 
     if (selectedDevice.type === 'simulator') {

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -134,7 +134,7 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
     const packageJson = getPackageJson(ctx.root);
     const preferredDevice = cacheManager.get(
       packageJson.name,
-      'lastUsedDeviceId',
+      'lastUsedIOSDeviceId',
     );
 
     const selectedDevice = await promptForDeviceSelection(
@@ -152,7 +152,7 @@ async function runIOS(_: Array<string>, ctx: Config, args: FlagsT) {
       if (selectedDevice.udid !== preferredDevice) {
         cacheManager.set(
           packageJson.name,
-          'lastUsedDeviceId',
+          'lastUsedIOSDeviceId',
           selectedDevice.udid,
         );
       }

--- a/packages/cli-platform-ios/src/tools/prompts.ts
+++ b/packages/cli-platform-ios/src/tools/prompts.ts
@@ -35,14 +35,27 @@ export async function promptForConfigurationSelection(
 }
 
 export async function promptForDeviceSelection(
-  availableDevices: Device[],
+  devices: Device[],
+  lastUsedDeviceId?: string,
 ): Promise<Device | undefined> {
+  const sortedDevices = devices;
+  const devicesIds = sortedDevices.map(({udid}) => udid);
+
+  if (lastUsedDeviceId) {
+    const preferredDeviceIndex = devicesIds.indexOf(lastUsedDeviceId);
+
+    if (preferredDeviceIndex > -1) {
+      const [preferredDevice] = sortedDevices.splice(preferredDeviceIndex, 1);
+      sortedDevices.unshift(preferredDevice);
+    }
+  }
+
   const {device} = await prompt({
     type: 'select',
     name: 'device',
     message: 'Select the device you want to use',
-    choices: availableDevices
-      .filter((d) => d.type === 'device' || d.type === 'simulator')
+    choices: sortedDevices
+      .filter(({type}) => type === 'device' || type === 'simulator')
       .map((d) => {
         const version = d.version
           ? ` (${d.version.match(/^(\d+\.\d+)/)?.[1]})`

--- a/packages/cli-platform-ios/src/tools/prompts.ts
+++ b/packages/cli-platform-ios/src/tools/prompts.ts
@@ -38,7 +38,7 @@ export async function promptForDeviceSelection(
   devices: Device[],
   lastUsedIOSDeviceId?: string,
 ): Promise<Device | undefined> {
-  const sortedDevices = devices;
+  const sortedDevices = [...devices];
   const devicesIds = sortedDevices.map(({udid}) => udid);
 
   if (lastUsedIOSDeviceId) {

--- a/packages/cli-platform-ios/src/tools/prompts.ts
+++ b/packages/cli-platform-ios/src/tools/prompts.ts
@@ -36,13 +36,13 @@ export async function promptForConfigurationSelection(
 
 export async function promptForDeviceSelection(
   devices: Device[],
-  lastUsedDeviceId?: string,
+  lastUsedIOSDeviceId?: string,
 ): Promise<Device | undefined> {
   const sortedDevices = devices;
   const devicesIds = sortedDevices.map(({udid}) => udid);
 
-  if (lastUsedDeviceId) {
-    const preferredDeviceIndex = devicesIds.indexOf(lastUsedDeviceId);
+  if (lastUsedIOSDeviceId) {
+    const preferredDeviceIndex = devicesIds.indexOf(lastUsedIOSDeviceId);
 
     if (preferredDeviceIndex > -1) {
       const [preferredDevice] = sortedDevices.splice(preferredDeviceIndex, 1);

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -5,7 +5,12 @@ import appDirs from 'appdirsjs';
 import chalk from 'chalk';
 import logger from './logger';
 
-type CacheKey = 'eTag' | 'lastChecked' | 'latestVersion' | 'dependencies';
+type CacheKey =
+  | 'eTag'
+  | 'lastChecked'
+  | 'latestVersion'
+  | 'dependencies'
+  | 'lastUsedDeviceId';
 type Cache = {[key in CacheKey]?: string};
 
 function loadCache(name: string): Cache | undefined {

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -10,7 +10,7 @@ type CacheKey =
   | 'lastChecked'
   | 'latestVersion'
   | 'dependencies'
-  | 'lastUsedDeviceId';
+  | 'lastUsedIOSDeviceId';
 type Cache = {[key in CacheKey]?: string};
 
 function loadCache(name: string): Cache | undefined {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Developers often have a lot of simulators installed on their machines, and if they are running `--list-devices` or `--interactive` they need to go through all of them, but by adding simple caching we'll move last used device to the top of the list. 


Uploading CleanShot 2023-11-07 at 17.06.00.mp4…



Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --list-devices
```
3. Choose one devices
```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --list-devices
```
5. Chosen device from third step should be on the top of the list.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
