### PR TITLE
chore: move devices prompt to `prompts.ts`

### DIFF
--- a/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
+++ b/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
@@ -1,4 +1,4 @@
-import {CLIError, logger, prompt} from '@react-native-community/cli-tools';
+import {CLIError, logger} from '@react-native-community/cli-tools';
 import {Config, IOSProjectConfig} from '@react-native-community/cli-types';
 import {spawnSync} from 'child_process';
 import os from 'os';
@@ -8,6 +8,7 @@ import listDevices from '../../tools/listDevices';
 import {getPlatformInfo} from '../runCommand/getPlatformInfo';
 import {BuilderCommand} from '../../types';
 import {supportedPlatforms} from '../../config/supportedPlatforms';
+import {promptForDeviceToTailLogs} from '../../tools/prompts';
 
 /**
  * Starts Apple device syslog tail
@@ -64,15 +65,10 @@ const createLog =
     }
 
     if (args.interactive && bootedAndAvailableSimulators.length > 1) {
-      const {udid} = await prompt({
-        type: 'select',
-        name: 'udid',
-        message: `Select ${platformReadableName} simulators to tail logs from`,
-        choices: bootedAndAvailableSimulators.map((simulator) => ({
-          title: simulator.name,
-          value: simulator.udid,
-        })),
-      });
+      const udid = await promptForDeviceToTailLogs(
+        platformReadableName,
+        bootedAndAvailableSimulators,
+      );
 
       tailDeviceLogs(udid);
     } else {

--- a/packages/cli-platform-apple/src/tools/prompts.ts
+++ b/packages/cli-platform-apple/src/tools/prompts.ts
@@ -2,6 +2,10 @@ import chalk from 'chalk';
 import {Device} from '../types';
 import {prompt} from '@react-native-community/cli-tools';
 
+function getVersionFromDevice({version}: Device) {
+  return version ? ` (${version.match(/^(\d+\.\d+)/)?.[1]})` : '';
+}
+
 export async function promptForSchemeSelection(
   schemes: string[],
 ): Promise<string> {
@@ -57,17 +61,15 @@ export async function promptForDeviceSelection(
     choices: sortedDevices
       .filter(({type}) => type === 'device' || type === 'simulator')
       .map((d) => {
-        const version = d.version
-          ? ` (${d.version.match(/^(\d+\.\d+)/)?.[1]})`
-          : '';
-
         const availability =
           !d.isAvailable && !!d.availabilityError
             ? chalk.red(`(unavailable - ${d.availabilityError})`)
             : '';
 
         return {
-          title: `${chalk.bold(`${d.name}${version}`)} ${availability}`,
+          title: `${chalk.bold(
+            `${d.name}${getVersionFromDevice(d)}`,
+          )} ${availability}`,
           value: d,
           disabled: !d.isAvailable,
         };
@@ -85,16 +87,10 @@ export async function promptForDeviceToTailLogs(
     type: 'select',
     name: 'udid',
     message: `Select ${platformReadableName} simulators to tail logs from`,
-    choices: simulators.map((simulator) => {
-      const version = simulator.version
-        ? ` (${simulator.version.match(/^(\d+\.\d+)/)?.[1]})`
-        : '';
-
-      return {
-        title: `${simulator.name}${version}`.trim(),
-        value: simulator.udid,
-      };
-    }),
+    choices: simulators.map((simulator) => ({
+      title: `${simulator.name}${getVersionFromDevice(simulator)}`.trim(),
+      value: simulator.udid,
+    })),
   });
 
   return udid;

--- a/packages/cli-platform-apple/src/tools/prompts.ts
+++ b/packages/cli-platform-apple/src/tools/prompts.ts
@@ -76,3 +76,20 @@ export async function promptForDeviceSelection(
   });
   return device;
 }
+
+export async function promptForDeviceToTailLogs(
+  platformReadableName: string,
+  simulators: Device[],
+): Promise<string> {
+  const {udid} = await prompt({
+    type: 'select',
+    name: 'udid',
+    message: `Select ${platformReadableName} simulators to tail logs from`,
+    choices: simulators.map((simulator) => ({
+      title: simulator.name,
+      value: simulator.udid,
+    })),
+  });
+
+  return udid;
+}

--- a/packages/cli-platform-apple/src/tools/prompts.ts
+++ b/packages/cli-platform-apple/src/tools/prompts.ts
@@ -85,10 +85,16 @@ export async function promptForDeviceToTailLogs(
     type: 'select',
     name: 'udid',
     message: `Select ${platformReadableName} simulators to tail logs from`,
-    choices: simulators.map((simulator) => ({
-      title: simulator.name,
-      value: simulator.udid,
-    })),
+    choices: simulators.map((simulator) => {
+      const version = simulator.version
+        ? ` (${simulator.version.match(/^(\d+\.\d+)/)?.[1]})`
+        : '';
+
+      return {
+        title: `${simulator.name}${version}`.trim(),
+        value: simulator.udid,
+      };
+    }),
   });
 
   return udid;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Related https://github.com/react-native-community/cli/issues/2217

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Start few simulators
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js log-ios --interactive
```
Works as before. 
