### PR TITLE
feat: add platform-name option to init for out of tree platforms init

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -168,3 +168,29 @@ test('init uses npm as the package manager with --npm', () => {
     expect(fs.existsSync(path.join(initDirPath, file))).toBe(true);
   });
 });
+
+test('init --platform-name should work for out of tree platform', () => {
+  createCustomTemplateFiles();
+  const outOfTreePlatformName = 'react-native-macos';
+
+  const {stdout} = runCLI(DIR, [
+    'init',
+    PROJECT_NAME,
+    '--platform-name',
+    outOfTreePlatformName,
+    '--skip-install',
+    '--verbose',
+  ]);
+
+  expect(stdout).toContain('Run instructions');
+  expect(stdout).toContain(
+    `Installing template from ${outOfTreePlatformName}@latest`,
+  );
+
+  // make sure we don't leave garbage
+  expect(fs.readdirSync(DIR)).toContain('custom');
+
+  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
+
+  expect(dirFiles.length).toBeGreaterThan(0);
+});

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -47,5 +47,10 @@ export default {
       description:
         'Inits a project with a custom package name (Android) and bundle ID (iOS), e.g. com.example.app',
     },
+    {
+      name: '--platform-name <string>',
+      description:
+        'Name of out of tree platform to be used for ex. react-native-macos. This flag is optional as it should be passed automatically by out of tree platform.',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -50,7 +50,7 @@ export default {
     {
       name: '--platform-name <string>',
       description:
-        'Name of out of tree platform to be used for ex. react-native-macos. This flag is optional as it should be passed automatically by out of tree platform.',
+        'Name of out of tree platform to be used for ex. react-native-macos. This flag is optional as it should be passed automatically by out of tree platform. It needs to match the name of the platform declared in package.json',
     },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -44,6 +44,7 @@ type Options = {
   version?: string;
   packageName?: string;
   installPods?: string | boolean;
+  platformName?: string;
 };
 
 interface TemplateOptions {
@@ -261,14 +262,17 @@ function createTemplateUri(options: Options, version: string): string {
   const isTypescriptTemplate =
     options.template === 'react-native-template-typescript';
 
+  // This allows to correctly retrieve template uri for out of tree platforms.
+  const platform = options.platformName || 'react-native';
+
   if (isTypescriptTemplate) {
     logger.warn(
       "Ignoring custom template: 'react-native-template-typescript'. Starting from React Native v0.71 TypeScript is used by default.",
     );
-    return 'react-native';
+    return platform;
   }
 
-  return options.template || `react-native@${version}`;
+  return options.template || `${platform}@${version}`;
 }
 
 //remove quotes from object keys to match the linter rules of the template

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -134,15 +134,16 @@ function attachCommand<C extends Command<boolean>>(
   }
 }
 
-async function run() {
+// Platform name is optional argument passed by out of tree platforms.
+async function run(platformName?: string) {
   try {
-    await setupAndRun();
+    await setupAndRun(platformName);
   } catch (e) {
     handleError(e as Error);
   }
 }
 
-async function setupAndRun() {
+async function setupAndRun(platformName?: string) {
   // Commander is not available yet
 
   // when we run `config`, we don't want to output anything to the console. We
@@ -210,7 +211,14 @@ async function setupAndRun() {
     }
   }
 
-  program.parse(process.argv);
+  const argv = [...process.argv];
+
+  // If out of tree platform specifices custom platform name by passing it to , we need to pass it to argv array.
+  if (platformName) {
+    argv.push('--platform-name', platformName);
+  }
+
+  program.parse(argv);
 }
 
 const bin = require.resolve('./bin');


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This PR adds `platform-name` option to allow for out of tree platforms to leverage `init` command without (almost) any changes in their repo. 

### Problem

When initializing project (for OOT platform) with command similar to this: `@callstack/react-native-visionos init MyApp` current approach would be to pass `--template` option to specify custom template for this platform. However this requires to maintain separate template (as RN-TvOS is doing: https://www.npmjs.com/package/react-native-template-typescript-tv).

Also CLI has a hardcoded path to retrieve template URI (in `createTemplateUri`). 

### Solution

Allow OOT platforms to pass it's name to `cli.run()` function call which doesn't require to pass any extra flags by user. 

Inside of `[OutOfTreePlatform]/packages/react-native/cli.js` we pass out of tree platform name from the package.json

```diff
+ const {name} = require('./package.json');

async function main() {
  if (isNpxRuntime && !process.env.SKIP && currentVersion !== HEAD) {
    try {
      const latest = await getLatestVersion();
      if (latest !== currentVersion) {
        const msg = `
  ${chalk.bold.yellow('WARNING:')} You should run ${chalk.white.bold(
    'npx react-native@latest',
  )} to ensure you're always using the most current version of the CLI. NPX has cached version (${chalk.bold.yellow(
    currentVersion,
  )}) != current release (${chalk.bold.green(latest)})
  `;
        console.warn(msg);
      }
    } catch (_) {
      // Ignore errors, since it's a nice to have warning
    }
  }
+  return cli.run(name);
}
```

As an extension of this we could later on detect if we are inside of a project and if so just add new platform to this project (instead of initializing new one)

Test Plan:
----------

- Check if it works 
- Add tests (after the idea is validated)

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
