### PR TITLE
fix: use preferred device in default mode

### DIFF
--- a/packages/cli-platform-apple/src/tools/prompts.ts
+++ b/packages/cli-platform-apple/src/tools/prompts.ts
@@ -40,25 +40,12 @@ export async function promptForConfigurationSelection(
 
 export async function promptForDeviceSelection(
   devices: Device[],
-  lastUsedIOSDeviceId?: string,
 ): Promise<Device | undefined> {
-  const sortedDevices = [...devices];
-  const devicesIds = sortedDevices.map(({udid}) => udid);
-
-  if (lastUsedIOSDeviceId) {
-    const preferredDeviceIndex = devicesIds.indexOf(lastUsedIOSDeviceId);
-
-    if (preferredDeviceIndex > -1) {
-      const [preferredDevice] = sortedDevices.splice(preferredDeviceIndex, 1);
-      sortedDevices.unshift(preferredDevice);
-    }
-  }
-
   const {device} = await prompt({
     type: 'select',
     name: 'device',
     message: 'Select the device you want to use',
-    choices: sortedDevices
+    choices: devices
       .filter(({type}) => type === 'device' || type === 'simulator')
       .map((d) => {
         const availability =


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In https://github.com/react-native-community/cli/pull/2162 I added preferred device feature - it saves device id to cache, and then when running `run-ios` command it'll push preferred device to the beginning. 

For some strange reason, we only enabled this for `--interactive` or `--list-devices` mode. In this Pull Request preferred device is also in default mode. 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run `run-ios --interactive` pick a simulator
3. Open bunch other simulators
4. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios
```
5. It should pick one that was selected in the interactive prompt.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
