### PR TITLE
fix: only run app on booted and available devices

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -230,7 +230,7 @@ const createRun =
 
       logger.info(`Found booted ${booted.map(({name}) => name).join(', ')}`);
 
-      for (const device of devices) {
+      for (const device of bootedDevices) {
         await runOnDevice(
           device,
           platformName,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Regression implemented https://github.com/react-native-community/cli/pull/2208

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```
3. Should only run on devices once it booted and available. 


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
