### PR TITLE
fix: launching activity defined with fully qualified name (#2269)

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
@@ -59,6 +59,28 @@ test('launches adb shell with intent to launch com.myapp.MainActivity with diffe
   );
 });
 
+test('launches adb shell with intent to launch com.myapp.MainActivity with different appId than packageName on a simulator when mainActivity is fully qualified name', () => {
+  tryLaunchAppOnDevice(
+    device,
+    {...androidProject, mainActivity: 'com.myapp.MainActivity'},
+    adbPath,
+    args,
+  );
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      '-s',
+      'emulator-5554',
+      ...shellStartCommand,
+      '-n',
+      'com.myapp.custom/com.myapp.MainActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});
+
 test('launches adb shell with intent to launch com.myapp.MainActivity with same appId as packageName on a simulator', () => {
   tryLaunchAppOnDevice(
     device,

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -24,7 +24,9 @@ function tryLaunchAppOnDevice(
     .filter(Boolean)
     .join('.');
 
-  const activityToLaunch = mainActivity.includes('.')
+  const activityToLaunch = mainActivity.startsWith(packageName)
+    ? mainActivity
+    : mainActivity.startsWith('.')
     ? [packageName, mainActivity].join('')
     : [packageName, mainActivity].filter(Boolean).join('.');
 


### PR DESCRIPTION
Summary:
---------

Take into account that activity may be defined as fully qualified name.

Cherry-picks https://github.com/react-native-community/cli/pull/2269

Test Plan:
----------

n/a

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)