### PR TITLE
chore: specify where to run `npx react-native info` for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,8 @@ labels: 'bug report'
 ## Environment
 
 <!-- 
-  Run `npx react-native info` in your terminal and paste its contents here. 
+  Run `npx react-native info` in your terminal inside a react-native project 
+  and paste its contents here. 
   Also please make sure that `npx react-native doctor` is passing.
 -->
 


### PR DESCRIPTION
Summary:
---------

the "info" command is not known to the react-native wrapper on npmjs.com so "info" only works if you run it from inside a directory where react-native is installed as a local package

This is what happens if you just run `npx react-native info` outside a project:

```
mike@isabela:~ % npx react-native info
npm WARN cli npm v10.2.4 does not support Node.js v18.15.0. This version of npm supports the following node versions: `^18.17.0 || >=20.5.0`. You can find the latest version at https://nodejs.org/.
Need to install the following packages:
react-native@0.73.5
Ok to proceed? (y) y
error: unknown command 'info'
(Did you mean init?)

```


Test Plan:
----------

Run it inside a working project with react-native installed, and it works


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
