### PR TITLE
Fixed cannot start Android emulator version 34.1.20.0

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -9,7 +9,8 @@ const emulatorCommand = process.env.ANDROID_HOME
 export const getEmulators = () => {
   try {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
-    return emulatorsOutput.split(os.EOL).filter((name) => name !== '');
+    return emulatorsOutput.split(os.EOL)
+      .filter((name) => name !== '' && !name.startsWith('INFO    | '));
   } catch {
     return [];
   }

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -11,6 +11,10 @@ export const getEmulators = () => {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
     return emulatorsOutput
       .split(os.EOL)
+      // The `name` is AVD ID which is expected to not contain whitespace.
+      // The `emulator` command, however, can occasionally return verbose
+      // information about crashes or similar. Hence filtering out anything 
+      // that has basic whitespace.
       .filter((name) => name !== '' && !name.includes(' '));
   } catch {
     return [];

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -9,7 +9,8 @@ const emulatorCommand = process.env.ANDROID_HOME
 export const getEmulators = () => {
   try {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
-    return emulatorsOutput.split(os.EOL)
+    return emulatorsOutput
+      .split(os.EOL)
       .filter((name) => name !== '' && !name.startsWith('INFO    | '));
   } catch {
     return [];

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -11,11 +11,11 @@ export const getEmulators = () => {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
     return emulatorsOutput
       .split(os.EOL)
-      // The `name` is AVD ID which is expected to not contain whitespace.
-      // The `emulator` command, however, can occasionally return verbose
-      // information about crashes or similar. Hence filtering out anything 
-      // that has basic whitespace.
       .filter((name) => name !== '' && !name.includes(' '));
+    // The `name` is AVD ID which is expected to not contain whitespace.
+    // The `emulator` command, however, can occasionally return verbose
+    // information about crashes or similar. Hence filtering out anything
+    // that has basic whitespace.
   } catch {
     return [];
   }

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchEmulator.ts
@@ -11,7 +11,7 @@ export const getEmulators = () => {
     const emulatorsOutput = execa.sync(emulatorCommand, ['-list-avds']).stdout;
     return emulatorsOutput
       .split(os.EOL)
-      .filter((name) => name !== '' && !name.startsWith('INFO    | '));
+      .filter((name) => name !== '' && !name.includes(' '));
   } catch {
     return [];
   }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Closes https://github.com/react-native-community/cli/pull/2351
Fixes https://github.com/react-native-community/cli/issues/2350

```
» npm run android 

> connectedCoffee@0.0.1 android
> react-native run-android

info Launching emulator...
error Failed to launch emulator. Reason: The emulator (INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 30977) quit before it finished opening. You can try starting the emulator manually from the terminal with: /Users/sung.lee/Library/Android/sdk/emulator/emulator @INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 30977.
warn Please launch an emulator manually or connect a device. Otherwise app may fail to launch.
```
```
» emulator
INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 37429
INFO    | Android emulator version 34.1.20.0 (build_id 11610631) (CL:N/A)
ERROR   | No AVD specified. Use '@foo' or '-avd foo' to launch a virtual device named 'foo'

» emulator -list-avds
INFO    | Storing crashdata in: /tmp/android-sung.lee/emu-crash-34.1.20.db, detection is enabled for process: 37459
Pixel_7a_API_33
```


There's an issue with launching emulator in 34.1.20.0. Previously #2351  @doothez published PR that fixes, this PR changes some logic of it. For more context you can find it from #2351 


<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
```
yarn react-native run-android 
yarn run v1.22.22
$ /Users/****/WebstormProjects/AwesomeProject/node_modules/.bin/react-native run-android
(node:4859) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
info A dev server is already running for this project on port 8081.
info Launching emulator...
info Successfully launched emulator.
info Installing the app...

> Task :app:installDebug
Installing APK 'app-debug.apk' on 'Pixel_3a_API_34_extension_level_7_arm64-v8a(AVD) - 14' for :app:debug
Installed on 1 device.

BUILD SUCCESSFUL in 5s
43 actionable tasks: 2 executed, 41 up-to-date
info Connecting to the development server...
8081
info Starting the app on "emulator-5554"...
Starting: Intent { act=android.intent.action.MAIN cat=[android.intent.category.LAUNCHER] cmp=com.awesomeproject/.MainActivity }
✨  Done in 12.24s.

```
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [*] Documentation is up to date to reflect these changes.
- [*] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
