### PR TITLE
fix(ios): `run-ios` command

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -194,3 +194,23 @@ test('init --platform-name should work for out of tree platform', () => {
 
   expect(dirFiles.length).toBeGreaterThan(0);
 });
+
+test('should not create custom config file if installed version is below 0.73', () => {
+  createCustomTemplateFiles();
+
+  runCLI(DIR, ['init', PROJECT_NAME, '--skip-install', '--version', '0.72.0']);
+
+  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
+
+  expect(dirFiles).not.toContain('react-native.config.js');
+});
+
+test('should create custom config file if installed version is latest (starting from 0.73)', () => {
+  createCustomTemplateFiles();
+
+  runCLI(DIR, ['init', PROJECT_NAME, '--skip-install']);
+
+  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
+
+  expect(dirFiles).toContain('react-native.config.js');
+});

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -213,4 +213,22 @@ test('should create custom config file if installed version is latest (starting 
   let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
 
   expect(dirFiles).toContain('react-native.config.js');
+  const fileContent = fs.readFileSync(
+    path.join(DIR, PROJECT_NAME, 'react-native.config.js'),
+    'utf8',
+  );
+
+  const configFileContent = `
+  module.exports = {
+    project: {
+      ios: {
+        automaticPodsInstallation: true
+      }
+    }
+  }`;
+
+  //normalize all white-spaces for easier comparision
+  expect(fileContent.replace(/\s+/g, '')).toEqual(
+    configFileContent.replace(/\s+/g, ''),
+  );
 });

--- a/packages/cli-tools/src/__tests__/cacheManager.test.ts
+++ b/packages/cli-tools/src/__tests__/cacheManager.test.ts
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import cacheManager from '../cacheManager';
+
+const projectName = 'Project1';
+const cachePath = '.react-native-cli/cache';
+const fullPath = path.join(cachePath, projectName);
+
+describe('cacheManager', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('should remove cache if it exists', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'rmSync').mockImplementation(() => {});
+    jest
+      .spyOn(path, 'resolve')
+      .mockReturnValue(path.join(cachePath, projectName));
+
+    cacheManager.removeProjectCache(projectName);
+
+    expect(fs.rmSync).toHaveBeenCalledWith(fullPath, {recursive: true});
+  });
+
+  test('should not remove cache if it does not exist', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fs, 'rmSync').mockImplementation(() => {});
+
+    cacheManager.removeProjectCache(projectName);
+
+    expect(fs.rmSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli-tools/src/__tests__/cacheManager.test.ts
+++ b/packages/cli-tools/src/__tests__/cacheManager.test.ts
@@ -1,26 +1,19 @@
 import fs from 'fs';
 import path from 'path';
 import cacheManager from '../cacheManager';
+import {cleanup, getTempDirectory} from '../../../../jest/helpers';
 
+const DIR = getTempDirectory('.react-native-cli/cache');
 const projectName = 'Project1';
-const cachePath = '.react-native-cli/cache';
-const fullPath = path.join(cachePath, projectName);
+const fullPath = path.join(DIR, projectName);
 
 describe('cacheManager', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
-  test('should remove cache if it exists', () => {
-    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    jest.spyOn(fs, 'rmSync').mockImplementation(() => {});
-    jest
-      .spyOn(path, 'resolve')
-      .mockReturnValue(path.join(cachePath, projectName));
-
-    cacheManager.removeProjectCache(projectName);
-
-    expect(fs.rmSync).toHaveBeenCalledWith(fullPath, {recursive: true});
+  afterEach(() => {
+    cleanup(DIR);
   });
 
   test('should not remove cache if it does not exist', () => {
@@ -30,5 +23,15 @@ describe('cacheManager', () => {
     cacheManager.removeProjectCache(projectName);
 
     expect(fs.rmSync).not.toHaveBeenCalled();
+  });
+
+  test('should remove cache if it exists', () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'rmSync').mockImplementation(() => {});
+    jest.spyOn(path, 'resolve').mockReturnValue(fullPath);
+
+    cacheManager.removeProjectCache(projectName);
+
+    expect(fs.rmSync).toHaveBeenCalledWith(fullPath, {recursive: true});
   });
 });

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import fs from 'fs';
 import os from 'os';
 import appDirs from 'appdirsjs';
+import chalk from 'chalk';
 import logger from './logger';
 
 type CacheKey = 'eTag' | 'lastChecked' | 'latestVersion' | 'dependencies';
@@ -49,10 +50,19 @@ function getCacheRootPath() {
 }
 
 function removeProjectCache(name: string) {
-  const fullPath = path.resolve(getCacheRootPath(), name);
+  const cacheRootPath = getCacheRootPath();
+  try {
+    const fullPath = path.resolve(cacheRootPath, name);
 
-  if (fs.existsSync(fullPath)) {
-    fs.rmSync(fullPath, {recursive: true});
+    if (fs.existsSync(fullPath)) {
+      fs.rmSync(fullPath, {recursive: true});
+    }
+  } catch {
+    logger.error(
+      `Failed to remove cache for ${name}. If you experience any issues when running freshly initialized project, please remove ${chalk.underline(
+        path.join(cacheRootPath, name),
+      )} folder manually.`,
+    );
   }
 }
 
@@ -76,4 +86,5 @@ export default {
   get,
   set,
   removeProjectCache,
+  getCacheRootPath,
 };

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -48,6 +48,14 @@ function getCacheRootPath() {
   return cachePath;
 }
 
+function removeProjectCache(name: string) {
+  const fullPath = path.resolve(getCacheRootPath(), name);
+
+  if (fs.existsSync(fullPath)) {
+    fs.rmSync(fullPath, {recursive: true});
+  }
+}
+
 function get(name: string, key: CacheKey): string | undefined {
   const cache = loadCache(name);
   if (cache) {
@@ -67,4 +75,5 @@ function set(name: string, key: CacheKey, value: string) {
 export default {
   get,
   set,
+  removeProjectCache,
 };

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -59,9 +59,9 @@ function removeProjectCache(name: string) {
     }
   } catch {
     logger.error(
-      `Failed to remove cache for ${name}. If you experience any issues when running freshly initialized project, please remove ${chalk.underline(
+      `Failed to remove cache for ${name}. If you experience any issues when running freshly initialized project, please remove the "${chalk.underline(
         path.join(cacheRootPath, name),
-      )} folder manually.`,
+      )}" folder manually.`,
     );
   }
 }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -136,6 +136,9 @@ async function createFromTemplate({
     packageManager = 'npm';
   }
 
+  // if the project with the name already has cache, remove the cache to avoid problems with pods installation
+  cacheManager.removeProjectCache(projectName);
+
   const projectDirectory = await setProjectDirectory(directory);
 
   const loader = getLoader({text: 'Downloading template'});
@@ -393,9 +396,6 @@ export default (async function initialize(
     });
     projectName = projName;
   }
-
-  // if the project with the name already has cache, remove the cache to avoid problems with pods installation
-  cacheManager.removeProjectCache(projectName);
 
   validateProjectName(projectName);
 

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -383,6 +383,9 @@ export default (async function initialize(
     projectName = projName;
   }
 
+  // if the project with the name already has cache, remove the cache to avoid problems with pods installation
+  cacheManager.removeProjectCache(projectName);
+
   validateProjectName(projectName);
 
   if (!!options.template && !!options.version) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Fixing numerous small issues that could lead for potential breaking `run-ios` command:
- if `run-ios` was called for the first time, and Pods were not installed during `init`, after installation it was trying to run `xcodebuild` command with `.xcodeproj` instead of `.xcworkspace`
- if project with a name existed in cache, it was skipping `bundle install` step in `run-ios`
-  if `--version` flag was used with < 0.73, pods had trouble installing because unknown flag was used in the config (this scenario will fail unless 0.73 is `latest`, if you are experiencing it, it's because `latest` is used when `--version` flag is not used)
<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
1. Follow the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create new app with `node ../path/to/cli init RN73RC5 --version 0.73.0-rc.5`
3. When asked for installing pods, press `n`
4. Once finished, use `run-ios`
5. Verify pods are installed and build was successful
6. `rm -rf RN73RC5`
7. Create new app with `node ../path/to/cli init RN73RC5 --version 0.73.0-rc.5`
8. When asked for installing pods, press `y`
9. Once finished, use `run-ios`
10. Verify build was successful

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
