### PR TITLE
feat: add `add-platform` command

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -73,6 +73,8 @@ module.exports = {
 
   // Path to script, which will be executed after initialization process, but before installing all the dependencies specified in the template. This script runs as a shell script but you can change that (e.g. to Node) by using a shebang (see example custom template).
   postInitScript: './script.js',
+  // We're also using `template.config.js` when adding new platforms to existing project in `add-platform` command. Thanks to value passed to `platformName` we know which folder we should copy to the project.
+  platformName: 'visionos',
 };
 ```
 
@@ -91,12 +93,16 @@ new Promise((resolve) => {
   spinner.start();
   // do something
   resolve();
-}).then(() => {
-  spinner.succeed();
-}).catch(() => {
-  spinner.fail();
-  throw new Error('Something went wrong during the post init script execution');
-});
+})
+  .then(() => {
+    spinner.succeed();
+  })
+  .catch(() => {
+    spinner.fail();
+    throw new Error(
+      'Something went wrong during the post init script execution',
+    );
+  });
 ```
 
 You can find example custom template [here](https://github.com/Esemesek/react-native-new-template).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "find-up": "^5.0.0",
     "fs-extra": "^8.1.0",
     "graceful-fs": "^4.1.3",
+    "npm-registry-fetch": "^16.1.0",
     "prompts": "^2.4.2",
     "semver": "^7.5.2"
   },
@@ -45,6 +46,7 @@
     "@types/fs-extra": "^8.1.0",
     "@types/graceful-fs": "^4.1.3",
     "@types/hapi__joi": "^17.1.6",
+    "@types/npm-registry-fetch": "^8.0.7",
     "@types/prompts": "^2.4.4",
     "@types/semver": "^6.0.2",
     "slash": "^3.0.0",

--- a/packages/cli/src/commands/addPlatform/addPlatform.ts
+++ b/packages/cli/src/commands/addPlatform/addPlatform.ts
@@ -43,13 +43,23 @@ const getAppName = async (root: string) => {
     throw new CLIError(`Unable to find package.json inside ${root}`);
   }
 
-  let {name} = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+  let name;
+
+  try {
+    name = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+  } catch (e) {
+    throw new CLIError(`Failed to read ${pkgJsonPath} file.`, e as Error);
+  }
 
   if (!name) {
     const appJson = join(root, 'app.json');
     if (appJson) {
       logger.log(`Reading ${chalk.cyan('name')} from app.json…`);
-      name = JSON.parse(readFileSync(appJson, 'utf8')).name;
+      try {
+        name = JSON.parse(readFileSync(appJson, 'utf8')).name;
+      } catch (e) {
+        throw new CLIError(`Failed to read ${pkgJsonPath} file.`, e as Error);
+      }
     }
 
     if (!name) {

--- a/packages/cli/src/commands/addPlatform/addPlatform.ts
+++ b/packages/cli/src/commands/addPlatform/addPlatform.ts
@@ -24,6 +24,7 @@ import {
 } from '../init/template';
 import {tmpdir} from 'os';
 import {mkdtempSync} from 'graceful-fs';
+import {existsSync} from 'fs';
 
 type Options = {
   packageName: string;
@@ -175,6 +176,15 @@ async function addPlatform(
   }
 
   for (const platform of templateConfig.platforms) {
+    if (existsSync(join(root, platform))) {
+      throw new CLIError(
+        `Platform ${platform} already exists in the project. Directory ${join(
+          root,
+          platform,
+        )} is not empty.`,
+      );
+    }
+
     await copyTemplate(
       templateName,
       templateConfig.templateDir,

--- a/packages/cli/src/commands/addPlatform/addPlatform.ts
+++ b/packages/cli/src/commands/addPlatform/addPlatform.ts
@@ -183,13 +183,15 @@ async function addPlatform(
     );
   }
 
-  loader.start(`Installing template packages from ${templateName}@0${version}`);
+  loader.start(
+    `Installing template packages from ${templateName}@0${matchingVersion}`,
+  );
 
   const templateSourceDir = mkdtempSync(join(tmpdir(), 'rncli-init-template-'));
 
   try {
     await installTemplatePackage(
-      `${templateName}@0${version}`,
+      `${templateName}@0${matchingVersion}`,
       templateSourceDir,
       pm,
     );
@@ -197,7 +199,7 @@ async function addPlatform(
   } catch (error) {
     loader.fail();
     throw new CLIError(
-      `Failed to install template packages from ${templateName}@0${version}`,
+      `Failed to install template packages from ${templateName}@0${matchingVersion}`,
       (error as Error).message,
     );
   }

--- a/packages/cli/src/commands/addPlatform/addPlatform.ts
+++ b/packages/cli/src/commands/addPlatform/addPlatform.ts
@@ -168,29 +168,33 @@ async function addPlatform(
   const templateName = getTemplateName(templateSourceDir);
   const templateConfig = getTemplateConfig(templateName, templateSourceDir);
 
-  if (!templateConfig.platformName) {
+  if (!templateConfig.platforms) {
     throw new CLIError(
-      `Template ${templateName} is missing platformName in its template.config.js`,
+      `Template ${templateName} is missing "platforms" in its "template.config.js"`,
     );
   }
 
-  await copyTemplate(
-    templateName,
-    templateConfig.templateDir,
-    templateSourceDir,
-    templateConfig.platformName,
-  );
+  for (const platform of templateConfig.platforms) {
+    await copyTemplate(
+      templateName,
+      templateConfig.templateDir,
+      templateSourceDir,
+      platform,
+    );
+  }
 
   loader.succeed();
   loader.start('Processing template');
 
-  await changePlaceholderInTemplate({
-    projectName,
-    projectTitle: title,
-    placeholderName: templateConfig.placeholderName,
-    placeholderTitle: templateConfig.titlePlaceholder,
-    projectPath: join(root, templateConfig.platformName),
-  });
+  for (const platform of templateConfig.platforms) {
+    await changePlaceholderInTemplate({
+      projectName,
+      projectTitle: title,
+      placeholderName: templateConfig.placeholderName,
+      placeholderTitle: templateConfig.titlePlaceholder,
+      projectPath: join(root, platform),
+    });
+  }
 
   loader.succeed();
 

--- a/packages/cli/src/commands/addPlatform/addPlatform.ts
+++ b/packages/cli/src/commands/addPlatform/addPlatform.ts
@@ -22,6 +22,7 @@ import {
 import {tmpdir} from 'os';
 import {mkdtempSync} from 'graceful-fs';
 import {existsSync} from 'fs';
+import {getNpmRegistryUrl} from '../../tools/npm';
 
 type Options = {
   packageName: string;
@@ -30,7 +31,7 @@ type Options = {
   title: string;
 };
 
-const NPM_REGISTRY_URL = 'http://registry.npmjs.org'; // TODO: Support local registry
+const NPM_REGISTRY_URL = getNpmRegistryUrl();
 
 const getAppName = async (root: string) => {
   logger.log(`Reading ${chalk.cyan('name')} from package.json…`);

--- a/packages/cli/src/commands/addPlatform/index.ts
+++ b/packages/cli/src/commands/addPlatform/index.ts
@@ -1,0 +1,23 @@
+import addPlatform from './addPlatform';
+
+export default {
+  func: addPlatform,
+  name: 'add-platform [packageName]',
+  description: 'Add new platform to your React Native project.',
+  options: [
+    {
+      name: '--version <string>',
+      description: 'Pass version of the platform to be added to the project.',
+    },
+    {
+      name: '--pm <string>',
+      description:
+        'Use specific package manager to initialize the project. Available options: `yarn`, `npm`, `bun`. Default: `yarn`',
+      default: 'yarn',
+    },
+    {
+      name: '--title <string>',
+      description: 'Uses a custom app title name for application',
+    },
+  ],
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -3,11 +3,13 @@ import {commands as cleanCommands} from '@react-native-community/cli-clean';
 import {commands as doctorCommands} from '@react-native-community/cli-doctor';
 import {commands as configCommands} from '@react-native-community/cli-config';
 import init from './init';
+import addPlatform from './addPlatform';
 
 export const projectCommands = [
   ...configCommands,
   cleanCommands.clean,
   doctorCommands.info,
+  addPlatform,
 ] as Command[];
 
 export const detachedCommands = [

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -146,7 +146,7 @@ export async function replacePlaceholderWithPackageName({
   placeholderName,
   placeholderTitle,
   packageName,
-  projectPath,
+  projectPath = process.cwd(),
 }: Omit<Required<PlaceholderConfig>, 'projectTitle'>) {
   validatePackageName(packageName);
   const cleanPackageName = packageName.replace(/[^\p{L}\p{N}.]+/gu, '');

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -278,9 +278,17 @@ export function getTemplateName(cwd: string) {
   // We use package manager to infer the name of the template module for us.
   // That's why we get it from temporary package.json, where the name is the
   // first and only dependency (hence 0).
-  const name = Object.keys(
-    JSON.parse(fs.readFileSync(path.join(cwd, './package.json'), 'utf8'))
-      .dependencies,
-  )[0];
+  let name;
+  try {
+    name = Object.keys(
+      JSON.parse(fs.readFileSync(path.join(cwd, './package.json'), 'utf8'))
+        .dependencies,
+    )[0];
+  } catch {
+    throw new CLIError(
+      'Failed to read template name from package.json. Please make sure that the template you are using has a valid package.json file.',
+    );
+  }
+
   return name;
 }

--- a/packages/cli/src/commands/init/git.ts
+++ b/packages/cli/src/commands/init/git.ts
@@ -68,3 +68,14 @@ export const createGitRepository = async (folder: string) => {
     );
   }
 };
+
+export const isGitTreeDirty = async (folder: string) => {
+  try {
+    const {stdout} = await execa('git', ['status', '--porcelain'], {
+      cwd: folder,
+    });
+    return stdout !== '';
+  } catch {
+    return false;
+  }
+};

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -19,7 +19,7 @@ import {
   copyTemplate,
   executePostInitScript,
 } from './template';
-import {changePlaceholderInTemplate} from './editTemplate';
+import {changePlaceholderInTemplate, getTemplateName} from './editTemplate';
 import * as PackageManager from '../../tools/packageManager';
 import banner from './banner';
 import TemplateAndVersionError from './errors/TemplateAndVersionError';
@@ -179,17 +179,6 @@ async function setProjectDirectory(
   }
 
   return process.cwd();
-}
-
-function getTemplateName(cwd: string) {
-  // We use package manager to infer the name of the template module for us.
-  // That's why we get it from temporary package.json, where the name is the
-  // first and only dependency (hence 0).
-  const name = Object.keys(
-    JSON.parse(fs.readFileSync(path.join(cwd, './package.json'), 'utf8'))
-      .dependencies,
-  )[0];
-  return name;
 }
 
 //set cache to empty string to prevent installing cocoapods on freshly created project

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -1,5 +1,5 @@
 import execa from 'execa';
-import path from 'path';
+import path, {join} from 'path';
 import {logger, CLIError} from '@react-native-community/cli-tools';
 import * as PackageManager from '../../tools/packageManager';
 import copyFiles from '../../tools/copyFiles';
@@ -14,6 +14,7 @@ export type TemplateConfig = {
   templateDir: string;
   postInitScript?: string;
   titlePlaceholder?: string;
+  platformName: string;
 };
 
 export async function installTemplatePackage(
@@ -91,6 +92,7 @@ export async function copyTemplate(
   templateName: string,
   templateDir: string,
   templateSourceDir: string,
+  platformName: string = '',
 ) {
   const templatePath = path.resolve(
     templateSourceDir,
@@ -101,9 +103,13 @@ export async function copyTemplate(
 
   logger.debug(`Copying template from ${templatePath}`);
   let regexStr = path.resolve(templatePath, 'node_modules');
-  await copyFiles(templatePath, process.cwd(), {
-    exclude: [new RegExp(replacePathSepForRegex(regexStr))],
-  });
+  await copyFiles(
+    join(templatePath, platformName),
+    join(process.cwd(), platformName),
+    {
+      exclude: [new RegExp(replacePathSepForRegex(regexStr))],
+    },
+  );
 }
 
 export function executePostInitScript(

--- a/packages/cli/src/commands/init/template.ts
+++ b/packages/cli/src/commands/init/template.ts
@@ -14,7 +14,7 @@ export type TemplateConfig = {
   templateDir: string;
   postInitScript?: string;
   titlePlaceholder?: string;
-  platformName: string;
+  platforms?: string[];
 };
 
 export async function installTemplatePackage(
@@ -92,7 +92,7 @@ export async function copyTemplate(
   templateName: string,
   templateDir: string,
   templateSourceDir: string,
-  platformName: string = '',
+  platform: string = '',
 ) {
   const templatePath = path.resolve(
     templateSourceDir,
@@ -103,13 +103,9 @@ export async function copyTemplate(
 
   logger.debug(`Copying template from ${templatePath}`);
   let regexStr = path.resolve(templatePath, 'node_modules');
-  await copyFiles(
-    join(templatePath, platformName),
-    join(process.cwd(), platformName),
-    {
-      exclude: [new RegExp(replacePathSepForRegex(regexStr))],
-    },
-  );
+  await copyFiles(join(templatePath, platform), join(process.cwd(), platform), {
+    exclude: [new RegExp(replacePathSepForRegex(regexStr))],
+  });
 }
 
 export function executePostInitScript(


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In this Pull Request I've added new command `add-platform` which re-uses code from `init` command to add a new OOT platform to existing React Native app. It gets React Native version from `package.json` and it tries to find a matching platform's version from NPM registry. Then, if successful it reuses `editTemplate` functions to replace placeholders. 

https://github.com/react-native-community/cli/assets/63900941/6529cf35-f27a-4373-b843-1dc4bf66b4c7



For OOT platforms to add a compatibility with the new command:
1. Add `platforms` inside [`template.config.js`](https://github.com/facebook/react-native/blob/main/packages/react-native/template.config.js), which is an array in which OOT platform should provide names of folders containing native code. e.g. `platforms: ["macos"]`
2. Add `postInitScript` (also under `template.config.js`) with e.g. installing Pods and printing run instructions.
3. Add platform's specific native code under `packages/react-native/template${platformName}`.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
