### PR TITLE
feat(ios): show simulator version in prompt

### DIFF
--- a/packages/cli-platform-ios/src/tools/prompts.ts
+++ b/packages/cli-platform-ios/src/tools/prompts.ts
@@ -43,15 +43,22 @@ export async function promptForDeviceSelection(
     message: 'Select the device you want to use',
     choices: availableDevices
       .filter((d) => d.type === 'device' || d.type === 'simulator')
-      .map((d) => ({
-        title: `${chalk.bold(d.name)} ${
+      .map((d) => {
+        const version = d.version
+          ? ` (${d.version.match(/^(\d+\.\d+)/)?.[1]})`
+          : '';
+
+        const availability =
           !d.isAvailable && !!d.availabilityError
             ? chalk.red(`(unavailable - ${d.availabilityError})`)
-            : ''
-        }`,
-        value: d,
-        disabled: !d.isAvailable,
-      })),
+            : '';
+
+        return {
+          title: `${chalk.bold(`${d.name}${version}`)} ${availability}`,
+          value: d,
+          disabled: !d.isAvailable,
+        };
+      }),
     min: 1,
   });
   return device;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Sometimes when user has installed few iOS version, it might be helpful to show simulator version to allow them to pick right one to run.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --list-devices 
```
3. Should list simulators with iOS versions

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
