### PR TITLE
fix: Do not have empty `AUTOLINKED_LIBRARIES`

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -298,6 +298,7 @@ class ReactNativeModules {
         if (it.cxxModuleCMakeListsModuleName != null) {
           autolinkedLibraries += "\n${it.cxxModuleCMakeListsModuleName}"
         }
+        autolinkedLibraries
       }.minus(null).join('\n  ')
     }
 


### PR DESCRIPTION
Summary:
---------

When working on TM CXX Autolinking I forgot to return the value here, and this results in `AUTOLINKED_LIBRARIES` CMake variable being empty. Effectively we're not linking against anything then, which is causing build failures in OSS.
See:
- https://github.com/facebook/react-native/issues/43145

Test Plan:
----------

Tested against RNTA reporducer by @tido64 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
