### PR TITLE
Fix for `run-android` on windows.

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -61,6 +61,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
     );
 
     if (startPackager) {
+      // Awaiting this causes the CLI to hang indefinitely, so this must execute without await.
       startServerInNewWindow(
         newPort,
         config.root,

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -61,7 +61,7 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
     );
 
     if (startPackager) {
-      await startServerInNewWindow(
+      startServerInNewWindow(
         newPort,
         config.root,
         config.reactNativePath,

--- a/packages/cli-tools/src/getDefaultUserTerminal.ts
+++ b/packages/cli-tools/src/getDefaultUserTerminal.ts
@@ -11,6 +11,10 @@ const getDefaultUserTerminal = (): string | undefined => {
     return TERM_PROGRAM;
   }
 
+  if (os.platform() === 'win32') {
+    return 'cmd.exe';
+  }
+
   return TERM;
 };
 

--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -103,7 +103,7 @@ function startServerInNewWindow(
   }
   if (isWindows) {
     // Awaiting this causes the CLI to hang indefinitely, so this must execute without await.
-    return execa('cmd.exe', ['/C', launchPackagerScript], {
+    return execa(terminal, ['/C', launchPackagerScript], {
       ...procConfig,
       detached: true,
       stdio: 'ignore',


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Fixes https://github.com/react-native-community/cli/issues/2219

Fixes `run-android` command on windows.
The issue is reported here - #2219 
Bug was introduced on #2021

Issue is - there is no default terminal defined for windows. In the above mentioned PR - terminal param became mandatory. So it was failing.

It also fixes where it tries to run `startServerInNewWindow` with async call, which causes CLI to hang indefinitely. And the native build never starts.
<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

https://github.com/react-native-community/cli/assets/1908862/e11c1db4-6bac-422d-b9d8-f4d518f07060


<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
