### PR TITLE
Improve Quotation and Path Handling in CLI Tools

### DIFF
--- a/packages/cli-tools/src/launchPackager.command
+++ b/packages/cli-tools/src/launchPackager.command
@@ -3,8 +3,8 @@
 THIS_DIR=$(cd -P "$(dirname "$(readlink "${BASH_SOURCE[0]}" || echo "${BASH_SOURCE[0]}")")" && pwd)
 
 source "$THIS_DIR/.packager.env"
-cd $PROJECT_ROOT
-$REACT_NATIVE_PATH/cli.js start --port $RCT_METRO_PORT
+cd "$PROJECT_ROOT"
+"$REACT_NATIVE_PATH/cli.js" start --port $RCT_METRO_PORT
 
 if [[ -z "$CI" ]]; then
   echo "Process terminated. Press <enter> to close the window"

--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -27,7 +27,7 @@ function startServerInNewWindow(
   const packagerEnvFilename = isWindows ? '.packager.bat' : '.packager.env';
   const packagerEnvFileExportContent = isWindows
     ? `set RCT_METRO_PORT=${port}\nset PROJECT_ROOT=${projectRoot}\nset REACT_NATIVE_PATH=${reactNativePath}`
-    : `export RCT_METRO_PORT=${port}\nexport PROJECT_ROOT=${projectRoot}\nexport REACT_NATIVE_PATH=${reactNativePath}`;
+    : `export RCT_METRO_PORT=${port}\nexport PROJECT_ROOT="${projectRoot}"\nexport REACT_NATIVE_PATH="${reactNativePath}"`;
   const nodeModulesPath = resolveNodeModuleDir(projectRoot, '.bin');
   const cliPluginMetroPath = path.join(
     path.dirname(


### PR DESCRIPTION
This pull request addresses compatibility issues with the 'make run-android' command in various shell environments. The changes ensure consistent behavior across different shells by improving path handling and quoting. Specifically, the modifications in 'launchPackager.command' and 'startServerInNewWindow.ts' include enclosing paths with spaces in double quotes and refining the quoting of variables.