### PR TITLE
feat: allow overriding commands from `react-native.config.js`

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -27,6 +27,8 @@ At the startup, React Native CLI reads configuration from all dependencies liste
 
 At the end, an array of commands concatenated from all plugins is passed on to the CLI to be loaded after built-in commands.
 
+Also, you can provide your own configuration by creating a `react-native.config.js` file in the root of the project, which overrides the configuration from plugins.
+
 > See [`healthChecks`](./healthChecks.md) for information on how plugins can provide additional health checks for `npx react-native doctor`.
 
 ## Command interface

--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -1,12 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`command specified in root config should overwrite command in "react-native-foo" and "react-native-bar" packages 1`] = `
-Array [
-  Object {
-    "description": "Custom option",
-    "name": "--option",
-  },
-]
+Object {
+  "func": [Function],
+  "name": "foo-command",
+  "options": Array [
+    Object {
+      "description": "Custom option",
+      "name": "--option",
+    },
+  ],
+}
 `;
 
 exports[`should apply build types from dependency config 1`] = `

--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -35,11 +35,11 @@ exports[`should load commands from "react-native-foo" and "react-native-bar" pac
 Array [
   Object {
     "func": [Function],
-    "name": "foo-command",
+    "name": "bar-command",
   },
   Object {
     "func": [Function],
-    "name": "bar-command",
+    "name": "foo-command",
   },
 ]
 `;

--- a/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
+++ b/packages/cli-config/src/__tests__/__snapshots__/index-test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`command specified in root config should overwrite command in "react-native-foo" and "react-native-bar" packages 1`] = `
+Array [
+  Object {
+    "description": "Custom option",
+    "name": "--option",
+  },
+]
+`;
+
 exports[`should apply build types from dependency config 1`] = `
 Object {
   "name": "react-native-test",
@@ -40,6 +49,12 @@ Array [
   Object {
     "func": [Function],
     "name": "foo-command",
+    "options": Array [
+      Object {
+        "description": "Custom option",
+        "name": "--option",
+      },
+    ],
   },
 ]
 `;

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -178,7 +178,7 @@ test('command specified in root config should overwrite command in "react-native
   const commandIndex = commandsNames.indexOf('foo-command');
 
   expect(commands[commandIndex].options).not.toBeNull();
-  expect(commands[commandIndex].options).toMatchSnapshot();
+  expect(commands[commandIndex]).toMatchSnapshot();
 });
 
 test('should merge project configuration with default values', () => {

--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -128,6 +128,59 @@ test('should read a config of a dependency and use it to load other settings', (
   ).toMatchSnapshot();
 });
 
+test('command specified in root config should overwrite command in "react-native-foo" and "react-native-bar" packages', () => {
+  DIR = getTempDirectory('config_test_packages');
+  writeFiles(DIR, {
+    'node_modules/react-native-foo/package.json': '{}',
+    'node_modules/react-native-foo/react-native.config.js': `module.exports = {
+      commands: [
+        {
+          name: 'foo-command',
+          func: () => console.log('foo')
+        }
+      ]
+    }`,
+    'node_modules/react-native-bar/package.json': '{}',
+    'node_modules/react-native-bar/react-native.config.js': `module.exports = {
+      commands: [
+        {
+          name: 'bar-command',
+          func: () => console.log('bar')
+        }
+      ]
+    }`,
+    'package.json': `{
+      "dependencies": {
+        "react-native-foo": "0.0.1",
+        "react-native-bar": "0.0.1"
+      }
+    }`,
+    'react-native.config.js': `module.exports = {
+      reactNativePath: '.',
+      commands: [
+        {
+          name: 'foo-command',
+          func: () => {
+            console.log('overridden foo command');
+          },
+          options: [
+            {
+              name: '--option',
+              description: 'Custom option',
+            },
+          ],
+        },
+      ],
+    };`,
+  });
+  const {commands} = loadConfig(DIR);
+  const commandsNames = commands.map(({name}) => name);
+  const commandIndex = commandsNames.indexOf('foo-command');
+
+  expect(commands[commandIndex].options).not.toBeNull();
+  expect(commands[commandIndex].options).toMatchSnapshot();
+});
+
 test('should merge project configuration with default values', () => {
   DIR = getTempDirectory('config_test_merge');
   writeFiles(DIR, {

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -143,7 +143,7 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
             );
           },
         }),
-        commands: [...acc.commands, ...config.commands],
+        commands: [...config.commands, ...acc.commands],
         platforms: {
           ...acc.platforms,
           ...config.platforms,

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -5,6 +5,7 @@ import {
   DependencyConfig,
   UserConfig,
   Config,
+  Command,
 } from '@react-native-community/cli-types';
 import {
   findProjectRoot,
@@ -71,6 +72,16 @@ function getReactNativeVersion(reactNativePath: string) {
   }
   return 'unknown';
 }
+
+const removeDuplicateCommands = <T extends boolean>(commands: Command<T>[]) => {
+  const uniqueCommandsMap = new Map();
+
+  commands.forEach((command) => {
+    uniqueCommandsMap.set(command.name, command);
+  });
+
+  return Array.from(uniqueCommandsMap.values());
+};
 
 /**
  * Loads CLI configuration
@@ -143,7 +154,10 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
             );
           },
         }),
-        commands: [...config.commands, ...acc.commands],
+        commands: removeDuplicateCommands([
+          ...config.commands,
+          ...acc.commands,
+        ]),
         platforms: {
           ...acc.platforms,
           ...config.platforms,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Closes https://github.com/react-native-community/cli/issues/2227, from now commands added inside `react-native.config.js` will override existing ones.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create`react-native.config.js` file with following content:
```js
module.exports = {
  commands: [
    {
      name: 'start',
      func: () => {
        console.log('hello!');
      },
    },
  ],
};
```
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js start
```
4. Command should be replaced ✅



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
