### PR TITLE
fix: add more guard conditions for retrieving buildConfig from XcScheme

### DIFF
--- a/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
+++ b/packages/cli-platform-ios/src/tools/getBuildConfigurationFromXcScheme.ts
@@ -9,7 +9,7 @@ const xmlParser = new XMLParser({ignoreAttributes: false});
 
 export function getBuildConfigurationFromXcScheme(
   scheme: string,
-  configuration: string,
+  _: string,
   sourceDir: string,
   projectInfo: IosInfo | undefined,
 ): string {


### PR DESCRIPTION
Summary:
---------

just an enhancement. Add more guard conditions when retrieving buildConfig from XcScheme.

Test Plan:
----------

add a new project to `/ios/` folder looks like this:

```
|-- ios
     |-- foo.xcodeproj
     |-- bar.xcodeproj
```

when running `npx react-native run-ios` it would throw an accurate error message.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)

Note:
----------

I'm not good at English, please feel free to correct the error message. Thanks.
