### PR TITLE
fix: save `.env` files under `node_modules/.generated`

### DIFF
--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -4,8 +4,6 @@ import execa from 'execa';
 import logger from './logger';
 import chalk from 'chalk';
 import {findPackageDependencyDir} from './findPackageDependencyDir';
-import {mkdir} from 'fs-extra';
-import {CLIError} from './errors';
 
 const ERROR = `a dev server manually by running ${chalk.bold(
   'npm start',
@@ -42,7 +40,7 @@ async function startServerInNewWindow(
 
   if (!generatedPath) {
     const newPath = path.join(projectRoot, 'node_modules', '.generated');
-    fs.mkdirSync(newPath, { recursive: true, mode: 0o755 });
+    fs.mkdirSync(newPath, {recursive: true, mode: 0o755});
     generatedPath = newPath;
   }
 

--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -1,15 +1,17 @@
 import path from 'path';
 import fs from 'fs';
 import execa from 'execa';
-import resolveNodeModuleDir from './resolveNodeModuleDir';
 import logger from './logger';
 import chalk from 'chalk';
+import {findPackageDependencyDir} from './findPackageDependencyDir';
+import {mkdir} from 'fs-extra';
+import {CLIError} from './errors';
 
 const ERROR = `a dev server manually by running ${chalk.bold(
   'npm start',
 )} or ${chalk.bold('yarn start')} in other terminal window.`;
 
-function startServerInNewWindow(
+async function startServerInNewWindow(
   port: number,
   projectRoot: string,
   reactNativePath: string,
@@ -34,7 +36,22 @@ function startServerInNewWindow(
   const packagerEnvFileExportContent = isWindows
     ? `set RCT_METRO_PORT=${port}\nset PROJECT_ROOT=${projectRoot}\nset REACT_NATIVE_PATH=${reactNativePath}`
     : `export RCT_METRO_PORT=${port}\nexport PROJECT_ROOT="${projectRoot}"\nexport REACT_NATIVE_PATH="${reactNativePath}"`;
-  const nodeModulesPath = resolveNodeModuleDir(projectRoot, '.bin');
+  let generatedPath = findPackageDependencyDir('.generated', {
+    startDir: projectRoot,
+  });
+
+  if (!generatedPath) {
+    const newPath = path.join(projectRoot, 'node_modules', '.generated');
+
+    try {
+      await mkdir(newPath);
+    } catch (e) {
+      throw new CLIError(`Failed to create ${newPath}`);
+    }
+
+    generatedPath = newPath;
+  }
+
   const cliPluginMetroPath = path.join(
     path.dirname(
       require.resolve('@react-native-community/cli-tools/package.json'),
@@ -45,13 +62,13 @@ function startServerInNewWindow(
   /**
    * Set up the `.packager.(env|bat)` file to ensure the packager starts on the right port and in right directory.
    */
-  const packagerEnvFile = path.join(nodeModulesPath, `${packagerEnvFilename}`);
+  const packagerEnvFile = path.join(generatedPath, `${packagerEnvFilename}`);
 
   /**
    * Set up the `launchPackager.(command|bat)` file.
    * It lives next to `.packager.(bat|env)`
    */
-  const launchPackagerScript = path.join(nodeModulesPath, scriptFile);
+  const launchPackagerScript = path.join(generatedPath, scriptFile);
   const procConfig: execa.SyncOptions = {cwd: path.dirname(packagerEnvFile)};
 
   /**
@@ -63,19 +80,19 @@ function startServerInNewWindow(
   });
 
   /**
-   * Copy files into `node_modules/.bin`.
+   * Copy files into `node_modules/.generated`.
    */
 
   try {
     if (isWindows) {
       fs.copyFileSync(
         path.join(cliPluginMetroPath, 'launchPackager.bat'),
-        path.join(nodeModulesPath, 'launchPackager.bat'),
+        path.join(generatedPath, 'launchPackager.bat'),
       );
     } else {
       fs.copyFileSync(
         path.join(cliPluginMetroPath, 'launchPackager.command'),
-        path.join(nodeModulesPath, 'launchPackager.command'),
+        path.join(generatedPath, 'launchPackager.command'),
       );
     }
   } catch (error) {

--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -42,13 +42,7 @@ async function startServerInNewWindow(
 
   if (!generatedPath) {
     const newPath = path.join(projectRoot, 'node_modules', '.generated');
-
-    try {
-      await mkdir(newPath);
-    } catch (e) {
-      throw new CLIError(`Failed to create ${newPath}`);
-    }
-
+    fs.mkdirSync(newPath, { recursive: true, mode: 0o755 });
     generatedPath = newPath;
   }
 

--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -9,7 +9,7 @@ const ERROR = `a dev server manually by running ${chalk.bold(
   'npm start',
 )} or ${chalk.bold('yarn start')} in other terminal window.`;
 
-async function startServerInNewWindow(
+function startServerInNewWindow(
   port: number,
   projectRoot: string,
   reactNativePath: string,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2307

From now we're saving `.packager.env` and `launchPackager.command` under `${ctx.root}/node_modules/.generated`, so that setups like Yarn v4 with `node-linker: pnpm` will also work.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run `yarn start` in other project on port 8081.
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```
4. and you should see this output:
```
> yarn ios
info Another process is running on port 8081.
✔ Use port 8082 instead? › Yes
info Found Xcode project "CliStartServerYarnPnpm.xcodeproj"
```


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
