### PR TITLE
fix(ios): properly pass port to `env` in `xcodebuild`

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/buildProject.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/buildProject.ts
@@ -170,7 +170,7 @@ function getProcessOptions<T extends BuildFlags>(
         : '';
 
     const port =
-      'port' in args && typeof args.port === 'string' ? args.port : '';
+      'port' in args && typeof args.port === 'number' ? String(args.port) : '';
 
     return {
       env: {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2228



When passing `--port` to `run-ios` command it is of type `number`:
https://github.com/react-native-community/cli/blob/0e8cf75bde113f6c0040f61a679882372b53b8b7/packages/cli-platform-apple/src/commands/runCommand/createRun.ts#L44


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --port 8888
```
3. Simulator should connect to a dev server on `8888` port.


https://github.com/react-native-community/cli/assets/63900941/026358cb-c568-4cd6-ac5b-91acbee81947



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
