### PR TITLE
fix: make sure command is passed

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -143,12 +143,16 @@ async function run(platformName?: string) {
   }
 }
 
+const isCommandPassed = (commandName: string) => {
+  return process.argv.filter((arg) => arg === commandName).length > 0;
+};
+
 async function setupAndRun(platformName?: string) {
   // Commander is not available yet
 
   // when we run `config`, we don't want to output anything to the console. We
   // expect it to return valid JSON
-  if (process.argv.includes('config')) {
+  if (isCommandPassed('config')) {
     logger.disable();
   }
 
@@ -214,7 +218,7 @@ async function setupAndRun(platformName?: string) {
   const argv = [...process.argv];
 
   // If out of tree platform specifices custom platform name, we need to pass it to argv array for the init command.
-  if (process.argv.includes('init') && platformName) {
+  if (isCommandPassed('init') && platformName) {
     argv.push('--platform-name', platformName);
   }
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

With current solution we're sure that command `init` was passed, with previous approach folder name could have "init" inside name and condition would be true

Test Plan:
----------

CI Green

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
