### PR TITLE
fix: sourceMappingURL were incorrect .ts → .js

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -108,7 +108,7 @@ function buildFile(file, silent) {
     let {code, map} = babel.transformFileSync(file, options);
 
     if (!file.endsWith('.d.ts') && map.sources.length > 0) {
-      code = `${code}\n\n//# sourceMappingURL=${fileName}.map`;
+      code = `${code}\n\n//# sourceMappingURL=${destPath}.map`;
       map.sources = [path.relative(path.dirname(destPath), file)];
       fs.writeFileSync(`${destPath}.map`, JSON.stringify(map));
     }


### PR DESCRIPTION
Summary:
---------

When debugging I noticed the source-maps weren't working, turns out these didn't match:
![CleanShot 2024-03-15 at 15 45 33@2x](https://github.com/react-native-community/cli/assets/49578/5d161414-5f5a-43fb-b033-d1a7a68247be)


Test Plan:
----------

Verified in my development environment, with `node --inspect-brk ./packages/cli/build/bin.js --help`.

## Before
<img width="1386" alt="Screenshot 2024-03-15 at 22 30 32" src="https://github.com/react-native-community/cli/assets/49578/d70ca2f0-01cc-4f63-8455-f8c322fe568f">

## After
<img width="1501" alt="Screenshot 2024-03-15 at 22 31 28" src="https://github.com/react-native-community/cli/assets/49578/a7b15f77-1d0e-4e25-a246-93e58b615269">

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
