### PR TITLE
fix(init): bump Yarn version on older Yarn versions

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -82,7 +82,6 @@ interface TemplateReturnType {
 
 // Here we are defining explicit version of Yarn to be used in the new project because in some cases providing `3.x` don't work.
 const YARN_VERSION = '3.6.4';
-const YARN_LEGACY_VERSION = '1.22.22';
 
 const bumpYarnVersion = async (silent: boolean, root: string) => {
   try {
@@ -91,9 +90,10 @@ const bumpYarnVersion = async (silent: boolean, root: string) => {
     if (yarnVersion) {
       // `yarn set` is unsupported until 1.22, however it's a alias (yarnpkg/yarn/pull/7862) calling `policies set-version`.
       const setVersionArgs =
-        yarnVersion.major > 1
+        yarnVersion.major > 1 && yarnVersion.minor >= 22
           ? ['set', 'version', YARN_VERSION]
-          : ['policies', 'set-version', YARN_LEGACY_VERSION];
+          : ['policies', 'set-version', YARN_VERSION];
+
       await executeCommand('yarn', setVersionArgs, {
         root,
         silent,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In https://github.com/react-native-community/cli/pull/2329 we've fixed support for older Yarn version, but also added a regression where actually *all* version of Yarn 1.x won't bump Yarn to `3.6.4` which is not what we want. 

In this Pull Request I've extended a condition to check the minor version, if it's higher or equal to `22` we can use safely use `yarn set version 3.6.4`, if not we use `yarn set policies set-version` with `3.6.4` not with the latest Yarn Classic versions.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Make sure your global Yarn version is `1.22.9`
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init AwesomeProject
```
4. Go to `./AwesomeProject` directory and check if `yarn --version` is equal to `3.6.4`.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
