### PR TITLE
fix: align `find-up` package version across packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
     "commander": "^9.4.1",
     "deepmerge": "^4.3.0",
     "execa": "^5.0.0",
-    "find-up": "^4.1.0",
+    "find-up": "^5.0.0",
     "fs-extra": "^8.1.0",
     "graceful-fs": "^4.1.3",
     "prompts": "^2.4.2",


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

When linking project inside app that is using Yarn > 3 there's an error:

```
➤ YN0000: ┌ Link step
➤ YN0071: │ Cannot link @react-native-community/cli-tools into @react-native-community/cli@portal:/path/cli/packages/cli::locator=RN0740RC1%40workspace%3A. dependency find-up@npm:5.0.0 conflicts with parent dependency find-up@npm:4.1.0
```

So by aligning `find-up` versions across monorepo 

Test Plan:
----------

CI

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
