### PR TITLE
chore: change `react-native` executable path key to `rnccli`

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
     "access": "public"
   },
   "bin": {
-    "rnc": "build/bin.js"
+    "rnccli": "build/bin.js",
+    "@react-native-community/cli": "build/bin.js"
   },
   "files": [
     "build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "access": "public"
   },
   "bin": {
-    "react-native": "build/bin.js"
+    "rnc": "build/bin.js"
   },
   "files": [
     "build",


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In this Pull Request I changed `react-native` executable to `rnc` key, `react-native` as key caused an issue where `@react-native-community/cli` executable overwrites `react-native`'s one (it sorts executables alphabetically). With current change running `npx react-native init` will execute [`cli.js`](https://github.com/facebook/react-native/blob/362abb9ffea5af7e6e5616849fbce28166c758a0/packages/react-native/package.json#L27) which is inside `react-native`, and then it'll resolve to `@react-native-community/cli`, so this change doesn't affects any of current behaviour for now.


If you want to check how `npx` resolves executables under same key, and why it's causing an issue - read more [here](https://github.com/byCedric/npm-npx-bin-collision#readme).

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Clone https://github.com/facebook/react-native, and follow their Contributing guide
3. Link CLI packages under `packages/react-native`, and `node_modules/.bin/rnc` → should resolve to `../../../../node_modules/@react-native-community/cli/build/bin.js`.
 
Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
