### PR TITLE
fix(init): use `yarn` as package manager when calling `init` with `npx`

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -331,16 +331,8 @@ async function createProject(
 function userAgentPackageManager() {
   const userAgent = process.env.npm_config_user_agent;
 
-  if (userAgent) {
-    if (userAgent.startsWith('yarn')) {
-      return 'yarn';
-    }
-    if (userAgent.startsWith('npm')) {
-      return 'npm';
-    }
-    if (userAgent.startsWith('bun')) {
-      return 'bun';
-    }
+  if (userAgent && userAgent.startsWith('bun')) {
+    return 'bun';
   }
 
   return null;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2213, when using `npx` ->  `npm_config_user_agent` is `npm`.

Test Plan:
----------

Not really tested, reverts old behaviour when user has strange setup.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
