### PR TITLE
Update `getLatestRelease.ts` to use `currentVersion` in `diffUrl`

### DIFF
--- a/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
@@ -76,7 +76,7 @@ export default async function getLatestRelease(
         stable,
         candidate,
         changelogUrl: buildChangelogUrl(stable),
-        diffUrl: buildDiffUrl(stable),
+        diffUrl: buildDiffUrl(currentVersion),
       };
     }
   } catch (e) {


### PR DESCRIPTION


Summary:
---------

As per https://github.com/react-native-community/cli/commit/5774e6adbf532e940c35a11aa78be2108509f74b#r135571193 I think a copy-paste error happened while refactoring this code. This is the current output printed by the `printNewRelease` function:

```
info React Native v0.73.1 is now available (your project is running on v0.73.0).
info Changelog: https://github.com/facebook/react-native/releases/tag/v0.73.1
info Diff: https://react-native-community.github.io/upgrade-helper/?from=0.73.1
info For more info, check out "https://reactnative.dev/docs/upgrading?os=macos".
```

Note how the `from` query param of the diff URL uses the stable version instead of the current.

This is the code prior to the commit that introduced the issue:

https://github.com/react-native-community/cli/blob/78a1742cfb0466e8e4e826da09e83e506dddb725/packages/cli-tools/src/releaseChecker/getLatestRelease.ts#L62

Test Plan:
----------

This is a simple change, which I applied locally to test it.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
