### PR TITLE
feat: add manual Cocoapods installation info

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -193,3 +193,16 @@ test('init --platform-name should work for out of tree platform', () => {
 
   expect(dirFiles.length).toBeGreaterThan(0);
 });
+
+test('init should contain Cocoapods instructions when pods are not installed automatically', () => {
+  createCustomTemplateFiles();
+
+  const {stdout} = runCLI(DIR, ['init', PROJECT_NAME, '--skip-install']);
+  expect(stdout).toContain('Install Cocoapods');
+
+  // make sure we don't leave garbage
+  expect(fs.readdirSync(DIR)).toContain('custom');
+
+  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
+  expect(dirFiles.length).toBeGreaterThan(0);
+});

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -198,7 +198,9 @@ test('init should contain Cocoapods instructions when pods are not installed aut
   createCustomTemplateFiles();
 
   const {stdout} = runCLI(DIR, ['init', PROJECT_NAME, '--skip-install']);
-  expect(stdout).toContain('Install Cocoapods');
+  if (process.platform === 'darwin') {
+    expect(stdout).toContain('Install Cocoapods');
+  }
 
   // make sure we don't leave garbage
   expect(fs.readdirSync(DIR)).toContain('custom');

--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -119,6 +119,10 @@ test('init skips installation of dependencies with --skip-install', () => {
 
   expect(stdout).toContain('Run instructions');
 
+  if (process.platform === 'darwin') {
+    expect(stdout).toContain('Install Cocoapods');
+  }
+
   // make sure we don't leave garbage
   expect(fs.readdirSync(DIR)).toContain('custom');
 
@@ -191,20 +195,5 @@ test('init --platform-name should work for out of tree platform', () => {
 
   let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
 
-  expect(dirFiles.length).toBeGreaterThan(0);
-});
-
-test('init should contain Cocoapods instructions when pods are not installed automatically', () => {
-  createCustomTemplateFiles();
-
-  const {stdout} = runCLI(DIR, ['init', PROJECT_NAME, '--skip-install']);
-  if (process.platform === 'darwin') {
-    expect(stdout).toContain('Install Cocoapods');
-  }
-
-  // make sure we don't leave garbage
-  expect(fs.readdirSync(DIR)).toContain('custom');
-
-  let dirFiles = fs.readdirSync(path.join(DIR, PROJECT_NAME));
   expect(dirFiles.length).toBeGreaterThan(0);
 });

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -213,15 +213,6 @@ async function createFromTemplate({
             )}`,
           });
           didInstallPods = installCocoapods;
-          logger.log('\n');
-          logger.info(
-            `💡 To enable automatic CocoaPods installation when building for iOS you can create react-native.config.js with automaticPodsInstallation field. \n${chalk.reset.dim(
-              `For more details, see ${chalk.underline(
-                'https://github.com/react-native-community/cli/blob/main/docs/projects.md#projectiosautomaticpodsinstallation',
-              )}`,
-            )}
-            `,
-          );
 
           if (installCocoapods) {
             await installPods(loader);
@@ -231,6 +222,7 @@ async function createFromTemplate({
         }
       }
     } else {
+      didInstallPods = false;
       loader.succeed('Dependencies installation skipped');
     }
   } catch (e) {
@@ -244,6 +236,19 @@ async function createFromTemplate({
   } finally {
     fs.removeSync(templateSourceDir);
   }
+
+  if (process.platform === 'darwin') {
+    logger.log('\n');
+    logger.info(
+      `💡 To enable automatic CocoaPods installation when building for iOS you can create react-native.config.js with automaticPodsInstallation field. \n${chalk.reset.dim(
+        `For more details, see ${chalk.underline(
+          'https://github.com/react-native-community/cli/blob/main/docs/projects.md#projectiosautomaticpodsinstallation',
+        )}`,
+      )}
+            `,
+    );
+  }
+
   return {didInstallPods};
 }
 

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -118,7 +118,10 @@ async function createFromTemplate({
   installCocoaPods,
 }: TemplateOptions): Promise<TemplateReturnType> {
   logger.debug('Initializing new project');
-  logger.log(banner);
+  // Only print out the banner if we're not in a CI
+  if (!process.env.CI) {
+    logger.log(banner);
+  }
   let didInstallPods = String(installCocoaPods) === 'true';
   let packageManager = pm;
 

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -61,7 +61,7 @@ interface TemplateOptions {
 }
 
 interface TemplateReturnType {
-  automaticPodsInstallation?: boolean;
+  didInstallPods?: boolean;
 }
 
 function doesDirectoryExist(dir: string) {
@@ -119,7 +119,7 @@ async function createFromTemplate({
 }: TemplateOptions): Promise<TemplateReturnType> {
   logger.debug('Initializing new project');
   logger.log(banner);
-  let automaticPodsInstallation = String(installCocoaPods) === 'true';
+  let didInstallPods = String(installCocoaPods) === 'true';
   let packageManager = pm;
 
   if (pm) {
@@ -200,7 +200,7 @@ async function createFromTemplate({
         const installPodsValue = String(installCocoaPods);
 
         if (installPodsValue === 'true') {
-          automaticPodsInstallation = true;
+          didInstallPods = true;
           await installPods(loader);
           loader.succeed();
           setEmptyHashForCachedDependencies(projectName);
@@ -212,10 +212,10 @@ async function createFromTemplate({
               'Only needed if you run your project in Xcode directly',
             )}`,
           });
-          automaticPodsInstallation = installCocoapods;
+          didInstallPods = installCocoapods;
           logger.log('\n');
           logger.info(
-            `To enable automatic CocoaPods installation when building for iOS you can create react-native.config.js with automaticPodsInstallation field. \n${chalk.reset.dim(
+            `💡 To enable automatic CocoaPods installation when building for iOS you can create react-native.config.js with automaticPodsInstallation field. \n${chalk.reset.dim(
               `For more details, see ${chalk.underline(
                 'https://github.com/react-native-community/cli/blob/main/docs/projects.md#projectiosautomaticpodsinstallation',
               )}`,
@@ -235,14 +235,16 @@ async function createFromTemplate({
     }
   } catch (e) {
     if (e instanceof Error) {
-      logger.error(e.message);
+      logger.error(
+        'Installing pods failed. This doesn\'t affect project initialization and you can safely proceed. \nHowever, you will need to install pods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n',
+      );
     }
     loader.fail();
-    automaticPodsInstallation = false;
+    didInstallPods = false;
   } finally {
     fs.removeSync(templateSourceDir);
   }
-  return {automaticPodsInstallation};
+  return {didInstallPods};
 }
 
 async function installDependencies({
@@ -367,7 +369,7 @@ export default (async function initialize(
     return;
   }
 
-  const {automaticPodsInstallation} = await createProject(
+  const {didInstallPods} = await createProject(
     projectName,
     directoryName,
     version,
@@ -381,6 +383,6 @@ export default (async function initialize(
   }
 
   printRunInstructions(projectFolder, projectName, {
-    showPodsInstructions: !automaticPodsInstallation,
+    showPodsInstructions: !didInstallPods,
   });
 });

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -49,7 +49,7 @@ function printRunInstructions(
       options.showPodsInstructions
         ? `
     • Install Cocoapods
-      • bundle install
+      • bundle install # you need to run this only once in your project.
       • bundle exec pod install
       • cd ..
     `

--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -13,7 +13,17 @@ import process from 'process';
 import chalk from 'chalk';
 import {logger} from '@react-native-community/cli-tools';
 
-function printRunInstructions(projectDir: string, projectName: string) {
+interface Options {
+  showPodsInstructions?: boolean;
+}
+
+function printRunInstructions(
+  projectDir: string,
+  projectName: string,
+  options: Options = {
+    showPodsInstructions: false,
+  },
+) {
   let iosInstructions = '';
   let desktopInstructions = '';
 
@@ -34,7 +44,18 @@ function printRunInstructions(projectDir: string, projectName: string) {
 
     iosInstructions = `
   ${chalk.cyan(`Run instructions for ${chalk.bold('iOS')}`)}:
-    • cd "${projectDir}" && npx react-native run-ios
+    • cd "${projectDir}${options.showPodsInstructions ? '/ios' : ''}"
+    ${
+      options.showPodsInstructions
+        ? `
+    • Install Cocoapods
+      • bundle install
+      • bundle exec pod install
+      • cd ..
+    `
+        : ''
+    }
+    • npx react-native run-ios
     ${chalk.dim('- or -')}
     • Open ${relativeXcodeProjectPath} in Xcode or run "xed -b ios"
     • Hit the Run button


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This PR aims to: 
1. Add manual cocapods info when installation fails or user chooses "No" when prompted to install
2. Fix CLI exiting the process when cocoapods installation goes wrong

![CleanShot 2023-12-13 at 13 02 36@2x](https://github.com/react-native-community/cli/assets/52801365/8f0b0e97-d318-46f6-962c-7f79620f88be)


Test Plan:
----------

CI Green

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
