### PR TITLE
fix: init uses yarn assuming version > 1.x

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -1,7 +1,14 @@
 import fs from 'fs';
 import path from 'path';
 import {runCLI, getTempDirectory, cleanup, writeFiles} from '../jest/helpers';
+import {execSync} from 'child_process';
+import semver from 'semver';
 import slash from 'slash';
+
+const yarnVersion = semver.parse(execSync('yarn --version').toString().trim())!;
+
+// .yarnrc -> .yarnrc.yml >= 2.0.0: yarnpkg/berry/issues/239
+const yarnConfigFile = yarnVersion.major > 1 ? '.yarnrc.yml' : '.yarnrc';
 
 const DIR = getTempDirectory('command-init');
 const PROJECT_NAME = 'TestInit';
@@ -23,7 +30,7 @@ function createCustomTemplateFiles() {
 const customTemplateCopiedFiles = [
   '.git',
   '.yarn',
-  '.yarnrc.yml',
+  yarnConfigFile,
   'dir',
   'file',
   'node_modules',
@@ -178,7 +185,7 @@ test('init uses npm as the package manager with --npm', () => {
   // Remove yarn specific files and node_modules
   const filteredFiles = customTemplateCopiedFiles.filter(
     (file) =>
-      !['yarn.lock', 'node_modules', '.yarnrc.yml', '.yarn'].includes(file),
+      !['yarn.lock', 'node_modules', yarnConfigFile, '.yarn'].includes(file),
   );
 
   // Add package-lock.json

--- a/jest/helpers.ts
+++ b/jest/helpers.ts
@@ -45,7 +45,7 @@ export const makeTemplate =
     });
 
 export const cleanup = (directory: string) => {
-  fs.rmSync(directory, {recursive: true, force: true});
+  fs.rmSync(directory, {recursive: true, force: true, maxRetries: 10});
 };
 
 /**
@@ -142,18 +142,18 @@ function getExecaOptions(options: SpawnOptions) {
 function handleTestFailure(
   cmd: string,
   options: SpawnOptions,
-  result: {[key: string]: any},
+  result: execa.ExecaReturnBase<string>,
   args: string[] | undefined,
 ) {
-  if (!options.expectedFailure && result.code !== 0) {
+  if (!options.expectedFailure && result.exitCode !== 0) {
     console.log(`Running ${cmd} command failed for unexpected reason. Here's more info:
 ${chalk.bold('cmd:')}     ${cmd}
 ${chalk.bold('options:')} ${JSON.stringify(options)}
 ${chalk.bold('args:')}    ${(args || []).join(' ')}
 ${chalk.bold('stderr:')}  ${result.stderr}
 ${chalk.bold('stdout:')}  ${result.stdout}
-${chalk.bold('code:')}    ${result.code}`);
-  } else if (options.expectedFailure && result.code === 0) {
+${chalk.bold('exitCode:')}${result.exitCode}`);
+  } else if (options.expectedFailure && result.exitCode === 0) {
     throw new Error("Expected command to fail, but it didn't");
   }
 }

--- a/packages/cli-platform-android/src/config/findManifest.ts
+++ b/packages/cli-platform-android/src/config/findManifest.ts
@@ -11,7 +11,7 @@ import path from 'path';
 import {unixifyPaths} from '@react-native-community/cli-tools';
 
 export default function findManifest(folder: string) {
-  let manifestPaths = glob.sync(path.join('**', 'AndroidManifest.xml'), {
+  let manifestPaths = glob.sync('**/AndroidManifest.xml', {
     cwd: unixifyPaths(folder),
     ignore: [
       'node_modules/**',

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -78,19 +78,24 @@ interface TemplateReturnType {
 
 // Here we are defining explicit version of Yarn to be used in the new project because in some cases providing `3.x` don't work.
 const YARN_VERSION = '3.6.4';
+const YARN_LEGACY_VERSION = '1.22.22';
 
 const bumpYarnVersion = async (silent: boolean, root: string) => {
   try {
     let yarnVersion = semver.parse(getYarnVersionIfAvailable());
 
     if (yarnVersion) {
-      await executeCommand('yarn', ['set', 'version', YARN_VERSION], {
+      // `yarn set` is unsupported until 1.22, however it's a alias (yarnpkg/yarn/pull/7862) calling `policies set-version`.
+      const setVersionArgs =
+        yarnVersion.major > 1
+          ? ['set', 'version', YARN_VERSION]
+          : ['policies', 'set-version', YARN_LEGACY_VERSION];
+      await executeCommand('yarn', setVersionArgs, {
         root,
         silent,
       });
 
       // React Native doesn't support PnP, so we need to set nodeLinker to node-modules. Read more here: https://github.com/react-native-community/cli/issues/27#issuecomment-1772626767
-
       await executeCommand(
         'yarn',
         ['config', 'set', 'nodeLinker', 'node-modules'],


### PR DESCRIPTION
Summary:
---------

Checks that we're using yarn > 1.x when calling `yarn set` which isn't supported [1] but is for later versions [2].  This also updated the E2E test to vary depending on whether yarn 1 or 3 is running.

[1] https://classic.yarnpkg.com/en/docs/cli/set
[2] https://yarnpkg.com/cli/set/version

Test Plan:
----------

Ran against earlier version of yarn where I hit this.

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
