### PR TITLE
fix: pass user-defined health checks to config

### DIFF
--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -102,7 +102,7 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
     },
     dependencies: userConfig.dependencies,
     commands: userConfig.commands,
-    healthChecks: [],
+    healthChecks: userConfig.healthChecks,
     platforms: userConfig.platforms,
     get project() {
       if (lazyProject) {

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -102,7 +102,7 @@ function loadConfig(projectRoot: string = findProjectRoot()): Config {
     },
     dependencies: userConfig.dependencies,
     commands: userConfig.commands,
-    healthChecks: userConfig.healthChecks,
+    healthChecks: userConfig.healthChecks || [],
     platforms: userConfig.platforms,
     get project() {
       if (lazyProject) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Closes #2321 

User-defined health checks were not passed to the config, making it not possible to define custom checks.

<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
1. In a RN project, create a `react-native.config.js` file with the following content:
```
module.exports = {
  healthChecks: [
    {
      label: 'Custom category',
      healthchecks: [
        {
          label: 'Custom Health Check',
          description: 'This is a custom health check',
          visible: true,
          isRequired: true,
          getDiagnostics: async () => ({
            needsToBeFixed: true,
          }),
          runAutomaticFix: async () => {
            return new Promise.resolve({});
          },
        },
      ],
    },
  ],
};
```
2. Run `node ./path-to-cli/cli/build/bin.js doctor`
3. Verify the custom health check appears in the command output
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
