### PR TITLE
feat(init): add `--yarn-config-options` option

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -126,6 +126,10 @@ Skip git repository initialization.
 
 Replaces the directory if it already exists
 
+#### `--yarn-config-options <string>`
+
+Passes extra options that will be added to `.yarnrc.yml` file, format: key=value,key2=value2.
+
 ### `upgrade`
 
 Usage:

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -60,5 +60,18 @@ export default {
       name: '--replace-directory [boolean]',
       description: 'Replaces the directory if it already exists.',
     },
+    {
+      name: '--yarn-config-options <string>',
+      description:
+        'Passes extra options that will be added to `.yarnrc.yml` file, format: key=value,key2=value2.',
+      parse: (val: string): Record<string, string> => {
+        return Object.fromEntries(
+          val.split(',').map((option) => {
+            const [key, value] = option.split('=');
+            return [key, value];
+          }),
+        );
+      },
+    },
   ],
 };

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -52,6 +52,7 @@ type Options = {
   platformName?: string;
   skipGitInit?: boolean;
   replaceDirectory?: string | boolean;
+  yarnConfigOptions?: Record<string, string>;
 };
 
 interface TemplateOptions {
@@ -67,6 +68,7 @@ interface TemplateOptions {
   installCocoaPods?: string | boolean;
   version?: string;
   replaceDirectory?: string | boolean;
+  yarnConfigOptions?: Record<string, string>;
 }
 
 interface TemplateReturnType {
@@ -199,6 +201,7 @@ async function createFromTemplate({
   packageName,
   installCocoaPods,
   replaceDirectory,
+  yarnConfigOptions,
 }: TemplateOptions): Promise<TemplateReturnType> {
   logger.debug('Initializing new project');
   // Only print out the banner if we're not in a CI
@@ -244,6 +247,7 @@ async function createFromTemplate({
       templateUri,
       templateSourceDir,
       packageManager,
+      yarnConfigOptions,
     );
 
     loader.succeed();
@@ -419,6 +423,7 @@ async function createProject(
     installCocoaPods: options.installPods,
     version,
     replaceDirectory: options.replaceDirectory,
+    yarnConfigOptions: options.yarnConfigOptions,
   });
 }
 

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -20,6 +20,7 @@ export async function installTemplatePackage(
   templateName: string,
   root: string,
   packageManager: PackageManager.PackageManager,
+  yarnConfigOptions?: Record<string, string>,
 ) {
   logger.debug(`Installing template from ${templateName}`);
 
@@ -47,6 +48,13 @@ export async function installTemplatePackage(
       ['config', 'set', 'nmHoistingLimits', 'workspaces'],
       options,
     );
+
+    for (let key in yarnConfigOptions) {
+      if (yarnConfigOptions.hasOwnProperty(key)) {
+        let value = yarnConfigOptions[key];
+        executeCommand('yarn', ['config', 'set', key, value], options);
+      }
+    }
   }
 
   return PackageManager.install([templateName], {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In React Native CI when initialising project all packages are downloaded from local server, recently we introduced Yarn v3, to make Yarn v3 working with local packages we need to pass the server destination inside Yarn config file `.yarnrc.yml`. In this PR I created an option that accepts `key=value` format value, which is then passed via `yarn config set` when installing template packages in `/tmp/` directory. 


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init --yarn-config-options npmRegistryServer="http://localhost:4873" --verbose
```
3. You should see in console log from Yarn:
```
success Set "npmRegistryServer" to "http://localhost:4873".
```

 
Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
