### PR TITLE
fix(cli-debugger-ui): fix missing `@babel/runtime` dependency

### DIFF
--- a/packages/cli-debugger-ui/package.json
+++ b/packages/cli-debugger-ui/package.json
@@ -15,9 +15,11 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.6.4",
+    "@babel/plugin-transform-runtime": "^7.6.2",
     "parcel-bundler": "^1.12.5"
   },
   "dependencies": {
+    "@babel/runtime": "^7.8.4",
     "serve-static": "^1.13.1"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-debugger-ui",


### PR DESCRIPTION
Summary:
---------

`@babel/plugin-transform-runtime` adds an implicit dependency on `@babel/runtime`, which causes issues in pnpm setups if not declared.

Test Plan:
----------

n/a

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)