### PR TITLE
feat: fallback to OOT scheme

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -46,6 +46,7 @@ const createBuild =
       xcodeProject,
       sourceDir,
       args,
+      platformName,
     );
 
     return buildProject(

--- a/packages/cli-platform-apple/src/commands/buildCommand/getConfiguration.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/getConfiguration.ts
@@ -28,7 +28,7 @@ export async function getConfiguration(
 
   if (!info?.schemes?.includes(scheme)) {
     const {readableName} = getPlatformInfo(platformName);
-    const fallbackScheme = `${scheme}-${readableName}`
+    const fallbackScheme = `${scheme}-${readableName}`;
 
     if (info?.schemes?.includes(fallbackScheme)) {
       logger.warn(

--- a/packages/cli-platform-apple/src/commands/buildCommand/getConfiguration.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/getConfiguration.ts
@@ -28,7 +28,7 @@ export async function getConfiguration(
 
   if (!info?.schemes?.includes(scheme)) {
     const {readableName} = getPlatformInfo(platformName);
-    const fallbackScheme = scheme + '-' + readableName;
+    const fallbackScheme = `${scheme}-${readableName}`
 
     if (info?.schemes?.includes(fallbackScheme)) {
       logger.warn(

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -124,6 +124,7 @@ const createRun =
       xcodeProject,
       sourceDir,
       args,
+      platformName,
     );
 
     if (platformName === 'macos') {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

When building app for macOS a scheme looks like this `AppName-macOS`. Inside `run-macos` implemention in `react-native-macos` repo [it's hardcoded assumption](https://github.com/microsoft/react-native-macos/blob/164469a0c424b8a6710b9f9b0d6f761ba289cec4/packages/react-native/local-cli/runMacOS/runMacOS.js#L61). I think we can also support this, so if the default one is not accessible, let's give a warning and fallback to one with the suffix. 



Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Follow steps described [here](https://github.com/react-native-community/cli/blob/main/packages/cli-platform-apple/README.md) to add OOT platform e.g. inside `react-native-macos`
3. Run this command inside app that is using OOT platform:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-macos
```
4. Fallback scheme should be selected, so in this case `ProjectName-macOS`



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
