### PR TITLE
fix: allow users to specify `--device` without value

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
@@ -43,10 +43,10 @@ export const getRunOptions = ({platformName}: BuilderCommand) => {
         '"iPhone 15 (17.0)"',
     },
     !isMac && {
-      name: '--device <string>',
+      name: '--device [string]', // here we're intentionally using [] over <> to make passed value optional to allow users to run only on physical devices
       description:
-        'Explicitly set the device to use by name. The value is not required ' +
-        'if you have a single device connected.',
+        'Explicitly set the device to use by name. If the value is not provided,' +
+        'the app will run on the first available physical device.',
     },
     ...getBuildOptions({platformName}),
   ];


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2262.

In https://github.com/react-native-community/cli/pull/2078 `--device` was accidentally removed, and in https://github.com/react-native-community/cli/pull/2086 the flag was restored, but with a small change where now `--device` flag accept value wrapped `<>` instead of `[]`:
- Current implementation: 
https://github.com/react-native-community/cli/blob/f50cc16bce038808680f55c10d659b94215f1a71/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts#L46
- Old one:
https://github.com/react-native-community/cli/blob/a2eb8c0d605bdc5ad03b20a78d515b2ac7994699/packages/cli-platform-ios/src/commands/buildIOS/index.ts#L227

that caused a regression, because with `<>` value is required, but with `[]` is optional. 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Plug physical device to computer
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --device
```
4.  First physical device should be picked:
```
❯ yarn ios --device
yarn run v1.22.19
$ react-native run-ios --device
info Found Xcode workspace "RN0732.xcworkspace"
info Using first available device named "iPhone Szymon" due to lack of name supplied.
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
