### PR TITLE
build: support Gradle configuration cache

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -366,29 +366,20 @@ class ReactNativeModules {
   }
 
   /**
-   * Runs a specified command using Runtime exec() in a specified directory.
+   * Runs a specified command using providers.exec in a specified directory.
    * Throws when the command result is empty.
    */
-  String getCommandOutput(String[] command, File directory) {
+  String getCommandOutput(String[] command, File directory) {    
     try {
-      def output = ""
-      def cmdProcess = Runtime.getRuntime().exec(command, null, directory)
-      def bufferedReader = new BufferedReader(new InputStreamReader(cmdProcess.getInputStream()))
-      def buff = ""
-      def readBuffer = new StringBuffer()
-      while ((buff = bufferedReader.readLine()) != null) {
-        readBuffer.append(buff)
+      def execOutput = providers.exec {
+        commandLine(command)
+        workingDir(directory)
       }
-      output = readBuffer.toString()
+      def output = execOutput.standardOutput.asText.get().trim()
       if (!output) {
         this.logger.error("${LOG_PREFIX}Unexpected empty result of running '${command}' command.")
-        def bufferedErrorReader = new BufferedReader(new InputStreamReader(cmdProcess.getErrorStream()))
-        def errBuff = ""
-        def readErrorBuffer = new StringBuffer()
-        while ((errBuff = bufferedErrorReader.readLine()) != null) {
-          readErrorBuffer.append(errBuff)
-        }
-        throw new Exception(readErrorBuffer.toString())
+        def error = execOutput.standardError.asText.get().trim()
+        throw new Exception(error)
       }
       return output
     } catch (Exception exception) {

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -369,7 +369,7 @@ class ReactNativeModules {
    * Runs a specified command using providers.exec in a specified directory.
    * Throws when the command result is empty.
    */
-  String getCommandOutput(String[] command, File directory) {    
+  String getCommandOutput(String[] command, File directory) {
     try {
       def execOutput = providers.exec {
         commandLine(command)

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -138,6 +138,7 @@ void rncli_registerProviders(std::shared_ptr<ComponentDescriptorProviderRegistry
 
 class ReactNativeModules {
   private Logger logger
+  private ProviderFactory providers
   private String packageName
   private File root
   private ArrayList<HashMap<String, String>> reactNativeModules
@@ -147,8 +148,9 @@ class ReactNativeModules {
 
   private static String LOG_PREFIX = ":ReactNative:"
 
-  ReactNativeModules(Logger logger, File root) {
+  ReactNativeModules(Logger logger, ProviderFactory providers, File root) {
     this.logger = logger
+    this.providers = providers
     this.root = root
 
     def (nativeModules, reactNativeModulesBuildVariants, androidProject, reactNativeVersion) = this.getReactNativeConfig()
@@ -477,7 +479,7 @@ class ReactNativeModules {
  */
 def projectRoot = rootProject.projectDir
 
-def autoModules = new ReactNativeModules(logger, projectRoot)
+def autoModules = new ReactNativeModules(logger, providers, projectRoot)
 
 def reactNativeVersionRequireNewArchEnabled(autoModules) {
     def rnVersion = autoModules.reactNativeVersion


### PR DESCRIPTION
Summary:
---------

Directly calling Runtime.exec breaks Gradle configuration caching. An easy workaround is to use `providers.exec` instead, which supports configuration caching.

Test Plan:
----------
This change should be functionally equivalent to existing behavior. I've tested locally that my project's gradle build still works with this change, both with and without the --configuration-cache argument

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
