### PR TITLE
fix(ios): prioritize simulators over devices

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -240,17 +240,6 @@ const createRun =
 
       logger.info(`Found booted ${booted.map(({name}) => name).join(', ')}`);
 
-      for (const device of bootedDevices) {
-        await runOnDevice(
-          device,
-          platformName,
-          mode,
-          scheme,
-          xcodeProject,
-          args,
-        );
-      }
-
       for (const simulator of bootedSimulators) {
         await runOnSimulator(
           xcodeProject,
@@ -259,6 +248,17 @@ const createRun =
           scheme,
           args,
           simulator || fallbackSimulator,
+        );
+      }
+
+      for (const device of bootedDevices) {
+        await runOnDevice(
+          device,
+          platformName,
+          mode,
+          scheme,
+          xcodeProject,
+          args,
         );
       }
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In `run-ios` command we prioritize simulators over devices:
https://github.com/react-native-community/cli/blob/992d01dc2d985c9950acac5a5d4855f91d54fd74/packages/cli-platform-apple/src/commands/runCommand/createRun.ts#L225
but we're launching app first on a device then on a simulator, in this PR I switched the order of launching app to align with logging and previous assumptions.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
