### PR TITLE
refactor: extract duplicated code to `getXcodeProjectAndDir`

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import {CLIError} from '@react-native-community/cli-tools';
 import {Config, IOSProjectConfig} from '@react-native-community/cli-types';
 import getArchitecture from '../../tools/getArchitecture';
@@ -8,7 +7,6 @@ import {buildProject} from './buildProject';
 import {getConfiguration} from './getConfiguration';
 import {getXcodeProjectAndDir} from './getXcodeProjectAndDir';
 import {BuilderCommand} from '../../types';
-import findXcodeProject from '../../config/findXcodeProject';
 
 const createBuild =
   ({platformName}: BuilderCommand) =>
@@ -17,8 +15,6 @@ const createBuild =
     if (platform === undefined) {
       throw new CLIError(`Unable to find ${platform} platform config`);
     }
-
-    let {xcodeProject, sourceDir} = getXcodeProjectAndDir(platform);
 
     let installedPods = false;
     if (platform?.automaticPodsInstallation || args.forcePods) {
@@ -34,14 +30,10 @@ const createBuild =
       installedPods = true;
     }
 
-    // if project is freshly created, revisit Xcode project to verify Pods are installed correctly.
-    // This is needed because ctx project is created before Pods are installed, so it might have outdated information.
-    if (installedPods) {
-      const recheckXcodeProject = findXcodeProject(fs.readdirSync(sourceDir));
-      if (recheckXcodeProject) {
-        xcodeProject = recheckXcodeProject;
-      }
-    }
+    let {xcodeProject, sourceDir} = getXcodeProjectAndDir(
+      platform,
+      installedPods,
+    );
 
     process.chdir(sourceDir);
 

--- a/packages/cli-platform-apple/src/commands/buildCommand/getXcodeProjectAndDir.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/getXcodeProjectAndDir.ts
@@ -1,8 +1,11 @@
+import fs from 'fs';
 import {IOSProjectConfig} from '@react-native-community/cli-types';
 import {CLIError} from '@react-native-community/cli-tools';
+import findXcodeProject from '../../config/findXcodeProject';
 
 export function getXcodeProjectAndDir(
   iosProjectConfig: IOSProjectConfig | undefined,
+  installedPods?: boolean,
 ) {
   if (!iosProjectConfig) {
     throw new CLIError(
@@ -10,12 +13,21 @@ export function getXcodeProjectAndDir(
     );
   }
 
-  const {xcodeProject, sourceDir} = iosProjectConfig;
+  let {xcodeProject, sourceDir} = iosProjectConfig;
 
   if (!xcodeProject) {
     throw new CLIError(
       `Could not find Xcode project files in "${sourceDir}" folder`,
     );
+  }
+
+  // if project is freshly created, revisit Xcode project to verify Pods are installed correctly.
+  // This is needed because ctx project is created before Pods are installed, so it might have outdated information.
+  if (installedPods) {
+    const recheckXcodeProject = findXcodeProject(fs.readdirSync(sourceDir));
+    if (recheckXcodeProject) {
+      xcodeProject = recheckXcodeProject;
+    }
   }
 
   return {xcodeProject, sourceDir};

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -18,7 +18,6 @@ import {
   findDevServerPort,
   cacheManager,
 } from '@react-native-community/cli-tools';
-import findXcodeProject from '../../config/findXcodeProject';
 import getArchitecture from '../../tools/getArchitecture';
 import getSimulators from '../../tools/getSimulators';
 import listDevices from '../../tools/listDevices';
@@ -97,16 +96,10 @@ const createRun =
       link.setVersion(ctx.reactNativeVersion);
     }
 
-    let {xcodeProject, sourceDir} = getXcodeProjectAndDir(platform);
-
-    // if project is freshly created, revisit Xcode project to verify Pods are installed correctly.
-    // This is needed because ctx project is created before Pods are installed, so it might have outdated information.
-    if (installedPods) {
-      const recheckXcodeProject = findXcodeProject(fs.readdirSync(sourceDir));
-      if (recheckXcodeProject) {
-        xcodeProject = recheckXcodeProject;
-      }
-    }
+    let {xcodeProject, sourceDir} = getXcodeProjectAndDir(
+      platform,
+      installedPods,
+    );
 
     process.chdir(sourceDir);
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This PR extracts duplicated code to re-check Xcode project between run and build commands, part of #2217 

Test Plan:
----------

CI Green

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
