### PR TITLE
feat: convert command options and dependencyConfig into getters

### DIFF
--- a/packages/cli-platform-apple/README.md
+++ b/packages/cli-platform-apple/README.md
@@ -18,7 +18,7 @@ Inside of `<oot-platform>/packages/react-native/react-native.config.js`:
 
 ```js
 const {
-  buildOptions,
+  getBuildOptions,
   createBuild,
 } = require('@react-native-community/cli-platform-apple');
 
@@ -32,11 +32,29 @@ const buildVisionOS = {
       cmd: 'npx react-native build-visionos --mode "Release"',
     },
   ],
-  options: buildOptions,
+  options: getBuildOptions({platformName: 'visionos'}),
 };
 
 module.exports = {
   commands: [buildVisionOS], // <- Add command here
   //..
 };
+```
+
+`cli-platform-apple` also exports utilities to create OOT platform config.
+
+- `getProjectConfig()` - creates project config for given platform
+- `getDependencyConfg()` - creates dependency config for given platform
+
+Example (`<oot-platform>/packages/react-native/react-native.config.js`):
+
+```js
+platforms: {
+    visionos: {
+      npmPackageName: '@callstack/react-native-visionos',
+      projectConfig: getProjectConfig({platformName: 'visionos'}),
+      dependencyConfig: getDependencyConfg({platformName: 'visionos'}),
+    },
+    ..
+  },
 ```

--- a/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
@@ -1,3 +1,6 @@
+import {BuilderCommand} from '../../types';
+import {getPlatformInfo} from '../runCommand/getPlatformInfo';
+
 export type BuildFlags = {
   mode?: string;
   target?: string;
@@ -11,49 +14,51 @@ export type BuildFlags = {
   forcePods?: boolean;
 };
 
-export const buildOptions = [
-  {
-    name: '--mode <string>',
-    description:
-      'Explicitly set the scheme configuration to use. This option is case sensitive.',
-  },
-  {
-    name: '--scheme <string>',
-    description: 'Explicitly set Xcode scheme to use',
-  },
-  {
-    name: '--destination <string>',
-    description: 'Explicitly extend destination e.g. "arch=x86_64"',
-  },
-  {
-    name: '--verbose',
-    description: 'Do not use xcbeautify or xcpretty even if installed',
-  },
-  {
-    name: '--xcconfig [string]',
-    description: 'Explicitly set xcconfig to use',
-  },
-  {
-    name: '--buildFolder <string>',
-    description:
-      'Location for iOS build artifacts. Corresponds to Xcode\'s "-derivedDataPath".',
-  },
-  {
-    name: '--extra-params <string>',
-    description: 'Custom params that will be passed to xcodebuild command.',
-    parse: (val: string) => val.split(' '),
-  },
-  {
-    name: '--target <string>',
-    description: 'Explicitly set Xcode target to use.',
-  },
-  {
-    name: '--interactive',
-    description:
-      'Explicitly select which scheme and configuration to use before running a build',
-  },
-  {
-    name: '--force-pods',
-    description: 'Force CocoaPods installation',
-  },
-];
+export const getBuildOptions = ({platformName}: BuilderCommand) => {
+  const {readableName} = getPlatformInfo(platformName);
+  return [
+    {
+      name: '--mode <string>',
+      description:
+        'Explicitly set the scheme configuration to use. This option is case sensitive.',
+    },
+    {
+      name: '--scheme <string>',
+      description: 'Explicitly set Xcode scheme to use',
+    },
+    {
+      name: '--destination <string>',
+      description: 'Explicitly extend destination e.g. "arch=x86_64"',
+    },
+    {
+      name: '--verbose',
+      description: 'Do not use xcbeautify or xcpretty even if installed',
+    },
+    {
+      name: '--xcconfig [string]',
+      description: 'Explicitly set xcconfig to use',
+    },
+    {
+      name: '--buildFolder <string>',
+      description: `Location for ${readableName} build artifacts. Corresponds to Xcode's "-derivedDataPath".`,
+    },
+    {
+      name: '--extra-params <string>',
+      description: 'Custom params that will be passed to xcodebuild command.',
+      parse: (val: string) => val.split(' '),
+    },
+    {
+      name: '--target <string>',
+      description: 'Explicitly set Xcode target to use.',
+    },
+    {
+      name: '--interactive',
+      description:
+        'Explicitly select which scheme and configuration to use before running a build',
+    },
+    {
+      name: '--force-pods',
+      description: 'Force CocoaPods installation',
+    },
+  ];
+};

--- a/packages/cli-platform-apple/src/commands/logCommand/logOptions.ts
+++ b/packages/cli-platform-apple/src/commands/logCommand/logOptions.ts
@@ -1,4 +1,6 @@
-export const logOptions = [
+import {BuilderCommand} from '../../types';
+
+export const getLogOptions = ({}: BuilderCommand) => [
   {
     name: '--interactive',
     description:

--- a/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
@@ -1,48 +1,53 @@
 import {getDefaultUserTerminal} from '@react-native-community/cli-tools';
-import {buildOptions} from '../buildCommand/buildOptions';
+import {BuilderCommand} from '../../types';
+import {getPlatformInfo} from './getPlatformInfo';
+import {getBuildOptions} from '../buildCommand/buildOptions';
 
-export const runOptions = [
-  {
-    name: '--no-packager',
-    description: 'Do not launch packager while running the app',
-  },
-  {
-    name: '--port <number>',
-    default: process.env.RCT_METRO_PORT || 8081,
-    parse: Number,
-  },
-  {
-    name: '--terminal <string>',
-    description:
-      'Launches the Metro Bundler in a new window using the specified terminal path.',
-    default: getDefaultUserTerminal(),
-  },
-  {
-    name: '--binary-path <string>',
-    description:
-      'Path relative to project root where pre-built .app binary lives.',
-  },
-  {
-    name: '--list-devices',
-    description:
-      'List all available iOS devices and simulators and let you choose one to run the app. ',
-  },
-  {
-    name: '--simulator <string>',
-    description:
-      'Explicitly set the simulator to use. Optionally set the iOS version ' +
-      'between parentheses at the end to match an exact version: ' +
-      '"iPhone 15 (17.0)"',
-  },
-  {
-    name: '--device <string>',
-    description:
-      'Explicitly set the device to use by name. The value is not required ' +
-      'if you have a single device connected.',
-  },
-  {
-    name: '--udid <string>',
-    description: 'Explicitly set the device to use by UDID',
-  },
-  ...buildOptions,
-];
+export const getRunOptions = ({platformName}: BuilderCommand) => {
+  const {readableName} = getPlatformInfo(platformName);
+  const isMac = platformName === 'macos';
+  return [
+    {
+      name: '--no-packager',
+      description: 'Do not launch packager while running the app',
+    },
+    {
+      name: '--port <number>',
+      default: process.env.RCT_METRO_PORT || 8081,
+      parse: Number,
+    },
+    {
+      name: '--terminal <string>',
+      description:
+        'Launches the Metro Bundler in a new window using the specified terminal path.',
+      default: getDefaultUserTerminal(),
+    },
+    {
+      name: '--binary-path <string>',
+      description:
+        'Path relative to project root where pre-built .app binary lives.',
+    },
+    {
+      name: '--list-devices',
+      description: `List all available ${readableName} devices and simulators and let you choose one to run the app. `,
+    },
+    {
+      name: '--udid <string>',
+      description: 'Explicitly set the device to use by UDID',
+    },
+    !isMac && {
+      name: '--simulator <string>',
+      description:
+        `Explicitly set the simulator to use. Optionally set the ${readableName} version ` +
+        'between parentheses at the end to match an exact version: ' +
+        '"iPhone 15 (17.0)"',
+    },
+    !isMac && {
+      name: '--device <string>',
+      description:
+        'Explicitly set the device to use by name. The value is not required ' +
+        'if you have a single device connected.',
+    },
+    ...getBuildOptions({platformName}),
+  ];
+};

--- a/packages/cli-platform-apple/src/config/index.ts
+++ b/packages/cli-platform-apple/src/config/index.ts
@@ -55,42 +55,47 @@ export const getProjectConfig =
     };
   };
 
-export function dependencyConfig(
-  folder: string,
-  userConfig: IOSDependencyParams | null = {},
-): IOSDependencyConfig | null {
-  if (userConfig === null) {
-    return null;
-  }
-
-  const podspecPath = findPodspec(folder);
-
-  if (!podspecPath) {
-    return null;
-  }
-
-  let version = 'unresolved';
-
-  try {
-    const packageJson = require(path.join(folder, 'package.json'));
-
-    if (packageJson.version) {
-      version = packageJson.version;
+/**
+ * Make getDependencyConfig follow the same pattern as getProjectConfig
+ */
+export const getDependencyConfig =
+  ({}: BuilderCommand) =>
+  (
+    folder: string,
+    userConfig: IOSDependencyParams | null = {},
+  ): IOSDependencyConfig | null => {
+    if (userConfig === null) {
+      return null;
     }
-  } catch {
-    throw new CLIError(
-      `Failed to locate package.json file from ${chalk.underline(
-        folder,
-      )}. This is most likely issue with your node_modules folder being corrupted. Please force install dependencies and try again`,
-    );
-  }
 
-  return {
-    podspecPath,
-    version,
-    configurations: userConfig.configurations || [],
-    scriptPhases: userConfig.scriptPhases || [],
+    const podspecPath = findPodspec(folder);
+
+    if (!podspecPath) {
+      return null;
+    }
+
+    let version = 'unresolved';
+
+    try {
+      const packageJson = require(path.join(folder, 'package.json'));
+
+      if (packageJson.version) {
+        version = packageJson.version;
+      }
+    } catch {
+      throw new CLIError(
+        `Failed to locate package.json file from ${chalk.underline(
+          folder,
+        )}. This is most likely issue with your node_modules folder being corrupted. Please force install dependencies and try again`,
+      );
+    }
+
+    return {
+      podspecPath,
+      version,
+      configurations: userConfig.configurations || [],
+      scriptPhases: userConfig.scriptPhases || [],
+    };
   };
-}
 
 export const findPodfilePaths = findAllPodfilePaths;

--- a/packages/cli-platform-apple/src/index.ts
+++ b/packages/cli-platform-apple/src/index.ts
@@ -1,8 +1,12 @@
-export {dependencyConfig, getProjectConfig, findPodfilePaths} from './config';
+export {
+  getDependencyConfig,
+  getProjectConfig,
+  findPodfilePaths,
+} from './config';
 
-export {buildOptions} from './commands/buildCommand/buildOptions';
-export {logOptions} from './commands/logCommand/logOptions';
-export {runOptions} from './commands/runCommand/runOptions';
+export {getBuildOptions} from './commands/buildCommand/buildOptions';
+export {getLogOptions} from './commands/logCommand/logOptions';
+export {getRunOptions} from './commands/runCommand/runOptions';
 
 export {default as createBuild} from './commands/buildCommand/createBuild';
 export {default as createLog} from './commands/logCommand/createLog';

--- a/packages/cli-platform-ios/src/commands/buildIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/buildIOS/index.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  buildOptions,
+  getBuildOptions,
   createBuild,
 } from '@react-native-community/cli-platform-apple';
 
@@ -21,5 +21,5 @@ export default {
       cmd: 'npx react-native build-ios --mode "Release"',
     },
   ],
-  options: buildOptions,
+  options: getBuildOptions({platformName: 'ios'}),
 };

--- a/packages/cli-platform-ios/src/commands/logIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/logIOS/index.ts
@@ -8,12 +8,12 @@
 
 import {
   createLog,
-  logOptions,
+  getLogOptions,
 } from '@react-native-community/cli-platform-apple';
 
 export default {
   name: 'log-ios',
   description: 'starts iOS device syslog tail',
   func: createLog({platformName: 'ios'}),
-  options: logOptions,
+  options: getLogOptions({platformName: 'ios'}),
 };

--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -8,7 +8,7 @@
 
 import {
   createRun,
-  runOptions,
+  getRunOptions,
 } from '@react-native-community/cli-platform-apple';
 
 export default {
@@ -29,5 +29,5 @@ export default {
       cmd: 'npx react-native run-ios --simulator "Apple TV"  --scheme "helloworld-tvOS"',
     },
   ],
-  options: runOptions,
+  options: getRunOptions({platformName: 'ios'}),
 };

--- a/packages/cli-platform-ios/src/config/index.ts
+++ b/packages/cli-platform-ios/src/config/index.ts
@@ -1,4 +1,7 @@
-import {getProjectConfig} from '@react-native-community/cli-platform-apple';
+import {
+  getDependencyConfig,
+  getProjectConfig,
+} from '@react-native-community/cli-platform-apple';
 
-export {dependencyConfig} from '@react-native-community/cli-platform-apple';
+export const dependencyConfig = getDependencyConfig({platformName: 'ios'});
 export const projectConfig = getProjectConfig({platformName: 'ios'});


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This PR converts buildOptions and runOptions to follow the same builder pattern. That way we can remove irrelevant platform options and stick to a consistent pattern. 

Dependency config is now also a builder for consistent usage. Example of `run-visionos --help`: 

![CleanShot 2023-12-21 at 10 11 50@2x](https://github.com/react-native-community/cli/assets/52801365/150a1d59-65e6-4848-b354-e129eca21e77)

Test Plan:
----------

Test --help command 

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
