### PR TITLE
refactor(cli-platform-apple): move installing and launching app logic to separate function

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
@@ -1,8 +1,9 @@
 import {CLIError} from '@react-native-community/cli-tools';
 import path from 'path';
+import {BuildSettings} from './getBuildSettings';
 
 export async function getBuildPath(
-  buildSettings: any,
+  buildSettings: BuildSettings,
   isCatalyst: boolean = false,
 ) {
   const targetBuildDir = buildSettings.TARGET_BUILD_DIR;

--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
@@ -1,38 +1,13 @@
-import child_process from 'child_process';
-import {IOSProjectInfo} from '@react-native-community/cli-types';
-import {CLIError, logger} from '@react-native-community/cli-tools';
-import chalk from 'chalk';
+import {CLIError} from '@react-native-community/cli-tools';
+import path from 'path';
 
 export async function getBuildPath(
-  xcodeProject: IOSProjectInfo,
-  mode: string,
-  buildOutput: string,
-  scheme: string,
-  target: string | undefined,
+  buildSettings: any,
   isCatalyst: boolean = false,
 ) {
-  const buildSettings = child_process.execFileSync(
-    'xcodebuild',
-    [
-      xcodeProject.isWorkspace ? '-workspace' : '-project',
-      xcodeProject.name,
-      '-scheme',
-      scheme,
-      '-sdk',
-      getPlatformName(buildOutput),
-      '-configuration',
-      mode,
-      '-showBuildSettings',
-      '-json',
-    ],
-    {encoding: 'utf8'},
-  );
-
-  const {targetBuildDir, executableFolderPath} = await getTargetPaths(
-    buildSettings,
-    scheme,
-    target,
-  );
+  const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
+  const executableFolderPath = buildSettings.EXECUTABLE_FOLDER_PATH;
+  const fullProductName = buildSettings.FULL_PRODUCT_NAME;
 
   if (!targetBuildDir) {
     throw new CLIError('Failed to get the target build directory.');
@@ -42,63 +17,13 @@ export async function getBuildPath(
     throw new CLIError('Failed to get the app name.');
   }
 
-  return `${targetBuildDir}${
-    isCatalyst ? '-maccatalyst' : ''
-  }/${executableFolderPath}`;
-}
-
-async function getTargetPaths(
-  buildSettings: string,
-  scheme: string,
-  target: string | undefined,
-) {
-  const settings = JSON.parse(buildSettings);
-
-  const targets = settings.map(
-    ({target: settingsTarget}: any) => settingsTarget,
-  );
-
-  let selectedTarget = targets[0];
-
-  if (target) {
-    if (!targets.includes(target)) {
-      logger.info(
-        `Target ${chalk.bold(target)} not found for scheme ${chalk.bold(
-          scheme,
-        )}, automatically selected target ${chalk.bold(selectedTarget)}`,
-      );
-    } else {
-      selectedTarget = target;
-    }
+  if (!fullProductName) {
+    throw new CLIError('Failed to get product name.');
   }
 
-  // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
-
-  const targetIndex = targets.indexOf(selectedTarget);
-
-  const wrapperExtension =
-    settings[targetIndex].buildSettings.WRAPPER_EXTENSION;
-
-  if (wrapperExtension === 'app') {
-    return {
-      targetBuildDir: settings[targetIndex].buildSettings.TARGET_BUILD_DIR,
-      executableFolderPath:
-        settings[targetIndex].buildSettings.EXECUTABLE_FOLDER_PATH,
-    };
+  if (isCatalyst) {
+    return path.join(targetBuildDir, '-maccatalyst', executableFolderPath);
+  } else {
+    return path.join(targetBuildDir, executableFolderPath);
   }
-
-  return {};
-}
-
-function getPlatformName(buildOutput: string) {
-  // Xcode can sometimes escape `=` with a backslash or put the value in quotes
-  const platformNameMatch = /export PLATFORM_NAME\\?="?(\w+)"?$/m.exec(
-    buildOutput,
-  );
-  if (!platformNameMatch) {
-    throw new CLIError(
-      'Couldn\'t find "PLATFORM_NAME" variable in xcodebuild output. Please report this issue and run your project with Xcode instead.',
-    );
-  }
-  return platformNameMatch[1];
 }

--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
@@ -3,13 +3,20 @@ import {IOSProjectInfo} from '@react-native-community/cli-types';
 import chalk from 'chalk';
 import child_process from 'child_process';
 
+export type BuildSettings = {
+  TARGET_BUILD_DIR: string;
+  INFOPLIST_PATH: string;
+  EXECUTABLE_FOLDER_PATH: string;
+  FULL_PRODUCT_NAME: string;
+};
+
 export async function getBuildSettings(
   xcodeProject: IOSProjectInfo,
   mode: string,
   buildOutput: string,
   scheme: string,
   target?: string,
-) {
+): Promise<BuildSettings | null> {
   const buildSettings = child_process.execFileSync(
     'xcodebuild',
     [

--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
@@ -1,0 +1,74 @@
+import {CLIError, logger} from '@react-native-community/cli-tools';
+import {IOSProjectInfo} from '@react-native-community/cli-types';
+import chalk from 'chalk';
+import child_process from 'child_process';
+
+export async function getBuildSettings(
+  xcodeProject: IOSProjectInfo,
+  mode: string,
+  buildOutput: string,
+  scheme: string,
+  target?: string,
+) {
+  const buildSettings = child_process.execFileSync(
+    'xcodebuild',
+    [
+      xcodeProject.isWorkspace ? '-workspace' : '-project',
+      xcodeProject.name,
+      '-scheme',
+      scheme,
+      '-sdk',
+      getPlatformName(buildOutput),
+      '-configuration',
+      mode,
+      '-showBuildSettings',
+      '-json',
+    ],
+    {encoding: 'utf8'},
+  );
+
+  const settings = JSON.parse(buildSettings);
+
+  const targets = settings.map(
+    ({target: settingsTarget}: any) => settingsTarget,
+  );
+
+  let selectedTarget = targets[0];
+
+  if (target) {
+    if (!targets.includes(target)) {
+      logger.info(
+        `Target ${chalk.bold(target)} not found for scheme ${chalk.bold(
+          scheme,
+        )}, automatically selected target ${chalk.bold(selectedTarget)}`,
+      );
+    } else {
+      selectedTarget = target;
+    }
+  }
+
+  // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
+  const targetIndex = targets.indexOf(selectedTarget);
+  const targetSettings = settings[targetIndex].buildSettings;
+
+  const wrapperExtension = targetSettings.WRAPPER_EXTENSION;
+
+  if (wrapperExtension === 'app') {
+    return settings[targetIndex].buildSettings;
+  }
+
+  return null;
+}
+
+function getPlatformName(buildOutput: string) {
+  // Xcode can sometimes escape `=` with a backslash or put the value in quotes
+  const platformNameMatch = /export PLATFORM_NAME\\?="?(\w+)"?$/m.exec(
+    buildOutput,
+  );
+  if (!platformNameMatch) {
+    throw new CLIError(
+      'Couldn\'t find "PLATFORM_NAME" variable in xcodebuild output. Please report this issue and run your project with Xcode instead.',
+    );
+  }
+  return platformNameMatch[1];
+}

--- a/packages/cli-platform-apple/src/commands/runCommand/installApp.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/installApp.ts
@@ -1,0 +1,101 @@
+import child_process from 'child_process';
+import {CLIError, logger} from '@react-native-community/cli-tools';
+import {IOSProjectInfo} from '@react-native-community/cli-types';
+import chalk from 'chalk';
+import {getBuildPath} from './getBuildPath';
+import {getBuildSettings} from './getBuildSettings';
+import path from 'path';
+
+function handleLaunchResult(
+  success: boolean,
+  errorMessage: string,
+  errorDetails = '',
+) {
+  if (success) {
+    logger.success('Successfully launched the app');
+  } else {
+    logger.error(errorMessage, errorDetails);
+  }
+}
+
+type Options = {
+  buildOutput: any;
+  xcodeProject: IOSProjectInfo;
+  mode: string;
+  scheme: string;
+  target?: string;
+  udid: string;
+  binaryPath?: string;
+};
+
+export default async function installApp({
+  buildOutput,
+  xcodeProject,
+  mode,
+  scheme,
+  target,
+  udid,
+  binaryPath,
+}: Options) {
+  let appPath = binaryPath;
+
+  const buildSettings = await getBuildSettings(
+    xcodeProject,
+    mode,
+    buildOutput,
+    scheme,
+    target,
+  );
+
+  if (!appPath) {
+    appPath = await getBuildPath(buildSettings);
+  }
+
+  const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
+  const infoPlistPath = buildSettings.INFOPLIST_PATH;
+
+  if (!infoPlistPath) {
+    throw new CLIError('Failed to find Info.plist');
+  }
+
+  if (!targetBuildDir) {
+    throw new CLIError('Failed to get target build directory.');
+  }
+
+  logger.info(`Installing "${chalk.bold(appPath)}`);
+
+  if (udid && appPath) {
+    child_process.spawnSync('xcrun', ['simctl', 'install', udid, appPath], {
+      stdio: 'inherit',
+    });
+  }
+
+  const bundleID = child_process
+    .execFileSync(
+      '/usr/libexec/PlistBuddy',
+      [
+        '-c',
+        'Print:CFBundleIdentifier',
+        path.join(targetBuildDir, infoPlistPath),
+      ],
+      {encoding: 'utf8'},
+    )
+    .trim();
+
+  console.log(bundleID);
+
+  logger.info(`Launching "${chalk.bold(bundleID)}"`);
+
+  let result = child_process.spawnSync('xcrun', [
+    'simctl',
+    'launch',
+    udid,
+    bundleID,
+  ]);
+
+  handleLaunchResult(
+    result.status === 0,
+    'Failed to launch the app on simulator',
+    result.stderr.toString(),
+  );
+}

--- a/packages/cli-platform-apple/src/commands/runCommand/installApp.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/installApp.ts
@@ -47,8 +47,16 @@ export default async function installApp({
     target,
   );
 
+  if (!buildSettings) {
+    throw new CLIError('Failed to get build settings for your project');
+  }
+
   if (!appPath) {
     appPath = await getBuildPath(buildSettings);
+  }
+
+  if (!buildSettings) {
+    throw new CLIError('Failed to get build settings for your project');
   }
 
   const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
@@ -81,8 +89,6 @@ export default async function installApp({
       {encoding: 'utf8'},
     )
     .trim();
-
-  console.log(bundleID);
 
   logger.info(`Launching "${chalk.bold(bundleID)}"`);
 

--- a/packages/cli-platform-apple/src/commands/runCommand/runOnDevice.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOnDevice.ts
@@ -53,6 +53,10 @@ export async function runOnDevice(
       scheme,
     );
 
+    if (!buildSettings) {
+      throw new CLIError('Failed to get build settings for your project');
+    }
+
     const appPath = await getBuildPath(buildSettings, true);
     const appProcess = child_process.spawn(`${appPath}/${scheme}`, [], {
       detached: true,
@@ -77,6 +81,10 @@ export async function runOnDevice(
         buildOutput,
         scheme,
       );
+
+      if (!buildSettings) {
+        throw new CLIError('Failed to get build settings for your project');
+      }
 
       appPath = await getBuildPath(buildSettings);
     } else {

--- a/packages/cli-platform-apple/src/commands/runCommand/runOnDevice.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOnDevice.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import {buildProject} from '../buildCommand/buildProject';
 import {getBuildPath} from './getBuildPath';
 import {FlagsT} from './createRun';
+import {getBuildSettings} from './getBuildSettings';
 
 export async function runOnDevice(
   selectedDevice: Device,
@@ -45,14 +46,14 @@ export async function runOnDevice(
       args,
     );
 
-    const appPath = await getBuildPath(
+    const buildSettings = await getBuildSettings(
       xcodeProject,
       mode,
       buildOutput,
       scheme,
-      args.target,
-      true,
     );
+
+    const appPath = await getBuildPath(buildSettings, true);
     const appProcess = child_process.spawn(`${appPath}/${scheme}`, [], {
       detached: true,
       stdio: 'ignore',
@@ -70,13 +71,14 @@ export async function runOnDevice(
         args,
       );
 
-      appPath = await getBuildPath(
+      const buildSettings = await getBuildSettings(
         xcodeProject,
         mode,
         buildOutput,
         scheme,
-        args.target,
       );
+
+      appPath = await getBuildPath(buildSettings);
     } else {
       appPath = args.binaryPath;
     }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Moves installing and launching app logic to separate function, so that adding additional logic for another platforms will be fairly easy.


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```
Works same as before.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
