### PR TITLE
fix: Fix made to handle if mode in command argument includes build flavor …

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -16,10 +16,10 @@ function tryInstallAppOnDevice(
     // "app" is usually the default value for Android apps with only 1 app
     const {appName, sourceDir} = androidProject;
 
-    const defaultVariant = (args.mode || 'debug').toLowerCase();
+    const defaultVariant = 'debug';
 
-    // handle if selected task from interactive mode includes build flavour as well, eg. installProductionDebug should create ['production','debug'] array
-    const variantFromSelectedTask = selectedTask
+    // handle if selected task from interactive mode, or mode from arguments, includes build flavour as well, eg. installProductionDebug should create ['production','debug'] array
+    const variantFromSelectedTask = (selectedTask ?? args.mode)
       ?.replace('install', '')
       .split(/(?=[A-Z])/);
 


### PR DESCRIPTION

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This change addresses the bug #2323  reported for `yarn react-native run-android` with product flavor.


Test Plan:
----------

Fix made locally and tested by installing on simulator, please refer below screenshot.

![rn-cli-screenshot](https://github.com/react-native-community/cli/assets/1378156/f8363e45-7e4d-465a-a9cb-a5f58205d0af)

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
