### PR TITLE
Fix: cleaning metro cache

### DIFF
--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@react-native-community/cli-tools": "13.5.1-alpha.0",
     "chalk": "^4.1.2",
-    "execa": "^5.0.0"
+    "execa": "^5.0.0",
+    "glob": "^7.1.3"
   },
   "files": [
     "build",
@@ -18,8 +19,9 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "13.5.1-alpha.0",
-    "@types/prompts": "^2.4.4"
+   "@react-native-community/cli-types": "13.5.1-alpha.0",
+    "@types/prompts": "^2.4.4",
+    "@types/glob": "^7.1.1"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-clean",
   "repository": {

--- a/packages/cli-clean/src/__tests__/clean.test.ts
+++ b/packages/cli-clean/src/__tests__/clean.test.ts
@@ -1,10 +1,18 @@
 import execa from 'execa';
 import os from 'os';
 import prompts from 'prompts';
-import {clean} from '../clean';
+import {clean, cleanDir} from '../clean';
+import {cleanup, getTempDirectory, writeFiles} from '../../../../jest/helpers';
+import fs from 'fs';
+
+const DIR = getTempDirectory('temp-cache');
 
 jest.mock('execa', () => jest.fn());
 jest.mock('prompts', () => jest.fn());
+
+afterEach(() => {
+  cleanup(DIR);
+});
 
 describe('clean', () => {
   const mockConfig: any = {};
@@ -47,5 +55,26 @@ describe('clean', () => {
       ['watch-del-all'],
       expect.anything(),
     );
+  });
+
+  it('should remove paths defined with patterns', async () => {
+    writeFiles(DIR, {
+      'metro-cache/cache.txt': 'cache file',
+      'metro-zxcvbnm/cache.txt': 'cache file',
+    });
+
+    await cleanDir(`${DIR}/metro-*`);
+
+    expect(fs.readdirSync(DIR)).toEqual([]);
+  });
+
+  it('should remove paths defined without patterns', async () => {
+    writeFiles(DIR, {
+      'metro-cache/cache.txt': 'cache file',
+    });
+
+    await cleanDir(`${DIR}/metro-cache`);
+
+    expect(fs.readdirSync(DIR)).toEqual([]);
   });
 });


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
`fs.rm` function does not expand, so when using `clean` command, Metro files are not removed.

This is a follow-up PR to #2161 which solves this problem for Windows, but since `fs.rm` does not expand at all, it still doesn't work properly for macOS. Removing OS check in this solution does not solve the issue, probably because `convertPathToPattern` from `fast-glob` modifies the pattern from `metro-*` to `metro-\*`. This PR should work correctly on both operating systems.
<!-- Help us understand your motivation by explaining why you decided to make this change: -->

Closes #2161

Test Plan:
----------
1. Find your OS temp directory (`os.tmpdir()`)
2. Use `start` command in any CLI app
3. `ls` in the temp directory to verify any `metro-*` are listed
4. Use `clean` command, select `metro` option and confirm
5. `ls` in the temp directory again and verify all `metro-*` are gone
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
