### PR TITLE
refactor: improved type safety of platformConfig in createRun function

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -12,9 +12,7 @@ import {supportedPlatforms} from '../../config/supportedPlatforms';
 const createBuild =
   ({platformName}: BuilderCommand) =>
   async (_: Array<string>, ctx: Config, args: BuildFlags) => {
-    const platformConfig = ctx.project[platformName] as
-      | IOSProjectConfig
-      | undefined;
+    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
 
     if (
       platformConfig === undefined ||

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -12,7 +12,10 @@ import {supportedPlatforms} from '../../config/supportedPlatforms';
 const createBuild =
   ({platformName}: BuilderCommand) =>
   async (_: Array<string>, ctx: Config, args: BuildFlags) => {
-    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
+    const platformConfig = ctx.project[platformName] as
+      | IOSProjectConfig
+      | undefined;
+
     if (
       platformConfig === undefined ||
       supportedPlatforms[platformName] === undefined
@@ -21,9 +24,9 @@ const createBuild =
     }
 
     let installedPods = false;
-    if (platformConfig?.automaticPodsInstallation || args.forcePods) {
-      const isAppRunningNewArchitecture = platformConfig?.sourceDir
-        ? await getArchitecture(platformConfig?.sourceDir)
+    if (platformConfig.automaticPodsInstallation || args.forcePods) {
+      const isAppRunningNewArchitecture = platformConfig.sourceDir
+        ? await getArchitecture(platformConfig.sourceDir)
         : undefined;
 
       await resolvePods(ctx.root, ctx.dependencies, platformName, {

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -51,7 +51,9 @@ const createRun =
   async (_: Array<string>, ctx: Config, args: FlagsT) => {
     // React Native docs assume platform is always ios/android
     link.setPlatform('ios');
-    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
+    const platformConfig = ctx.project[platformName] as
+      | IOSProjectConfig
+      | undefined;
     const {sdkNames, readableName: platformReadableName} =
       getPlatformInfo(platformName);
 
@@ -67,9 +69,9 @@ const createRun =
     let {packager, port} = args;
     let installedPods = false;
     // check if pods need to be installed
-    if (platformConfig?.automaticPodsInstallation || args.forcePods) {
-      const isAppRunningNewArchitecture = platformConfig?.sourceDir
-        ? await getArchitecture(platformConfig?.sourceDir)
+    if (platformConfig.automaticPodsInstallation || args.forcePods) {
+      const isAppRunningNewArchitecture = platformConfig.sourceDir
+        ? await getArchitecture(platformConfig.sourceDir)
         : undefined;
 
       await resolvePods(ctx.root, ctx.dependencies, platformName, {

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -51,9 +51,7 @@ const createRun =
   async (_: Array<string>, ctx: Config, args: FlagsT) => {
     // React Native docs assume platform is always ios/android
     link.setPlatform('ios');
-    const platformConfig = ctx.project[platformName] as
-      | IOSProjectConfig
-      | undefined;
+    const platformConfig = ctx.project[platformName] as IOSProjectConfig;
     const {sdkNames, readableName: platformReadableName} =
       getPlatformInfo(platformName);
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

I improved type safety of `platformConfig` in `createRun` function. and removed unnecessary optional chaining of the `platformConfig`.
(code is located in cli-platform-apple/src/commands/runCommand/createRun.ts)

before I modified type of `platformConfig`, we couldn't infer that platformConfig could be `undefined`.
so, I added `undefined` type to `platformConfig` as optional.

Additionally, there was unnecessary optional chaining, so I removed it.

``` typescript
// * already checked if platformConfig is 'undefined'.
if (
  platformConfig === undefined ||
  supportedPlatforms[platformName] === undefined
) {
  throw new CLIError(
    `Unable to find ${platformReadableName} platform config`,
  );
}

//  * as far as I see, we don't need optional chaining in here
if (platformConfig?.automaticPodsInstallation || args.forcePods) {
  const isAppRunningNewArchitecture = platformConfig?.sourceDir
    ? await getArchitecture(platformConfig.sourceDir)
    : undefined;

  await resolvePods(ctx.root, ctx.dependencies, platformName, {
    forceInstall: args.forcePods,
    newArchEnabled: isAppRunningNewArchitecture,
  });

  installedPods = true;
}
```

<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

We need to check that the function is working properly, even if we put a platformName that is invalid.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
