### PR TITLE
fix(macCatalyst): construct correct path for macCatalyst build

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
@@ -25,7 +25,7 @@ export async function getBuildPath(
   }
 
   if (isCatalyst) {
-    return path.join(targetBuildDir, '-maccatalyst', executableFolderPath);
+    return path.join(`${targetBuildDir}-maccatalyst`, executableFolderPath);
   } else if (platform === 'macos') {
     return path.join(targetBuildDir, fullProductName);
   } else {


### PR DESCRIPTION

Summary:
---------

Hi there! I have a demo script I use to test ios + android builds in both debug+release on rc candidates to make sure react-native-firebase will work with upcoming releases

I'm testing the 0.74-rc series now

It also tests macCatalyst builds, and since that's a pretty niche build setup I frequently find little issues.

I believe I found a little issue here, where after the build (which did work...) there was no ability to launch the macCatalyst app because the path construction for the macCatalyst build was very subtly incorrect


----

Related but not completely related:

I actually have a separate issue with macCatalyst builds in that it is impossible without a hacky-patch to target macCatalyst from the command line but I'm not sure what to do with that. [Explanation here in the patch](https://github.com/mikehardy/rnfbdemo/commit/a4596188a27935e0a521dd52eace2f1b5a4e2343#diff-bc218854a45288de2973d93616e4798ffd0dc0c6056cd6174d44c80d5ed34390R13-R21)

----

Test Plan:
----------

This was tested via [patch-package applying this patch](https://github.com/mikehardy/rnfbdemo/blob/a4596188a27935e0a521dd52eace2f1b5a4e2343/patches/%40react-native-community%2Bcli-platform-apple%2B13.6.0.patch#L33-L34) to the build code for the cli-platform-package package in node_modules in an automated build harness that I have here (this is pointing to the 0.74 rc testing branch: https://github.com/mikehardy/rnfbdemo/blob/rn74/make-demo.sh)

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
