### PR TITLE
fix: Make sure cxxModuleCMakeListsPath is treated as relative path

### DIFF
--- a/packages/cli-platform-android/src/config/index.ts
+++ b/packages/cli-platform-android/src/config/index.ts
@@ -169,7 +169,10 @@ export function dependencyConfig(
   const cxxModuleCMakeListsModuleName =
     userConfig.cxxModuleCMakeListsModuleName || null;
   const cxxModuleHeaderName = userConfig.cxxModuleHeaderName || null;
-  let cxxModuleCMakeListsPath = userConfig.cxxModuleCMakeListsPath || null;
+  let cxxModuleCMakeListsPath = userConfig.cxxModuleCMakeListsPath
+    ? path.join(sourceDir, userConfig.cxxModuleCMakeListsPath)
+    : null;
+
   if (process.platform === 'win32') {
     cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
     if (cxxModuleCMakeListsPath) {


### PR DESCRIPTION
Summary:
---------

Currently `cxxModuleCMakeListsPath` works only with absolute paths. This is quite bad as it prevents C++ autolinking adoption in 0.74.

Test Plan:
----------

Tested against the TM C++ Autolinking here:
https://github.com/cortinico/reproducer-cxx-tm-autolinking

Specifically here https://github.com/cortinico/reproducer-cxx-tm-autolinking/commit/d9866946e0b554c3f946e425dae2a72d9a4b26c1#r140284699

With this change we can change this file as follows
```diff
module.exports = {
  dependency: {
    platforms: {
      android: {
        cxxModuleCMakeListsModuleName: "react-native-reproducer-cxx-tm-autolinking",
-       cxxModuleCMakeListsPath: "/Users/ncor/pg/RN074/node_modules/react-native-reproducer-cxx-tm-autolinking/android/CMakeLists.txt",
+       cxxModuleCMakeListsPath: "./CMakeLists.txt",
        cxxModuleHeaderName: "NativeCxxModuleExample"
      },
    },
  },
};
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
