### PR TITLE
perf: only use project  params, this can let native.gradle file Load …

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -514,17 +514,17 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings ->
 ext.applyNativeModulesAppBuildGradle = { Project project ->
   autoModules.addReactNativeModuleDependencies(project)
 
-  def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
+  def generatedSrcDir = new File(project.getBuildDir(), "generated/rncli/src/main/java")
   def generatedCodeDir = new File(generatedSrcDir, generatedFilePackage.replace('.', '/'))
-  def generatedJniDir = new File(buildDir, "generated/rncli/src/main/jni")
+  def generatedJniDir = new File(project.getBuildDir(), "generated/rncli/src/main/jni")
 
-  task generatePackageList {
+  project.task("generatePackageList"){
     doLast {
       autoModules.generatePackagesFile(generatedCodeDir, generatedFileName, generatedFileContentsTemplate)
     }
   }
 
-  task generateNewArchitectureFiles {
+  project.task("generateNewArchitectureFiles"){
     doLast {
       autoModules.generateCmakeFile(generatedJniDir, "Android-rncli.cmake", cmakeTemplate)
       autoModules.generateRncliCpp(generatedJniDir, "rncli.cpp", rncliCppTemplate)
@@ -532,14 +532,14 @@ ext.applyNativeModulesAppBuildGradle = { Project project ->
     }
   }
 
-  preBuild.dependsOn generatePackageList
+  project.preBuild.dependsOn("generatePackageList")
   def isNewArchEnabled = (project.hasProperty("newArchEnabled") && project.newArchEnabled == "true") ||
     reactNativeVersionRequireNewArchEnabled(autoModules)
   if (isNewArchEnabled) {
-    preBuild.dependsOn generateNewArchitectureFiles
+    project.preBuild.dependsOn("generateNewArchitectureFiles")
   }
 
-  android {
+  project.android {
     sourceSets {
       main {
         java {


### PR DESCRIPTION
…only once in setting.gradle

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
before:
we use cli-platform-android
in **settings.gradle**
```
apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
```

in **app/build.gradle**
```
apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesAppBuildGradle(project)
```

We can see that this will load the **native_modules.gradle** file twice,   this will cause two traversals of the node_ Modules folder. 

Now:
We can change the **applyNativeModulesAppBuildGradle** method to be a pure function, so that we can only load native_module.gradle in settings. gradle file

in **settings.gradle**
```
apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle");
applyNativeModulesSettingsGradle(settings)
gradle.ext.applyNativeModulesAppBuildGradle = applyNativeModulesAppBuildGradle
```
in **app/build.gradle**
```
gradle.ext.applyNativeModulesAppBuildGradle(project)
```

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Use the configuration above， can successfully complete autolink
Checklist
----------

- [ OK] Documentation is up to date to reflect these changes.
- [ OK] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
