### PR TITLE
fix: regression where run was executing multiple times

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -253,6 +253,8 @@ const createRun =
           simulator || fallbackSimulator,
         );
       }
+
+      return;
     }
 
     if (args.device && args.udid) {


### PR DESCRIPTION
Summary:
---------

This PR fixes a regression where builds were executed multiple times because of missing return statement (Introduced during refactor #2208). 

This code before `cli-platform-apple` refactor: https://github.com/react-native-community/cli/blob/3906b900b6a97a234f1f377bb768072d2162292c/packages/cli-platform-ios/src/commands/runIOS/index.ts#L189

Issue screenshot: 

![image](https://github.com/react-native-community/cli/assets/52801365/75e34790-0905-4703-948e-d60eddbd9605)


Test Plan:
----------

1. Run `yarn ios` and check if build happens only once

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
