### PR TITLE
fix(cli-tools): fix nightly builds not being correctly detected

### DIFF
--- a/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
@@ -51,12 +51,9 @@ export default async function getLatestRelease(
   try {
     logger.debug(`Current version: ${currentVersion}`);
 
-    // if the version is a 1000.0.0 version or 0.0.0, we want to bail
+    // if the version is a nightly/canary build, we want to bail
     // since they are nightlies or unreleased versions
-    if (
-      currentVersion.includes('1000.0.0') ||
-      currentVersion.includes('0.0.0')
-    ) {
+    if (['-canary', '-nightly'].some((s) => currentVersion.includes(s))) {
       return;
     }
 

--- a/packages/cli-tools/src/releaseChecker/index.ts
+++ b/packages/cli-tools/src/releaseChecker/index.ts
@@ -4,7 +4,7 @@ import semver, {SemVer} from 'semver';
 import {UnknownProjectError} from '../errors';
 import logger from '../logger';
 import resolveNodeModuleDir from '../resolveNodeModuleDir';
-import getLatestRelease, {Release} from './getLatestRelease';
+import getLatestRelease, {type Release} from './getLatestRelease';
 import printNewRelease from './printNewRelease';
 
 const getReactNativeVersion = (projectRoot: string): string | undefined =>

--- a/packages/cli-tools/src/releaseChecker/printNewRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/printNewRelease.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import * as link from '../doclink';
 
 import logger from '../logger';
-import {Release} from './getLatestRelease';
+import type {Release} from './getLatestRelease';
 import cacheManager from '../cacheManager';
 
 /**


### PR DESCRIPTION
Summary:
---------

Nightly builds no longer contain `1000.0.0`. Changed to check for either `-nightly` or `-canary` (Windows).

Test Plan:
----------

n/a