### PR TITLE
fix: remove automatic config file generation

### DIFF
--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -81,8 +81,7 @@ exports[`shows up current config without unnecessary output 1`] = `
   },
   "project": {
     "ios": {
-      "sourceDir": "<<REPLACED_ROOT>>/TestProject/ios",
-      "automaticPodsInstallation": true
+      "sourceDir": "<<REPLACED_ROOT>>/TestProject/ios"
     },
     "android": {
       "sourceDir": "<<REPLACED_ROOT>>/TestProject/android",

--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -52,16 +52,11 @@ beforeAll(() => {
   writeFiles(DIR, {});
 
   // Initialise React Native project
-  runCLI(DIR, ['init', 'TestProject']);
+  runCLI(DIR, ['init', 'TestProject', '--install-pods']);
 
   // Link CLI to the project
   spawnScript('yarn', ['link', ...addRNCPrefix(packages)], {
     cwd: path.join(DIR, 'TestProject'),
-  });
-
-  // Install pods after linking packages because Podfile uses `use_native_modules` function that executes `config` command. In case there was introduce breaking change in `cli-config` package, it will fail since it will be using old version of the package.
-  spawnScript('pod', ['install'], {
-    cwd: path.join(DIR, 'TestProject', 'ios'),
   });
 });
 

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -26,7 +26,6 @@ const customTemplateCopiedFiles = [
   'file',
   'node_modules',
   'package.json',
-  'react-native.config.js',
   'yarn.lock',
 ];
 
@@ -193,42 +192,4 @@ test('init --platform-name should work for out of tree platform', () => {
   let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
 
   expect(dirFiles.length).toBeGreaterThan(0);
-});
-
-test('should not create custom config file if installed version is below 0.73', () => {
-  createCustomTemplateFiles();
-
-  runCLI(DIR, ['init', PROJECT_NAME, '--skip-install', '--version', '0.72.0']);
-
-  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
-
-  expect(dirFiles).not.toContain('react-native.config.js');
-});
-
-test('should create custom config file if installed version is latest (starting from 0.73)', () => {
-  createCustomTemplateFiles();
-
-  runCLI(DIR, ['init', PROJECT_NAME, '--skip-install']);
-
-  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
-
-  expect(dirFiles).toContain('react-native.config.js');
-  const fileContent = fs.readFileSync(
-    path.join(DIR, PROJECT_NAME, 'react-native.config.js'),
-    'utf8',
-  );
-
-  const configFileContent = `
-  module.exports = {
-    project: {
-      ios: {
-        automaticPodsInstallation: true
-      }
-    }
-  }`;
-
-  //normalize all white-spaces for easier comparision
-  expect(fileContent.replace(/\s+/g, '')).toEqual(
-    configFileContent.replace(/\s+/g, ''),
-  );
 });


### PR DESCRIPTION
Summary:
---------

This PR removes automatic config file generation during the `init` command.

Relates to #2202

Test Plan:
----------

Run `init` command and test if it doesn't generate `react-native.config.js`

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
