### PR TITLE
fix: platform-name option causing regressions for other commands

### DIFF
--- a/__e2e__/default.test.ts
+++ b/__e2e__/default.test.ts
@@ -14,3 +14,8 @@ test('shows up help information without passing in any args', () => {
   const {stderr} = runCLI(DIR);
   expect(stderr).toMatchSnapshot();
 });
+
+test('does not pass --platform-name by default', () => {
+  const {stderr} = runCLI(DIR);
+  expect(stderr).not.toContain("unknown option '--platform-name'");
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -213,8 +213,8 @@ async function setupAndRun(platformName?: string) {
 
   const argv = [...process.argv];
 
-  // If out of tree platform specifices custom platform name by passing it to , we need to pass it to argv array.
-  if (platformName) {
+  // If out of tree platform specifices custom platform name, we need to pass it to argv array for the init command.
+  if (process.argv.includes('init') && platformName) {
     argv.push('--platform-name', platformName);
   }
 


### PR DESCRIPTION
Summary:
---------

This PR fixes a regression caused by #2170. Now we pass the `platform-name` **only** to init command. Which was the source of error: `Unkown command `--platform-name` as other commands didn't expect this option passed.

I've added a test case to check for this special case

Test Plan:
----------

Green CI

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
