### PR TITLE
fix(android): launching app on simulator with different appId than pa…

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/runOnAllDevices.test.ts
@@ -66,6 +66,7 @@ describe('--appFolder', () => {
   const androidProject: AndroidProjectConfig = {
     appName: 'app',
     packageName: 'com.test',
+    applicationId: 'com.test',
     sourceDir: '/android',
     mainActivity: '.MainActivity',
   };

--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
@@ -1,0 +1,133 @@
+import {AndroidProjectConfig} from '@react-native-community/cli-types';
+import tryLaunchAppOnDevice from '../tryLaunchAppOnDevice';
+import {Flags} from '..';
+import execa from 'execa';
+
+jest.mock('execa');
+jest.mock('../getAdbPath');
+jest.mock('../tryLaunchEmulator');
+
+const adbPath = 'path/to/adb';
+const device = 'emulator-5554';
+let args: Flags = {
+  activeArchOnly: false,
+  packager: true,
+  port: 8081,
+  terminal: 'iTerm.app',
+  appId: '',
+  appIdSuffix: '',
+  listDevices: false,
+};
+
+let androidProject: AndroidProjectConfig = {
+  sourceDir: '/Users/thymikee/Developer/tmp/App73/android',
+  appName: 'app',
+  packageName: 'com.myapp',
+  applicationId: 'com.myapp.custom',
+  mainActivity: '.MainActivity',
+  dependencyConfiguration: undefined,
+  watchModeCommandParams: undefined,
+  unstable_reactLegacyComponentNames: undefined,
+};
+
+const shellStartCommand = ['shell', 'am', 'start'];
+const actionCategoryFlags = [
+  '-a',
+  'android.intent.action.MAIN',
+  '-c',
+  'android.intent.category.LAUNCHER',
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('launches adb shell with intent to launch com.myapp.MainActivity with different appId than packageName on a simulator', () => {
+  tryLaunchAppOnDevice(device, androidProject, adbPath, args);
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      '-s',
+      'emulator-5554',
+      ...shellStartCommand,
+      '-n',
+      'com.myapp.custom/com.myapp.MainActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});
+
+test('launches adb shell with intent to launch com.myapp.MainActivity with same appId as packageName on a simulator', () => {
+  tryLaunchAppOnDevice(
+    device,
+    {...androidProject, applicationId: 'com.myapp'},
+    adbPath,
+    args,
+  );
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      '-s',
+      'emulator-5554',
+      ...shellStartCommand,
+      '-n',
+      'com.myapp/com.myapp.MainActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});
+
+test('launches adb shell with intent to launch com.myapp.MainActivity with different appId than packageName on a device (without calling simulator)', () => {
+  tryLaunchAppOnDevice(undefined, androidProject, adbPath, args);
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      ...shellStartCommand,
+      '-n',
+      'com.myapp.custom/com.myapp.MainActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});
+
+test('--appId flag overwrites applicationId setting in androidProject', () => {
+  tryLaunchAppOnDevice(undefined, androidProject, adbPath, {
+    ...args,
+    appId: 'my.app.id',
+  });
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      ...shellStartCommand,
+      '-n',
+      'my.app.id/com.myapp.MainActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});
+
+test('appIdSuffix Staging is appended to applicationId', () => {
+  tryLaunchAppOnDevice(undefined, androidProject, adbPath, {
+    ...args,
+    appIdSuffix: 'Staging',
+  });
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      ...shellStartCommand,
+      '-n',
+      'com.myapp.custom.Staging/com.myapp.MainActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -34,7 +34,7 @@ import {checkUsers, promptForUser} from './listAndroidUsers';
 export interface Flags extends BuildFlags {
   appId: string;
   appIdSuffix: string;
-  mainActivity: string;
+  mainActivity?: string;
   port: number;
   terminal?: string;
   packager?: boolean;

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -25,7 +25,7 @@ function tryLaunchAppOnDevice(
     .join('.');
 
   const activityToLaunch = mainActivity.includes('.')
-    ? mainActivity
+    ? [packageName, mainActivity].join('')
     : [packageName, mainActivity].filter(Boolean).join('.');
 
   try {


### PR DESCRIPTION
Summary:
---------

Fixes #2194 


Test Plan:
----------

Added a test for `tryLaunchAppOnDevice` covering this scenario and a handful of others. The tests fail without the change introduced. 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
