### PR TITLE
chore(init): remove error when Git initialisation failed

### DIFF
--- a/packages/cli/src/commands/init/createGitRepository.ts
+++ b/packages/cli/src/commands/init/createGitRepository.ts
@@ -56,9 +56,7 @@ const createGitRepository = async (folder: string) => {
     );
     loader.succeed();
   } catch (e) {
-    loader.fail(
-      'Could not create an empty Git repository, see debug logs with --verbose',
-    );
+    loader.stop();
     logger.debug(e as string);
   }
 };

--- a/packages/cli/src/commands/init/createGitRepository.ts
+++ b/packages/cli/src/commands/init/createGitRepository.ts
@@ -57,7 +57,10 @@ const createGitRepository = async (folder: string) => {
     loader.succeed();
   } catch (e) {
     loader.stop();
-    logger.debug(e as string);
+    logger.debug(
+      'Could not create an empty Git repository, error: ',
+      e as string,
+    );
   }
 };
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

It may be confusing when we throw an error while initialising Git repo, let's just don't give any information since isn't not-blocking thing. Reference: https://github.com/react-native-community/cli/issues/2212

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Put `throw new Error('Git commit failed');` on 57th line in `createGitRepository.ts` file.
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
Git repo init loader shouldn't be presented. 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
