### PR TITLE
docs: update iOS auto-linking docs after adding support for PNPM and workspace setups

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -29,7 +29,7 @@ Each platform defines its own [`platforms`](./platforms.md) configuration. It in
 
 ## Platform iOS
 
-The [native_modules.rb](https://github.com/react-native-community/cli/blob/main/packages/cli-platform-ios/native_modules.rb) script required by `Podfile` gets the package metadata from `react-native config` during install phase and:
+The [react-native/scripts/react_native_pods.rb](https://github.com/robhogan/react-native/blob/master/packages/react-native/scripts/react_native_pods.rb) script required by `Podfile` requires the [native_modules.rb](https://github.com/react-native-community/cli/blob/main/packages/cli-platform-ios/native_modules.rb) script, which gets the package metadata from `react-native config` during install phase and:
 
 1. Adds dependencies via CocoaPods dev pods (using files from a local path).
 1. Adds build phase scripts to the App project’s build phase. (see examples below)
@@ -146,7 +146,7 @@ There is nothing extra you need to do - monorepos are supported by default.
 Please note that in certain scenarios, such as when using Yarn workspaces, your packages might be hoisted to the root of the repository. If that is the case, please make sure that the following paths are pointing to the
 correct location and update them accordingly:
 
-- path to `native_modules.rb` in your `ios/Podfile`
+- path to `native_modules.rb` in your `ios/Podfile` (the right path should be resolved automatically in react-native >0.73)
 - path to `native_modules.gradle` in your `android/settings.gradle`
 - path to `native_modules.gradle` in your `android/app/build.gradle`
 

--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -29,7 +29,7 @@ Each platform defines its own [`platforms`](./platforms.md) configuration. It in
 
 ## Platform iOS
 
-The [react-native/scripts/react_native_pods.rb](https://github.com/robhogan/react-native/blob/master/packages/react-native/scripts/react_native_pods.rb) script required by `Podfile` requires the [native_modules.rb](https://github.com/react-native-community/cli/blob/main/packages/cli-platform-ios/native_modules.rb) script, which gets the package metadata from `react-native config` during install phase and:
+The [react-native/scripts/react_native_pods.rb](https://github.com/facebook/react-native/blob/master/packages/react-native/scripts/react_native_pods.rb) script required by `Podfile` requires the [native_modules.rb](https://github.com/react-native-community/cli/blob/main/packages/cli-platform-ios/native_modules.rb) script, which gets the package metadata from `react-native config` during install phase and:
 
 1. Adds dependencies via CocoaPods dev pods (using files from a local path).
 1. Adds build phase scripts to the App project’s build phase. (see examples below)


### PR DESCRIPTION
Summary:
---------

The `react-native` project updated how the auto-linking script is imported into the `Podfile` (https://github.com/facebook/react-native/pull/36485), so we need to update the docs to reflect these changes.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
