### PR TITLE
feat: add `--skip-git-init` to opt out git init

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,10 @@ Create project with custom package name for Android and bundle identifier for iO
 - contain at least two segments separated by dots, e.g. `com.example`
 - contain only alphanumeric characters and dots
 
+#### `--skip-git-init <boolean>`
+
+Skip git repository initialization.
+
 ### `upgrade`
 
 Usage:

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -52,5 +52,9 @@ export default {
       description:
         'Name of out of tree platform to be used for ex. react-native-macos. This flag is optional as it should be passed automatically by out of tree platform. It needs to match the name of the platform declared in package.json',
     },
+    {
+      name: '--skip-git-init',
+      description: 'Skip git repository initialization',
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -45,6 +45,7 @@ type Options = {
   packageName?: string;
   installPods?: string | boolean;
   platformName?: string;
+  skipGitInit?: boolean;
 };
 
 interface TemplateOptions {
@@ -404,6 +405,9 @@ export default (async function initialize(
 
   const projectFolder = path.join(root, directoryName);
 
-  await createGitRepository(projectFolder);
+  if (!options.skipGitInit) {
+    await createGitRepository(projectFolder);
+  }
+
   printRunInstructions(projectFolder, projectName);
 });


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Adds flag to opt out `git init` inside `init` command.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init asdf --skip-git-init
```
3. Should not create git repository.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
