### PR TITLE
fix: replace `ip` package with default value and `--host` flag

### DIFF
--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -19,7 +19,6 @@
     "envinfo": "^7.10.0",
     "execa": "^5.0.0",
     "hermes-profile-transformer": "^0.0.6",
-    "ip": "^1.1.5",
     "node-stream-zip": "^1.9.1",
     "ora": "^5.4.1",
     "semver": "^7.5.2",

--- a/packages/cli-hermes/README.md
+++ b/packages/cli-hermes/README.md
@@ -57,6 +57,12 @@ Specify an `applicationId` to launch after build. If not specified, `package` fr
 
 Specify an `applicationIdSuffix` to launch after build.
 
+#### `--host <string>`
+
+The host of the packager.
+
+> default: localhost
+
 ### Notes on source map
 
 This step is recommended in order for the source map to be generated:

--- a/packages/cli-hermes/package.json
+++ b/packages/cli-hermes/package.json
@@ -11,8 +11,7 @@
     "@react-native-community/cli-platform-android": "13.5.2",
     "@react-native-community/cli-tools": "13.5.2",
     "chalk": "^4.1.2",
-    "hermes-profile-transformer": "^0.0.6",
-    "ip": "^1.1.5"
+    "hermes-profile-transformer": "^0.0.6"
   },
   "files": [
     "build",

--- a/packages/cli-hermes/src/profileHermes/downloadProfile.ts
+++ b/packages/cli-hermes/src/profileHermes/downloadProfile.ts
@@ -59,6 +59,7 @@ export async function downloadProfile(
   port: string = '8081',
   appId?: string,
   appIdSuffix?: string,
+  host: string = 'localhost',
 ) {
   try {
     const androidProject = getAndroidProject(ctx);
@@ -101,7 +102,7 @@ export async function downloadProfile(
         `adb shell run-as ${packageNameWithSuffix} cat cache/${file} > ${tempFilePath}`,
       );
 
-      const bundleOptions = getMetroBundleOptions(tempFilePath);
+      const bundleOptions = getMetroBundleOptions(tempFilePath, host);
 
       // If path to source map is not given
       if (!sourcemapPath) {

--- a/packages/cli-hermes/src/profileHermes/index.ts
+++ b/packages/cli-hermes/src/profileHermes/index.ts
@@ -10,6 +10,7 @@ type Options = {
   port: string;
   appId?: string;
   appIdSuffix?: string;
+  host?: string;
 };
 
 async function profileHermes(
@@ -34,6 +35,7 @@ async function profileHermes(
       options.port,
       options.appId,
       options.appIdSuffix,
+      options.host,
     );
   } catch (err) {
     throw err as CLIError;
@@ -77,6 +79,11 @@ export default {
     {
       name: '--appIdSuffix <string>',
       description: 'Specify an applicationIdSuffix to launch after build.',
+    },
+    {
+      name: '--host <string>',
+      description: 'The host of the packager.',
+      default: 'localhost',
     },
   ],
   examples: [

--- a/packages/cli-hermes/src/profileHermes/metroBundleOptions.ts
+++ b/packages/cli-hermes/src/profileHermes/metroBundleOptions.ts
@@ -6,15 +6,18 @@ export interface MetroBundleOptions {
   platform: string;
   dev: boolean;
   minify: boolean;
+  host: string;
 }
 
 export function getMetroBundleOptions(
   downloadedProfileFilePath: string,
+  host: string,
 ): MetroBundleOptions {
   let options: MetroBundleOptions = {
     platform: 'android',
     dev: true,
     minify: false,
+    host,
   };
 
   try {

--- a/packages/cli-hermes/src/profileHermes/sourcemapUtils.ts
+++ b/packages/cli-hermes/src/profileHermes/sourcemapUtils.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import {SourceMap} from 'hermes-profile-transformer';
-import ip from 'ip';
 import {MetroBundleOptions} from './metroBundleOptions';
 
 function getTempFilePath(filename: string) {
@@ -31,12 +30,11 @@ function writeJsonSync(targetPath: string, data: any) {
 
 async function getSourcemapFromServer(
   port: string,
-  {platform, dev, minify}: MetroBundleOptions,
+  {platform, dev, minify, host}: MetroBundleOptions,
 ): Promise<SourceMap | undefined> {
   logger.debug('Getting source maps from Metro packager server');
-  const IP_ADDRESS = ip.address();
 
-  const requestURL = `http://${IP_ADDRESS}:${port}/index.map?platform=${platform}&dev=${dev}&minify=${minify}`;
+  const requestURL = `http://${host}:${port}/index.map?platform=${platform}&dev=${dev}&minify=${minify}`;
   logger.debug(`Downloading from ${requestURL}`);
   try {
     const {data} = await fetch(requestURL);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6798,11 +6798,6 @@ ip-regex@^2.1.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
   integrity sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
 
-ip@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
-  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
-
 ip@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2294

In this Pull Request I've replace usage of `ip` package with default value `localhost`, and added option to specify custom if needed. (It's following the same logic that is inside `start` command). 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js profile-hermes
```


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
