### PR TITLE
feat: improve native_module.gradle for certain custom project setups

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -534,7 +534,8 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String
 
 ext.applyNativeModulesAppBuildGradle = { Project project ->
   def reactExtension = rootProject.extensions.getByName("privateReact")
-  def autoModules = new ReactNativeModules(logger, providers, reactExtension.root.getAsFile().getOrNull() ?: rootProject.projectDir)
+  def projectRoot = reactExtension.root.getAsFile().getOrNull() ?: rootProject.projectDir
+  def autoModules = new ReactNativeModules(logger, providers, projectRoot)
   autoModules.addReactNativeModuleDependencies(project)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -520,7 +520,7 @@ def getAutoModules(customPathToProject) {
     projectRoot = rootProject.projectDir
   }
 
-  return new ReactNativeModules(logger, projectRoot)
+  return new ReactNativeModules(logger, providers, projectRoot)
 }
 
 /** -----------------------
@@ -532,8 +532,9 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String
   autoModules.addReactNativeModuleProjects(defaultSettings)
 }
 
-ext.applyNativeModulesAppBuildGradle = { Project project, String customPathToProject = null ->
-  def autoModules = getAutoModules(customPathToProject)
+ext.applyNativeModulesAppBuildGradle = { Project project ->
+  def reactExtension = rootProject.extensions.getByName("privateReact")
+  def autoModules = new ReactNativeModules(logger, reactExtension.root.getAsFile().getOrNull() ?: rootProject.projectDir)
   autoModules.addReactNativeModuleDependencies(project)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -511,24 +511,13 @@ def reactNativeVersionRequireNewArchEnabled(autoModules) {
     return false
 }
 
-def getAutoModules(customPathToProject) {
-  def projectRoot
-
-  if (customPathToProject != null) {
-    projectRoot = new File(rootProject.projectDir, customPathToProject)
-  } else {
-    projectRoot = rootProject.projectDir
-  }
-
-  return new ReactNativeModules(logger, providers, projectRoot)
-}
-
 /** -----------------------
  *    Exported Extensions
  * ------------------------ */
 
-ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String customPathToProject = null ->
-  def autoModules = getAutoModules(customPathToProject)
+ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, File reactRoot = null ->
+  def projectRoot = reactRoot != null ? reactRoot : rootProject.projectDir
+  def autoModules = new ReactNativeModules(logger, providers, projectRoot)
   autoModules.addReactNativeModuleProjects(defaultSettings)
 }
 

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -496,15 +496,6 @@ class ReactNativeModules {
   }
 }
 
-
-/*
- * Sometimes Gradle can be called outside of JavaScript hierarchy. Detect the directory
- * where build files of an active project are located.
- */
-def projectRoot = rootProject.projectDir
-
-def autoModules = new ReactNativeModules(logger, providers, projectRoot)
-
 def reactNativeVersionRequireNewArchEnabled(autoModules) {
     def rnVersion = autoModules.reactNativeVersion
     def regexPattern = /^(\d+)\.(\d+)\.(\d+)(?:-(\w+(?:[-.]\d+)?))?$/
@@ -520,15 +511,29 @@ def reactNativeVersionRequireNewArchEnabled(autoModules) {
     return false
 }
 
+def getAutoModules(customPathToProject) {
+  def projectRoot
+
+  if (customPathToProject != null) {
+    projectRoot = new File(rootProject.projectDir, customPathToProject)
+  } else {
+    projectRoot = rootProject.projectDir
+  }
+
+  return new ReactNativeModules(logger, projectRoot)
+}
+
 /** -----------------------
  *    Exported Extensions
  * ------------------------ */
 
-ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings ->
+ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String customPathToProject = null ->
+  def autoModules = getAutoModules(customPathToProject)
   autoModules.addReactNativeModuleProjects(defaultSettings)
 }
 
-ext.applyNativeModulesAppBuildGradle = { Project project ->
+ext.applyNativeModulesAppBuildGradle = { Project project, String customPathToProject = null ->
+  def autoModules = getAutoModules(customPathToProject)
   autoModules.addReactNativeModuleDependencies(project)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -534,7 +534,7 @@ ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, String
 
 ext.applyNativeModulesAppBuildGradle = { Project project ->
   def reactExtension = rootProject.extensions.getByName("privateReact")
-  def autoModules = new ReactNativeModules(logger, reactExtension.root.getAsFile().getOrNull() ?: rootProject.projectDir)
+  def autoModules = new ReactNativeModules(logger, providers, reactExtension.root.getAsFile().getOrNull() ?: rootProject.projectDir)
   autoModules.addReactNativeModuleDependencies(project)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
This change include the ability for project to run a custom setup where the react project is not directly part of the android root project but instead is located somewhere else.

This change is backwards compatible and won't break any templates or existing projects.

I have added more details as part of this issue: https://github.com/react-native-community/cli/issues/2289

Test Plan:
----------
I added a patch in my local project setup (RN 0.73.6) and was able to compile and run the project without issues. This is the following patch I've applied:

```patch
diff --git a/native_modules.gradle b/native_modules.gradle
index bbfa7f741aed02bbeed4494c56a475ec19171c70..d07af21dfed430ed8fd33eb253e7588e8d9c48b5 100644
--- a/native_modules.gradle
+++ b/native_modules.gradle
@@ -479,15 +479,6 @@ class ReactNativeModules {
   }
 }
 
-
-/*
- * Sometimes Gradle can be called outside of JavaScript hierarchy. Detect the directory
- * where build files of an active project are located.
- */
-def projectRoot = rootProject.projectDir
-
-def autoModules = new ReactNativeModules(logger, projectRoot)
-
 def reactNativeVersionRequireNewArchEnabled(autoModules) {
     def rnVersion = autoModules.reactNativeVersion
     def regexPattern = /^(\d+)\.(\d+)\.(\d+)(?:-(\w+(?:[-.]\d+)?))?$/
@@ -507,11 +498,16 @@ def reactNativeVersionRequireNewArchEnabled(autoModules) {
  *    Exported Extensions
  * ------------------------ */
 
-ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings ->
+ext.applyNativeModulesSettingsGradle = { DefaultSettings defaultSettings, File reactRoot = null ->
+  def projectRoot = reactRoot != null ? reactRoot : rootProject.projectDir
+  def autoModules = new ReactNativeModules(logger, projectRoot)
   autoModules.addReactNativeModuleProjects(defaultSettings)
 }
 
 ext.applyNativeModulesAppBuildGradle = { Project project ->
+  def reactExtension = rootProject.extensions.getByName("privateReact")
+  def projectRoot = reactExtension.root.getAsFile().getOrNull() ?: rootProject.projectDir
+  def autoModules = new ReactNativeModules(logger, projectRoot)
   autoModules.addReactNativeModuleDependencies(project)
 
   def generatedSrcDir = new File(buildDir, "generated/rncli/src/main/java")
```

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
