### PR TITLE
Fix native_modules.rb tests

### DIFF
--- a/packages/cli-platform-ios/native_modules.rb
+++ b/packages/cli-platform-ios/native_modules.rb
@@ -12,20 +12,30 @@
 require 'pathname'
 require 'cocoapods'
 
-def use_native_modules!()
+def use_native_modules!(config = nil)
+  if (config.is_a? String)
+    Pod::UI.warn("Passing custom root to use_native_modules! is deprecated.",
+      [
+        "CLI detects root of the project automatically. The \"#{config}\" argument was ignored.",
+      ]);
+    config = nil;
+  end
+
   # Resolving the path the RN CLI. The `@react-native-community/cli` module may not be there for certain package managers, so we fall back to resolving it through `react-native` package, that's always present in RN projects
   cli_resolve_script = "try {console.log(require('@react-native-community/cli').bin);} catch (e) {console.log(require('react-native/cli').bin);}"
   cli_bin = Pod::Executable.execute_command("node", ["-e", cli_resolve_script], true).strip
 
-  json = []
+  if (!config)
+    json = []
 
-  IO.popen(["node", cli_bin, "config"]) do |data|
-    while line = data.gets
-      json << line
+    IO.popen(["node", cli_bin, "config"]) do |data|
+      while line = data.gets
+        json << line
+      end
     end
-  end
 
-  config = JSON.parse(json.join("\n"))
+    config = JSON.parse(json.join("\n"))
+  end
 
   project_root = Pathname.new(config["project"]["ios"]["sourceDir"])
 


### PR DESCRIPTION
Summary:
---------

This partially reverts commit 2486e49ab6b8d25172953f7dc0075e97134ad70e. It broke tests that run when `ruby` and `pod` are installed (which apparently is not the case on our CI, we should fix that). These tests inject different `config`s to `use_native_modules!`, so the `config` argument is still needed, just for the testing purposes.


Test Plan:
----------

Verify locally that all test suites are executed, and none skipped

<img width="315" alt="image" src="https://github.com/react-native-community/cli/assets/5106466/e9200a94-8fb2-4fec-832a-e34780cfe49b">


Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
