### PR TITLE
fix: `execa` phantom dependency in cli-tools

### DIFF
--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "appdirsjs": "^1.2.4",
     "chalk": "^4.1.2",
+    "execa": "^5.0.0",
     "find-up": "^5.0.0",
     "mime": "^2.4.1",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION

Summary:
---------

`execa` is not declared as a dependency inside of `cli-tools`. This causes CLI to fail in setups with `pnpm`


Test Plan:
----------

not needed

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
