### PR TITLE
fix: packager starting when using run-ios and run-android

### DIFF
--- a/packages/cli-tools/src/findDevServerPort.ts
+++ b/packages/cli-tools/src/findDevServerPort.ts
@@ -10,7 +10,7 @@ const findDevServerPort = async (
   startPackager: boolean;
 }> => {
   let port = initialPort;
-  let startPackager = false;
+  let startPackager = true;
 
   const packagerStatus = await isPackagerRunning(port);
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

When the packager is not running `findDevServerPort` returns `startPackager = false` which is not what we want. Changing the initial value of `startPackager` fixes it (we could also add a branch to check for not_running state but it seemed redundant).

Test Plan:
----------

Tested this patch in an app on RN 0.73 and made sure packager starts when running cli on iOS and Android.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
