### PR TITLE
refactor: adapt `getSimulators()` for OOT platforms

### DIFF
--- a/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
+++ b/packages/cli-platform-apple/src/commands/logCommand/createLog.ts
@@ -4,9 +4,9 @@ import {spawnSync} from 'child_process';
 import os from 'os';
 import path from 'path';
 import getSimulators from '../../tools/getSimulators';
-import listDevices from '../../tools/listDevices';
+import listDevices, {stripPlatform} from '../../tools/listDevices';
 import {getPlatformInfo} from '../runCommand/getPlatformInfo';
-import {BuilderCommand} from '../../types';
+import {BuilderCommand, Device} from '../../types';
 import {supportedPlatforms} from '../../config/supportedPlatforms';
 import {promptForDeviceToTailLogs} from '../../tools/prompts';
 
@@ -50,12 +50,14 @@ const createLog =
       return;
     }
 
-    const bootedAndAvailableSimulators = bootedSimulators.map((booted) => {
-      const available = availableSimulators.find(
-        ({udid}) => udid === booted.udid,
-      );
-      return {...available, ...booted};
-    });
+    const bootedAndAvailableSimulators = bootedSimulators
+      .map((booted) => {
+        const available = availableSimulators.find(
+          ({udid}) => udid === booted.udid,
+        );
+        return {...available, ...booted};
+      })
+      .filter(({sdk}) => sdk && sdkNames.includes(stripPlatform(sdk)));
 
     if (bootedAndAvailableSimulators.length === 0) {
       logger.error(
@@ -70,21 +72,33 @@ const createLog =
         bootedAndAvailableSimulators,
       );
 
-      tailDeviceLogs(udid);
+      const simulator = bootedAndAvailableSimulators.find(
+        ({udid: deviceUDID}) => deviceUDID === udid,
+      );
+
+      if (!simulator) {
+        throw new CLIError(
+          `Unable to find simulator with udid: ${udid} in booted simulators`,
+        );
+      }
+
+      tailDeviceLogs(simulator);
     } else {
-      tailDeviceLogs(bootedAndAvailableSimulators[0].udid);
+      tailDeviceLogs(bootedAndAvailableSimulators[0]);
     }
   };
 
-function tailDeviceLogs(udid: string) {
+function tailDeviceLogs(device: Device) {
   const logDir = path.join(
     os.homedir(),
     'Library',
     'Logs',
     'CoreSimulator',
-    udid,
+    device.udid,
     'asl',
   );
+
+  logger.info(`Tailing logs for device ${device.name} (${device.udid})`);
 
   const log = spawnSync('syslog', ['-w', '-F', 'std', '-d', logDir], {
     stdio: 'inherit',

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -19,7 +19,6 @@ import {
   cacheManager,
 } from '@react-native-community/cli-tools';
 import getArchitecture from '../../tools/getArchitecture';
-import getSimulators from '../../tools/getSimulators';
 import listDevices from '../../tools/listDevices';
 import resolvePods, {getPackageJson} from '../../tools/pods';
 import {promptForDeviceSelection} from '../../tools/prompts';
@@ -208,12 +207,7 @@ const createRun =
       const bootedDevices = availableDevices.filter(
         ({type}) => type === 'device',
       );
-
-      const simulators = getSimulators();
-      const bootedSimulators = Object.keys(simulators.devices)
-        .map((key) => simulators.devices[key])
-        .reduce((acc, val) => acc.concat(val), [])
-        .filter(({state}) => state === 'Booted');
+      const bootedSimulators = devices.filter(({type}) => type === 'simulator');
 
       const booted = [...bootedDevices, ...bootedSimulators];
       if (booted.length === 0) {

--- a/packages/cli-platform-apple/src/tools/listDevices.ts
+++ b/packages/cli-platform-apple/src/tools/listDevices.ts
@@ -54,7 +54,7 @@ async function listDevices(sdkNames: string[]): Promise<Device[]> {
   return parseXcdeviceList(out, sdkNames);
 }
 
-function stripPlatform(platform: string): string {
+export function stripPlatform(platform: string): string {
   return platform.replace('com.apple.platform.', '');
 }
 


### PR DESCRIPTION
Summary:
---------

This PR removes `getSimulators()` from createRun and adopts them for createLog. I've also added a handful info message from where we are tailing logs from: 

![CleanShot 2024-01-03 at 10 58 50@2x](https://github.com/react-native-community/cli/assets/52801365/96a9a67b-8201-45ed-9233-8447646a55a7)


Test Plan:
----------

Check if returned devices are the same.

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
