### PR TITLE
feat: Deprecate `unstable_reactLegacyComponentNames`

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -68,7 +68,6 @@ The following settings are available on iOS and Android:
 type IOSProjectParams = {
   sourceDir?: string;
   watchModeCommandParams?: string[];
-  unstable_reactLegacyComponentNames?: string[] | null;
   automaticPodsInstallation?: boolean;
 };
 
@@ -79,7 +78,6 @@ type AndroidProjectParams = {
   packageName?: string;
   dependencyConfiguration?: string;
   watchModeCommandParams?: string[];
-  unstable_reactLegacyComponentNames?: string[] | null;
 };
 ```
 
@@ -94,7 +92,7 @@ Array of strings that will be passed to the `npx react-native run-ios` command w
 
 #### project.ios.unstable_reactLegacyComponentNames
 
-> Note: Only applicable when new architecture is turned on.
+> Note: Deprecated in React Native 0.74. Only applicable when new architecture is turned on.
 
 Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
 hence the `unstable_` prefix.
@@ -103,6 +101,8 @@ An array with a list of Legacy Component Name that you want to be registered wit
 This will allow you to use libraries that haven't been migrated yet on the New Architecture.
 
 The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
+
+Since React Native 0.74, this property is ignored as the Interop Layer is **Automatic**, you don't need to register the Legacy Components anymore and they will be discovered automatically.
 
 #### project.ios.automaticPodsInstallation
 
@@ -141,7 +141,7 @@ Array of strings that will be passed to the `npx react-native run-android` comma
 
 #### project.android.unstable_reactLegacyComponentNames
 
-> Note: Only applicable when new architecture is turned on.
+> Note: Deprecated in React Native 0.74. Only applicable when new architecture is turned on.
 
 Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
 hence the `unstable_` prefix.
@@ -150,6 +150,8 @@ An array with a list of Legacy Component Name that you want to be registered wit
 This will allow you to use libraries that haven't been migrated yet on the New Architecture.
 
 The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
+
+Since React Native 0.74, this property is ignored as the Interop Layer is **Automatic**, you don't need to register the Legacy Components anymore and they will be discovered automatically.
 
 ### platforms
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -92,7 +92,8 @@ Array of strings that will be passed to the `npx react-native run-ios` command w
 
 #### project.ios.unstable_reactLegacyComponentNames
 
-> Note: Deprecated in React Native 0.74. Only applicable when new architecture is turned on.
+> [!CAUTION]
+> Deprecated in React Native 0.74, where this behavior is detected automatically and this config does nothing. You can safely remove it from your project. 
 
 Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
 hence the `unstable_` prefix.
@@ -141,7 +142,8 @@ Array of strings that will be passed to the `npx react-native run-android` comma
 
 #### project.android.unstable_reactLegacyComponentNames
 
-> Note: Deprecated in React Native 0.74. Only applicable when new architecture is turned on.
+> [!CAUTION]
+> Deprecated in React Native 0.74, where this behavior is detected automatically and this config does nothing. You can safely remove it from your project. 
 
 Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
 hence the `unstable_` prefix.

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -152,10 +152,11 @@ export const projectConfig = t
           .object({
             sourceDir: t.string(),
             watchModeCommandParams: t.array().items(t.string()),
+            // @todo remove for RN 0.75
             unstable_reactLegacyComponentNames: t
               .array()
               .items(t.string())
-              .default([]),
+              .optional(),
             automaticPodsInstallation: t.bool().default(false),
           })
           .default({}),
@@ -168,10 +169,11 @@ export const projectConfig = t
             packageName: t.string(),
             dependencyConfiguration: t.string(),
             watchModeCommandParams: t.array().items(t.string()),
+            // @todo remove for RN 0.75
             unstable_reactLegacyComponentNames: t
               .array()
               .items(t.string())
-              .default([]),
+              .optional(),
           })
           .default({}),
       })

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -142,7 +142,6 @@ class ReactNativeModules {
   private String packageName
   private File root
   private ArrayList<HashMap<String, String>> reactNativeModules
-  private ArrayList<String> unstable_reactLegacyComponentNames
   private HashMap<String, ArrayList> reactNativeModulesBuildVariants
   private String reactNativeVersion
 
@@ -157,7 +156,6 @@ class ReactNativeModules {
     this.reactNativeModules = nativeModules
     this.reactNativeModulesBuildVariants = reactNativeModulesBuildVariants
     this.packageName = androidProject["packageName"]
-    this.unstable_reactLegacyComponentNames = androidProject["unstable_reactLegacyComponentNames"]
     this.reactNativeVersion = reactNativeVersion
   }
 
@@ -296,7 +294,6 @@ class ReactNativeModules {
 
   void generateRncliCpp(File outputDir, String generatedFileName, String generatedFileContentsTemplate) {
     ArrayList<HashMap<String, String>> packages = this.reactNativeModules
-    ArrayList<String> unstable_reactLegacyComponentNames = this.unstable_reactLegacyComponentNames
     String rncliCppIncludes = ""
     String rncliCppModuleProviders = ""
     String rncliCppComponentDescriptors = ""
@@ -331,16 +328,6 @@ class ReactNativeModules {
         }
         result
       }.join("\n")
-    }
-
-    rncliReactLegacyComponentDescriptors = unstable_reactLegacyComponentNames.collect {
-      "  providerRegistry->add(concreteComponentDescriptorProvider<UnstableLegacyViewManagerInteropComponentDescriptor<${it}>>());"
-    }.join("\n")
-    rncliReactLegacyComponentNames = unstable_reactLegacyComponentNames.collect {
-      "extern const char ${it}[] = \"${it}\";"
-    }.join("\n")
-    if (unstable_reactLegacyComponentNames && unstable_reactLegacyComponentNames.size() > 0) {
-      rncliCppIncludes += "\n#include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerInteropComponentDescriptor.h>"
     }
 
     String generatedFileContents = generatedFileContentsTemplate

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -76,8 +76,7 @@ export function projectConfig(
     mainActivity,
     dependencyConfiguration: userConfig.dependencyConfiguration,
     watchModeCommandParams: userConfig.watchModeCommandParams,
-    unstable_reactLegacyComponentNames:
-      userConfig.unstable_reactLegacyComponentNames,
+    unstable_reactLegacyComponentNames: null,
   };
 }
 

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -24,7 +24,7 @@ import {
 import {findLibraryName} from './findLibraryName';
 import {findComponentDescriptors} from './findComponentDescriptors';
 import {findBuildGradle} from './findBuildGradle';
-import {CLIError} from '@react-native-community/cli-tools';
+import {CLIError, logger} from '@react-native-community/cli-tools';
 import getMainActivity from './getMainActivity';
 
 /**
@@ -68,6 +68,13 @@ export function projectConfig(
     : packageName;
   const mainActivity = getMainActivity(manifestPath || '') ?? '';
 
+  // @todo remove for RN 0.75
+  if (userConfig.unstable_reactLegacyComponentNames) {
+    logger.warn(
+      'The "unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.',
+    );
+  }
+
   return {
     sourceDir,
     appName,
@@ -76,7 +83,8 @@ export function projectConfig(
     mainActivity,
     dependencyConfiguration: userConfig.dependencyConfiguration,
     watchModeCommandParams: userConfig.watchModeCommandParams,
-    unstable_reactLegacyComponentNames: null,
+    // @todo remove for RN 0.75
+    unstable_reactLegacyComponentNames: undefined,
   };
 }
 

--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -71,7 +71,7 @@ export function projectConfig(
   // @todo remove for RN 0.75
   if (userConfig.unstable_reactLegacyComponentNames) {
     logger.warn(
-      'The "unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.',
+      'The "project.android.unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.',
     );
   }
 

--- a/packages/cli-platform-apple/src/config/index.ts
+++ b/packages/cli-platform-apple/src/config/index.ts
@@ -18,7 +18,7 @@ import {
   IOSProjectConfig,
   IOSDependencyConfig,
 } from '@react-native-community/cli-types';
-import {CLIError} from '@react-native-community/cli-tools';
+import {CLIError, logger} from '@react-native-community/cli-tools';
 import {BuilderCommand} from '../types';
 
 /**
@@ -46,6 +46,13 @@ export const getProjectConfig =
     const sourceDir = path.dirname(podfile);
 
     const xcodeProject = findXcodeProject(fs.readdirSync(sourceDir));
+
+    // @ts-ignore @todo remove for RN 0.75
+    if (userConfig.unstable_reactLegacyComponentNames) {
+      logger.warn(
+        'The "project.ios.unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.',
+      );
+    }
 
     return {
       sourceDir,

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -6,6 +6,7 @@ export interface AndroidProjectConfig {
   mainActivity: string;
   dependencyConfiguration?: string;
   watchModeCommandParams?: string[];
+  // @todo remove for RN 0.75
   unstable_reactLegacyComponentNames?: string[] | null;
 }
 
@@ -16,6 +17,7 @@ export type AndroidProjectParams = {
   packageName?: string;
   dependencyConfiguration?: string;
   watchModeCommandParams?: string[];
+  // @todo remove for RN 0.75
   unstable_reactLegacyComponentNames?: string[] | null;
 };
 


### PR DESCRIPTION
Summary:
---------

Related to:
- https://github.com/facebook/react-native/pull/42294

With RN 0.74 specifying the legacy components name wont' be necessary anymore as the framework will detect it automatically.

Test Plan:
----------

Not sure how to test this. I'm basically ignoring the `unstable_reactLegacyComponentNames`. We can remove this in 0.75

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
