### PR TITLE
feat: warn about multiple podfiles only if provided platform is unsupported

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -36,6 +36,7 @@ const createBuild =
 
     let {xcodeProject, sourceDir} = getXcodeProjectAndDir(
       platform,
+      platformName,
       installedPods,
     );
 

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -17,7 +17,7 @@ const createBuild =
       platformConfig === undefined ||
       supportedPlatforms[platformName] === undefined
     ) {
-      throw new CLIError(`Unable to find ${platformConfig} platform config`);
+      throw new CLIError(`Unable to find ${platformName} platform config`);
     }
 
     let installedPods = false;

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -12,18 +12,18 @@ import {supportedPlatforms} from '../../config/supportedPlatforms';
 const createBuild =
   ({platformName}: BuilderCommand) =>
   async (_: Array<string>, ctx: Config, args: BuildFlags) => {
-    const platform = ctx.project[platformName] as IOSProjectConfig;
+    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
     if (
-      platform === undefined ||
+      platformConfig === undefined ||
       supportedPlatforms[platformName] === undefined
     ) {
-      throw new CLIError(`Unable to find ${platform} platform config`);
+      throw new CLIError(`Unable to find ${platformConfig} platform config`);
     }
 
     let installedPods = false;
-    if (platform?.automaticPodsInstallation || args.forcePods) {
-      const isAppRunningNewArchitecture = platform?.sourceDir
-        ? await getArchitecture(platform?.sourceDir)
+    if (platformConfig?.automaticPodsInstallation || args.forcePods) {
+      const isAppRunningNewArchitecture = platformConfig?.sourceDir
+        ? await getArchitecture(platformConfig?.sourceDir)
         : undefined;
 
       await resolvePods(ctx.root, ctx.dependencies, platformName, {
@@ -35,7 +35,7 @@ const createBuild =
     }
 
     let {xcodeProject, sourceDir} = getXcodeProjectAndDir(
-      platform,
+      platformConfig,
       platformName,
       installedPods,
     );

--- a/packages/cli-platform-apple/src/commands/buildCommand/getXcodeProjectAndDir.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/getXcodeProjectAndDir.ts
@@ -2,14 +2,19 @@ import fs from 'fs';
 import {IOSProjectConfig} from '@react-native-community/cli-types';
 import {CLIError} from '@react-native-community/cli-tools';
 import findXcodeProject from '../../config/findXcodeProject';
+import {getPlatformInfo} from '../runCommand/getPlatformInfo';
+import {ApplePlatform} from '../../types';
 
 export function getXcodeProjectAndDir(
   iosProjectConfig: IOSProjectConfig | undefined,
+  platformName: ApplePlatform,
   installedPods?: boolean,
 ) {
+  const {readableName: platformReadableName} = getPlatformInfo(platformName);
+
   if (!iosProjectConfig) {
     throw new CLIError(
-      'iOS project folder not found. Are you sure this is a React Native project?',
+      `${platformReadableName} project folder not found. Make sure that project.${platformName}.sourceDir points to a directory with your Xcode project and that you are running this command inside of React Native project.`,
     );
   }
 

--- a/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
+++ b/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
@@ -27,7 +27,7 @@ const createLog =
       platformConfig === undefined ||
       supportedPlatforms[platformName] === undefined
     ) {
-      throw new CLIError(`Unable to find ${platformConfig} platform config`);
+      throw new CLIError(`Unable to find ${platformName} platform config`);
     }
 
     // Here we're using two command because first command `xcrun simctl list --json devices` outputs `state` but doesn't return `available`. But second command `xcrun xcdevice list` outputs `available` but doesn't output `state`. So we need to connect outputs of both commands.

--- a/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
+++ b/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
@@ -20,14 +20,14 @@ type Args = {
 const createLog =
   ({platformName}: BuilderCommand) =>
   async (_: Array<string>, ctx: Config, args: Args) => {
-    const platform = ctx.project[platformName] as IOSProjectConfig;
+    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
     const {readableName: platformReadableName} = getPlatformInfo(platformName);
 
     if (
-      platform === undefined ||
+      platformConfig === undefined ||
       supportedPlatforms[platformName] === undefined
     ) {
-      throw new CLIError(`Unable to find ${platform} platform config`);
+      throw new CLIError(`Unable to find ${platformConfig} platform config`);
     }
 
     // Here we're using two command because first command `xcrun simctl list --json devices` outputs `state` but doesn't return `available`. But second command `xcrun xcdevice list` outputs `available` but doesn't output `state`. So we need to connect outputs of both commands.

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -102,6 +102,7 @@ const createRun =
 
     let {xcodeProject, sourceDir} = getXcodeProjectAndDir(
       platform,
+      platformName,
       installedPods,
     );
 

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -51,12 +51,12 @@ const createRun =
   async (_: Array<string>, ctx: Config, args: FlagsT) => {
     // React Native docs assume platform is always ios/android
     link.setPlatform('ios');
-    const platform = ctx.project[platformName] as IOSProjectConfig;
+    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
     const {sdkNames, readableName: platformReadableName} =
       getPlatformInfo(platformName);
 
     if (
-      platform === undefined ||
+      platformConfig === undefined ||
       supportedPlatforms[platformName] === undefined
     ) {
       throw new CLIError(
@@ -67,9 +67,9 @@ const createRun =
     let {packager, port} = args;
     let installedPods = false;
     // check if pods need to be installed
-    if (platform?.automaticPodsInstallation || args.forcePods) {
-      const isAppRunningNewArchitecture = platform?.sourceDir
-        ? await getArchitecture(platform?.sourceDir)
+    if (platformConfig?.automaticPodsInstallation || args.forcePods) {
+      const isAppRunningNewArchitecture = platformConfig?.sourceDir
+        ? await getArchitecture(platformConfig?.sourceDir)
         : undefined;
 
       await resolvePods(ctx.root, ctx.dependencies, platformName, {
@@ -101,7 +101,7 @@ const createRun =
     }
 
     let {xcodeProject, sourceDir} = getXcodeProjectAndDir(
-      platform,
+      platformConfig,
       platformName,
       installedPods,
     );

--- a/packages/cli-platform-apple/src/config/findPodfilePath.ts
+++ b/packages/cli-platform-apple/src/config/findPodfilePath.ts
@@ -10,6 +10,7 @@ import {inlineString, logger} from '@react-native-community/cli-tools';
 import path from 'path';
 import findAllPodfilePaths from './findAllPodfilePaths';
 import {ApplePlatform} from '../types';
+import {supportedPlatforms} from './supportedPlatforms';
 
 // Regexp matching all test projects
 const TEST_PROJECTS = /test|example|sample/i;
@@ -50,8 +51,13 @@ export default function findPodfilePath(
      */
     .sort((project) => (path.dirname(project) === platformName ? -1 : 1));
 
+  const supportedPlatformsArray: string[] = Object.values(supportedPlatforms);
+  const containsOnlySupportedPodfiles = podfiles.every((podfile) =>
+    supportedPlatformsArray.includes(podfile.split('/')[0]),
+  );
+
   if (podfiles.length > 0) {
-    if (podfiles.length > 1) {
+    if (podfiles.length > 1 && !containsOnlySupportedPodfiles) {
       logger.warn(
         inlineString(`
           Multiple Podfiles were found: ${podfiles}. Choosing ${podfiles[0]} automatically.

--- a/packages/cli-platform-apple/src/config/findPodfilePath.ts
+++ b/packages/cli-platform-apple/src/config/findPodfilePath.ts
@@ -52,12 +52,12 @@ export default function findPodfilePath(
     .sort((project) => (path.dirname(project) === platformName ? -1 : 1));
 
   const supportedPlatformsArray: string[] = Object.values(supportedPlatforms);
-  const containsOnlySupportedPodfiles = podfiles.every((podfile) =>
-    supportedPlatformsArray.includes(podfile.split('/')[0]),
+  const containsUnsupportedPodfiles = podfiles.every(
+    (podfile) => !supportedPlatformsArray.includes(podfile.split('/')[0]),
   );
 
   if (podfiles.length > 0) {
-    if (podfiles.length > 1 && !containsOnlySupportedPodfiles) {
+    if (podfiles.length > 1 && containsUnsupportedPodfiles) {
       logger.warn(
         inlineString(`
           Multiple Podfiles were found: ${podfiles}. Choosing ${podfiles[0]} automatically.


### PR DESCRIPTION
Summary:
---------

This PR warns about multiple podfiles only if user is using an unsupported platform directory (for example: `native-ios-folder` for ios root). 

It also provides a useful error message when user overrides the sourceDir for given platform. For example:

For this `react-native.config.js`: 

```
module.exports = {
  project: {
    visionos: {
      sourceDir: './not-exist',
    },
  },
};
```

We show this error: 

![CleanShot 2023-12-20 at 16 39 41@2x](https://github.com/react-native-community/cli/assets/52801365/2ec55d76-cbb4-4ff0-bf40-bc625835fb97)


Test Plan:
----------

Init multi-platform project and check if the warning is there

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
