### PR TITLE
feat: Add ability to use PREFERRED_IOS_DEVICES environment variable #…

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -218,6 +218,33 @@ const createRun =
     }
 
     if (!args.device && !args.udid && !args.simulator) {
+      const preferences = process.env.PREFERRED_IOS_DEVICES?.split(',') ?? [];
+      const found = preferences.flatMap((pref) =>
+        devices.filter((dev) => dev.name === pref || dev.udid === pref),
+      )[0];
+      if (found) {
+        logger.info('Running on device from preferred devices list');
+        if (found.type === 'simulator') {
+          return runOnSimulator(
+            xcodeProject,
+            platformName,
+            mode,
+            scheme,
+            args,
+            found,
+          );
+        } else {
+          return runOnDevice(
+            found,
+            platformName,
+            mode,
+            scheme,
+            xcodeProject,
+            args,
+          );
+        }
+      }
+
       const bootedSimulators = devices.filter(
         ({state, type}) => state === 'Booted' && type === 'simulator',
       );

--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -118,6 +118,15 @@ List all available iOS devices and simulators and let you choose one to run the 
 
 Force running `pod install` before running an app
 
+#### Environment Variables
+
+#### `PREFERRED_IOS_DEVICES`
+
+Comma-separated list of devices or simulators to use when none are specified
+in the command line options. These can be either names or udids. The first to match
+an attached device or a simulator will be selected. Matched simulators will be booted
+if necessary.
+
 ### `build-ios`
 
 Usage:


### PR DESCRIPTION
…2274

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Implements the feature described in #2274 for iOS


Test Plan:
----------

Created new react-native HelloWorld app and ran the following commands:
```sh
PREFERRED_IOS_DEVICES="BogusName,iPhone 14 Pro,3E09B439-89A2-4D48-B452-527D9B4BAD9A" yarn react-native run-ios
PREFERRED_IOS_DEVICES="BogusName,3E09B439-89A2-4D48-B452-527D9B4BAD9A" yarn react-native run-ios
```

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
