### PR TITLE
chore(ios): remove deprecated param in `use_native_modules`

### DIFF
--- a/packages/cli-platform-ios/native_modules.rb
+++ b/packages/cli-platform-ios/native_modules.rb
@@ -12,30 +12,20 @@
 require 'pathname'
 require 'cocoapods'
 
-def use_native_modules!(config = nil)
-  if (config.is_a? String)
-    Pod::UI.warn("Passing custom root to use_native_modules! is deprecated.",
-      [
-        "CLI detects root of the project automatically. The \"#{config}\" argument was ignored.",
-      ]);
-    config = nil;
-  end
-
+def use_native_modules!()
   # Resolving the path the RN CLI. The `@react-native-community/cli` module may not be there for certain package managers, so we fall back to resolving it through `react-native` package, that's always present in RN projects
   cli_resolve_script = "try {console.log(require('@react-native-community/cli').bin);} catch (e) {console.log(require('react-native/cli').bin);}"
   cli_bin = Pod::Executable.execute_command("node", ["-e", cli_resolve_script], true).strip
 
-  if (!config)
-    json = []
+  json = []
 
-    IO.popen(["node", cli_bin, "config"]) do |data|
-      while line = data.gets
-        json << line
-      end
+  IO.popen(["node", cli_bin, "config"]) do |data|
+    while line = data.gets
+      json << line
     end
-
-    config = JSON.parse(json.join("\n"))
   end
+
+  config = JSON.parse(json.join("\n"))
 
   project_root = Pathname.new(config["project"]["ios"]["sourceDir"])
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Removes deprecated option in `native_modules.rb` 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command
```
pod install
``` 

inside `ios/` directory.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
