### PR TITLE
fix: allow users to specificy `--device` without value

### DIFF
--- a/packages/cli-platform-ios/src/commands/runIOS/index.ts
+++ b/packages/cli-platform-ios/src/commands/runIOS/index.ts
@@ -647,10 +647,10 @@ export default {
         '"iPhone 15 (17.0)"',
     },
     {
-      name: '--device <string>',
+      name: '--device [string]', // here we're intentionally using [] over <> to make passed value optional to allow users to run only on physical devices
       description:
-        'Explicitly set the device to use by name. The value is not required ' +
-        'if you have a single device connected.',
+        'Explicitly set the device to use by name. If the value is not provided,' +
+        'the app will run on the first available physical device.',
     },
     {
       name: '--udid <string>',


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Backports https://github.com/react-native-community/cli/pull/2263 to 12.x branch 