### PR TITLE
fix: check for main manifest if multiple are present

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-platform-android/src/config/__fixtures__/android.ts
@@ -30,6 +30,14 @@ const classNameManifest = fs.readFileSync(
   path.join(__dirname, './files/AndroidManifest-className.xml'),
 );
 
+const customFlavorManifest = fs.readFileSync(
+  path.join(__dirname, './files/AndroidManifest-custom-flavor.xml'),
+);
+
+const mainManifest = fs.readFileSync(
+  path.join(__dirname, './files/AndroidManifest.xml'),
+);
+
 function generateValidFileStructureForLib(classFileName: string) {
   return {
     'build.gradle': buildGradle,
@@ -296,5 +304,16 @@ export const fewActivities = {
 export const className = {
   src: {
     'AndroidManifest.xml': classNameManifest,
+  },
+};
+
+export const customFlavor = {
+  src: {
+    e2e: {
+      'AndroidManifest.xml': customFlavorManifest,
+    },
+    main: {
+      'AndroidManifest.xml': mainManifest,
+    },
   },
 };

--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-custom-flavor.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-custom-flavor.xml
@@ -1,0 +1,3 @@
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
@@ -26,6 +26,11 @@ describe('android::getMainActivity', () => {
           app: mocks.fewActivities,
         },
       },
+      customFlavor: {
+        android: {
+          app: mocks.customFlavor,
+        },
+      },
     });
   });
 
@@ -51,6 +56,14 @@ describe('android::getMainActivity', () => {
     expect(mainActivity).not.toBeNull();
     expect(typeof mainActivity).toBe('string');
     expect(mainActivity).toBe('com.example.ExampleAppActivity');
+  });
+
+  it('returns main activity from main manifest when custom flavors are defined', () => {
+    const manifestPath = findManifest('/customFlavor');
+    const mainActivity = getMainActivity(manifestPath || '');
+    expect(mainActivity).not.toBeNull();
+    expect(typeof mainActivity).toBe('string');
+    expect(mainActivity).toBe('.MainActivity');
   });
 
   it('returns null if file do not exist', () => {

--- a/packages/cli-platform-android/src/config/findManifest.ts
+++ b/packages/cli-platform-android/src/config/findManifest.ts
@@ -10,7 +10,7 @@ import glob from 'glob';
 import path from 'path';
 
 export default function findManifest(folder: string) {
-  const manifestPath = glob.sync(path.join('**', 'AndroidManifest.xml'), {
+  let manifestPaths = glob.sync(path.join('**', 'AndroidManifest.xml'), {
     cwd: folder,
     ignore: [
       'node_modules/**',
@@ -23,7 +23,16 @@ export default function findManifest(folder: string) {
       '**/src/androidTest/**',
       '**/src/test/**',
     ],
-  })[0];
+  });
+  if (manifestPaths.length > 1) {
+    // if we have more than one manifest, pick the one in the main folder if present
+    const mainManifest = manifestPaths.filter((manifestPath) =>
+      manifestPath.includes('src/main/'),
+    );
+    if (mainManifest.length === 1) {
+      manifestPaths = mainManifest;
+    }
+  }
 
-  return manifestPath ? path.join(folder, manifestPath) : null;
+  return manifestPaths[0] ? path.join(folder, manifestPaths[0]) : null;
 }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
This PR fixes a newly introduced (https://github.com/react-native-community/cli/pull/1967) problem that having multiple build flavors in app causes the `findManifest` script to take the first found one. We think it seems more reasonable to take the one from `main` folder, if present. It fixes the error in `Expensify` app, where `e2e` manifest is the first found one, and the `MainActivity` is present in the `main` folder's `AndroidManifest.xml`. It throws such error then: 
```
error Main activity not found in /Users/.../android/app/src/e2e/AndroidManifest.xml.
```

Test Plan:
----------

Make a simple app with `activity` tag inside `main` `AndroidManifest.xml` and add a directory e.g. `e2e` with other `AndroidManifest.xml`, which should have the `activity` merged from the `main`. It will cause the error on gradle sync in RN 0.73.x

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
