### PR TITLE
fix: remove error when main activity not found in `AndroidManifest.xml`

### DIFF
--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -66,11 +66,7 @@ export function projectConfig(
   const applicationId = buildGradlePath
     ? getApplicationId(buildGradlePath, packageName)
     : packageName;
-  const mainActivity = getMainActivity(manifestPath || '');
-
-  if (!mainActivity) {
-    throw new CLIError(`Main activity not found in ${manifestPath}`);
-  }
+  const mainActivity = getMainActivity(manifestPath || '') ?? '';
 
   return {
     sourceDir,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Sometimes there are _really_ complicated setups, like this [one](https://github.com/react-native-community/cli/issues/2183) - that are based on `native_modules.gradle`, so are based on `config` command. We should not block users in these cases. 

Test Plan:
----------

CI

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
