### PR TITLE
feat: merge buildOptions to runOptions

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
@@ -1,4 +1,5 @@
 import {getDefaultUserTerminal} from '@react-native-community/cli-tools';
+import {buildOptions} from '../buildCommand/buildOptions';
 
 export const runOptions = [
   {
@@ -43,4 +44,5 @@ export const runOptions = [
     name: '--udid <string>',
     description: 'Explicitly set the device to use by UDID',
   },
+  ...buildOptions,
 ];

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  buildOptions,
   createRun,
   runOptions,
 } from '@react-native-community/cli-platform-apple';
@@ -30,5 +29,5 @@ export default {
       cmd: 'npx react-native run-ios --simulator "Apple TV"  --scheme "helloworld-tvOS"',
     },
   ],
-  options: [...buildOptions, ...runOptions],
+  options: runOptions,
 };


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This PR merges buildOptions to runOptions avoiding confusion when creating runCommands

Test Plan:
----------

CI Green

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
