### PR TITLE
implement getting Main Activity from an Activity alias on Android

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-platform-android/src/config/__fixtures__/android.ts
@@ -34,6 +34,10 @@ const customFlavorManifest = fs.readFileSync(
   path.join(__dirname, './files/AndroidManifest-custom-flavor.xml'),
 );
 
+const activityAliasManifest = fs.readFileSync(
+  path.join(__dirname, './files/AndroidManifest-activity-alias.xml'),
+);
+
 const mainManifest = fs.readFileSync(
   path.join(__dirname, './files/AndroidManifest.xml'),
 );
@@ -304,6 +308,12 @@ export const fewActivities = {
 export const className = {
   src: {
     'AndroidManifest.xml': classNameManifest,
+  },
+};
+
+export const activityAlias = {
+  src: {
+    'AndroidManifest.xml': activityAliasManifest,
   },
 };
 

--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-activity-alias.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-activity-alias.xml
@@ -1,0 +1,21 @@
+<manifest
+  xmlns:android="http://schemas.android.com/apk/res/android">
+  <application android:name=".ExampleApplication">
+    <activity-alias android:name=".MainActivityAlias" android:targetActivity=".OldMainActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+        <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+      </intent-filter>
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="rntester" android:host="example" />
+      </intent-filter>
+    </activity-alias>
+    <activity android:name="com.old.package.OldMainActivity" android:exported="true"/>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
+  </application>
+  </queries>
+</manifest>

--- a/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getMainActivity.test.ts
@@ -31,6 +31,11 @@ describe('android::getMainActivity', () => {
           app: mocks.customFlavor,
         },
       },
+      activityAlias: {
+        android: {
+          app: mocks.activityAlias,
+        },
+      },
     });
   });
 
@@ -69,5 +74,13 @@ describe('android::getMainActivity', () => {
   it('returns null if file do not exist', () => {
     const fakeManifestPath = findManifest('/empty');
     expect(getMainActivity(fakeManifestPath || '')).toBeNull();
+  });
+
+  it('returns activity defined as alias in the manifest', () => {
+    const manifestPath = findManifest('/activityAlias');
+    const manifest = getMainActivity(manifestPath || '');
+    expect(manifest).not.toBeNull();
+    expect(typeof manifest).toBe('string');
+    expect(manifest).toBe('.MainActivityAlias');
   });
 });

--- a/packages/cli-platform-android/src/config/getMainActivity.ts
+++ b/packages/cli-platform-android/src/config/getMainActivity.ts
@@ -31,6 +31,7 @@ export default function getMainActivity(manifestPath: string): string | null {
 
       const application = manifest.application || {};
       const activity = application.activity || {};
+      const activityAlias = application['activity-alias'] || {};
 
       let activities: Activity[] = [];
 
@@ -38,6 +39,12 @@ export default function getMainActivity(manifestPath: string): string | null {
         activities = [activity];
       } else {
         activities = activity;
+      }
+
+      if (!Array.isArray(activityAlias)) {
+        activities.push(activityAlias);
+      } else {
+        activities = activities.concat(activityAlias);
       }
 
       const mainActivity = activities.find((act: Activity) => {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Android Manifests might contain Activity aliases: https://developer.android.com/guide/topics/manifest/activity-alias-element. This allows mapping activity paths. Such aliases might contain `<intent-filter>`s  no different from regular activities.

<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
Unit Test have been added. 

In an Android project.
Create an activity and an activity-alias. 
Make the activity alias point to the actual activity. 
The alias should have the launcher  category and main action. (Making it the main activity)
Expected: running `react-native android` should launch as expected on the device

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
