### PR TITLE
fix: update the diff link at update check to show both the old and new versions

### DIFF
--- a/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
+++ b/packages/cli-tools/src/releaseChecker/getLatestRelease.ts
@@ -73,7 +73,7 @@ export default async function getLatestRelease(
         stable,
         candidate,
         changelogUrl: buildChangelogUrl(stable),
-        diffUrl: buildDiffUrl(currentVersion),
+        diffUrl: buildDiffUrl(currentVersion, stable),
       };
     }
   } catch (e) {
@@ -89,8 +89,8 @@ function buildChangelogUrl(version: string) {
   return `https://github.com/facebook/react-native/releases/tag/v${version}`;
 }
 
-function buildDiffUrl(version: string) {
-  return `https://react-native-community.github.io/upgrade-helper/?from=${version}`;
+function buildDiffUrl(oldVersion: string, newVersion: string) {
+  return `https://react-native-community.github.io/upgrade-helper/?from=${oldVersion}&to=${newVersion}`;
 }
 
 type LatestVersions = {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->

When the newer ReactNative version comes out, we can see some info at console like this:

```
info React Native v0.74.1 is now available (your project is running on v0.73.6).
info Changelog: https://github.com/facebook/react-native/releases/tag/v0.74.1
info Diff: https://react-native-community.github.io/upgrade-helper/?from=0.74.1
info For more info, check out "https://reactnative.dev/docs/upgrading?os=windows".
info Dev server ready
```

but the Diff link can accept both old version and new version like this: 

```
info Diff: https://react-native-community.github.io/upgrade-helper/?from=0.73.6&to=0.74.1
```

This is what this pr solved


Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
