### PR TITLE
feat: RFC-0759: command init for iOS → @react-native/core-cli-utils

### DIFF
--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -1,12 +1,12 @@
 import {getLoader, logger, prompt} from '@react-native-community/cli-tools';
 import type {Config as CLIConfig} from '@react-native-community/cli-types';
 import chalk from 'chalk';
-import execa from 'execa';
 import {existsSync as fileExists, rm} from 'fs';
 import os from 'os';
 import path from 'path';
 import {promisify} from 'util';
 import glob from 'fast-glob';
+import execa from 'execa';
 
 type Args = {
   include?: string;

--- a/packages/cli-platform-apple/package.json
+++ b/packages/cli-platform-apple/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@react-native-community/cli-tools": "14.0.0-alpha.0",
+    "@react-native/core-cli-utils": "nightly",
     "chalk": "^4.1.2",
     "execa": "^5.0.0",
     "fast-glob": "^3.3.2",


### PR DESCRIPTION
Summary:
---------

Use the core library for iOS init actions.

> [!WARNING]
> This needs to wait for nightlies to land with the updated TypeScript definitions, expect CI to fail until then.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
