### PR TITLE
fix: Find build.gradle to be more flexible on some libraries folder structures

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-platform-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`android::getProjectConfig returns an object with android project configuration for flat structure 1`] = `
 Object {
   "appName": "",
-  "applicationId": "com.some.example",
+  "applicationId": "com.example",
   "dependencyConfiguration": undefined,
   "mainActivity": ".MainActivity",
   "packageName": "com.some.example",

--- a/packages/cli-platform-android/src/config/__tests__/findBuildGradle.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/findBuildGradle.test.ts
@@ -25,13 +25,13 @@ describe('findBuildGradle for apps', () => {
   });
 
   it('returns the app gradle path if file exists in the folder', () => {
-    expect(findBuildGradle('/flat/android', false)).toBe(
+    expect(findBuildGradle('/flat/android')).toBe(
       '/flat/android/app/build.gradle',
     );
   });
 
   it('returns `null` if there is no gradle in the app folder', () => {
-    expect(findBuildGradle('/empty', false)).toBeNull();
+    expect(findBuildGradle('/empty')).toBeNull();
   });
 });
 
@@ -46,12 +46,27 @@ describe('findBuildGradle for libraries', () => {
   });
 
   it('returns the app gradle path if file exists in the folder', () => {
-    expect(findBuildGradle('/flat/android', true)).toBe(
-      '/flat/android/build.gradle',
-    );
+    expect(findBuildGradle('/flat/android')).toBe('/flat/android/build.gradle');
   });
 
   it('returns `null` if there is no gradle in the app folder', () => {
-    expect(findBuildGradle('/empty', true)).toBeNull();
+    expect(findBuildGradle('/empty')).toBeNull();
+  });
+});
+
+describe('findBuildGradle for libraries with nested android folder', () => {
+  beforeAll(() => {
+    fs.__setMockFilesystem({
+      empty: {},
+      flat: {
+        android: mocks.validApp,
+      },
+    });
+  });
+
+  it('returns the app gradle path if file exists in the folder', () => {
+    expect(findBuildGradle('/flat/android')).toBe(
+      '/flat/android/app/build.gradle',
+    );
   });
 });

--- a/packages/cli-platform-android/src/config/findBuildGradle.ts
+++ b/packages/cli-platform-android/src/config/findBuildGradle.ts
@@ -1,21 +1,16 @@
 import fs from 'fs';
 import path from 'path';
 
-export function findBuildGradle(sourceDir: string, isLibrary: boolean) {
-  const buildGradlePath = path.join(
-    sourceDir,
-    isLibrary ? 'build.gradle' : 'app/build.gradle',
+export function findBuildGradle(sourceDir: string) {
+  const buildGradlePaths = [
+    'app/build.gradle',
+    'app/build.gradle.kts',
+    'build.gradle',
+    'build.gradle.kts',
+  ];
+  return (
+    buildGradlePaths
+      .map((bgp) => path.join(sourceDir, bgp))
+      .find((bgp) => fs.existsSync(bgp)) ?? null
   );
-  const buildGradleKtsPath = path.join(
-    sourceDir,
-    isLibrary ? 'build.gradle.kts' : 'app/build.gradle.kts',
-  );
-
-  if (fs.existsSync(buildGradlePath)) {
-    return buildGradlePath;
-  } else if (fs.existsSync(buildGradleKtsPath)) {
-    return buildGradleKtsPath;
-  } else {
-    return null;
-  }
 }

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -48,7 +48,7 @@ export function projectConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(path.join(sourceDir, appName));
-  const buildGradlePath = findBuildGradle(sourceDir, false);
+  const buildGradlePath = findBuildGradle(sourceDir);
 
   if (!manifestPath && !buildGradlePath) {
     return null;
@@ -130,7 +130,7 @@ export function dependencyConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);
-  const buildGradlePath = findBuildGradle(sourceDir, true);
+  const buildGradlePath = findBuildGradle(sourceDir);
 
   if (!manifestPath && !buildGradlePath) {
     return null;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Currently, functions that depend on finding the app-level build.gradle(.kt) fail in some instances as some libraries do not follow the same pattern with a single build.gradle at the top. Instead they follow the app pattern with a root-level build.gradle and an app-level build.gradle. 

A notable example: would be: https://github.com/microsoft/react-native-code-push/blob/master/android/app/build.gradle

Instead, we should use a generic detection method as the one proposed: Look for the app-level build.gradle(.kt) and only if doesn't exist, fallback to the normal pattern. 

Added bonus: no need to pass the `isLibrary` parameter
<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Create a react-native project@latest and add `react-native-code-push`. Run an android build, natively or using the react-native cli.  For example: `./android/gradlew app:buildDebug`. 
Expected: 
The app should build without errors.
Actual: 
The build will fail, with the error of unable to find namespace in either the manifest nor the (base-level) build.gradle.
Applying this PR:
The build passes as expected

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
