### PR TITLE
Fixed cannot start Android emulator version 34.1.20.0

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -9,7 +9,8 @@ const emulatorCommand = process.env.ANDROID_HOME
 export const getEmulators = () => {
   try {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
-    return emulatorsOutput.split(os.EOL).filter((name) => name !== '');
+    return emulatorsOutput.split(os.EOL)
+      .filter((name) => name !== '' && !name.startsWith('INFO    | '));
   } catch {
     return [];
   }

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -9,7 +9,8 @@ const emulatorCommand = process.env.ANDROID_HOME
 export const getEmulators = () => {
   try {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
-    return emulatorsOutput.split(os.EOL)
+    return emulatorsOutput
+      .split(os.EOL)
       .filter((name) => name !== '' && !name.startsWith('INFO    | '));
   } catch {
     return [];


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Fixes https://github.com/react-native-community/cli/issues/2350

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
```
» npm run android 

> connectedCoffee@0.0.1 android
> react-native run-android

info Launching emulator...
error Failed to launch emulator. Reason: The emulator (INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 30977) quit before it finished opening. You can try starting the emulator manually from the terminal with: /Users/sung.lee/Library/Android/sdk/emulator/emulator @INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 30977.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.
```

```

» emulator
INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 37429
INFO    | Android emulator version 34.1.20.0 (build_id 11610631) (CL:N/A)
ERROR   | No AVD specified. Use '@foo' or '-avd foo' to launch a virtual device named 'foo'

» emulator -list-avds
INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 37459
Pixel_7a_API_33

```

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

```
 » npm run android 

> connectedCoffee@0.0.1 android
> react-native run-android

info A dev server is already running for this project on port 8081.
info Launching emulator...
info Successfully launched emulator.
info Installing the app...

> Configure project :expo

Using expo modules
  - expo-application (5.8.3)
  - expo-av (13.10.5)
  - expo-constants (15.4.5)
  - expo-file-system (16.0.8)
  - expo-font (11.10.3)
  - expo-haptics (12.8.1)
  - expo-keep-awake (12.8.2)
  - expo-modules-core (1.11.12)
  - expo-modules-core$android-annotation (1.11.12)
  - expo-modules-core$android-annotation-processor (1.11.12)


> Task :app:installDebug
Installing APK 'app-debug.apk' on 'emulator-5554 - 13' for :app:debug
Installed on 1 device.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.3/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 19s
496 actionable tasks: 26 executed, 470 up-to-date
info Connecting to the development server...
8081
info Starting the app on "emulator-5554"...
Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=com.connectedcoffee/.MainActivity }
```

Checklist
----------

- [*] Documentation is up to date to reflect these changes.
- [*] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
