### PR TITLE
feat(run-ios): allow passing UDID inside `--device` option

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -300,9 +300,36 @@ const createRun =
         );
       }
     } else if (args.device) {
-      const physicalDevices = devices.filter(({type}) => type !== 'simulator');
-      const device = matchingDevice(physicalDevices, args.device);
-      if (device) {
+      let device = matchingDevice(devices, args.device);
+
+      if (!device) {
+        const deviceByUdid = devices.find((d) => d.udid === args.device);
+        if (!deviceByUdid) {
+          return logger.error(
+            `Could not find a physical device with name or unique device identifier: "${chalk.bold(
+              args.device,
+            )}". ${printFoundDevices(devices, 'device')}`,
+          );
+        }
+
+        device = deviceByUdid;
+
+        if (deviceByUdid.type === 'simulator') {
+          return logger.error(
+            `The device with udid: "${chalk.bold(
+              args.device,
+            )}" is a simulator. If you want to run on a simulator, use the "--simulator" flag instead.`,
+          );
+        }
+      }
+
+      if (device && device.type === 'simulator') {
+        return logger.error(
+          "`--device` flag is intended for physical devices. If you're trying to run on a simulator, use `--simulator` instead.",
+        );
+      }
+
+      if (device && device.type === 'device') {
         return runOnDevice(
           device,
           platformName,

--- a/packages/cli-platform-apple/src/commands/runCommand/matchingDevice.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/matchingDevice.ts
@@ -1,6 +1,6 @@
 import {logger} from '@react-native-community/cli-tools';
 import chalk from 'chalk';
-import {Device} from '../../types';
+import {Device, DeviceType} from '../../types';
 
 export function matchingDevice(
   devices: Array<Device>,
@@ -20,18 +20,10 @@ export function matchingDevice(
       return undefined;
     }
   }
-  const deviceByName = devices.find(
+  return devices.find(
     (device) =>
       device.name === deviceName || formattedDeviceName(device) === deviceName,
   );
-  if (!deviceByName) {
-    logger.error(
-      `Could not find a device named: "${chalk.bold(
-        String(deviceName),
-      )}". ${printFoundDevices(devices)}`,
-    );
-  }
-  return deviceByName;
 }
 
 export function formattedDeviceName(simulator: Device) {
@@ -40,9 +32,15 @@ export function formattedDeviceName(simulator: Device) {
     : simulator.name;
 }
 
-export function printFoundDevices(devices: Array<Device>) {
+export function printFoundDevices(devices: Array<Device>, type?: DeviceType) {
+  let filteredDevice = [...devices];
+
+  if (type) {
+    filteredDevice = filteredDevice.filter((device) => device.type === type);
+  }
+
   return [
     'Available devices:',
-    ...devices.map((device) => `  - ${device.name} (${device.udid})`),
+    ...filteredDevice.map(({name, udid}) => `  - ${name} (${udid})`),
   ].join('\n');
 }

--- a/packages/cli-platform-apple/src/commands/runCommand/matchingDevice.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/matchingDevice.ts
@@ -6,6 +6,7 @@ export function matchingDevice(
   devices: Array<Device>,
   deviceName: string | true | undefined,
 ) {
+  // The condition specifically checks if the value is `true`, not just truthy to allow for `--device` flag without a value
   if (deviceName === true) {
     const firstIOSDevice = devices.find((d) => d.type === 'device')!;
     if (firstIOSDevice) {

--- a/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
@@ -45,7 +45,7 @@ export const getRunOptions = ({platformName}: BuilderCommand) => {
     !isMac && {
       name: '--device [string]', // here we're intentionally using [] over <> to make passed value optional to allow users to run only on physical devices
       description:
-        'Explicitly set the device to use by name. If the value is not provided,' +
+        'Explicitly set the device to use by name or by unique device identifier . If the value is not provided,' +
         'the app will run on the first available physical device.',
     },
     ...getBuildOptions({platformName}),

--- a/packages/cli-platform-apple/src/types.ts
+++ b/packages/cli-platform-apple/src/types.ts
@@ -12,9 +12,11 @@ export interface Device {
   version?: string;
   sdk?: string;
   availabilityError?: string;
-  type?: 'simulator' | 'device' | 'catalyst';
+  type?: DeviceType;
   lastBootedAt?: string;
 }
+
+export type DeviceType = 'simulator' | 'device' | 'catalyst';
 
 export interface IosInfo {
   name: string;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

We have bunch of options to provide a target to run app on:
→ `--device`,
→ `--simulator`, 
→ `--udid`.

It creates some misconception for users, where one flag works as expected in theory but user think that it's not working since they may don't know about other options.

In this Pull Request I've improved experience of using `--device` flag in `run-ios` function (I'll add `run-android` implementation in separate Pull Request). From now `--device` accepts device name and unique device identifier and also checks if target device is maybe a simulator to give an appropriate error message to guide user what they should use. 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. This command

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --device "iPhone Szymon"
```
should run app on physical device.
3. This command

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --device "XYZ-UDID-PHYSICAL"
```
should run app also on physical device (the same behaviour as with device name).
4. This command (iPhone 15 is a simulator)

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --device "iPhone 15"
```
should throw the error: 
5. This command ("XYZ-UDID-SIMULATOR" is a simulator's UDID)

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios --device "XYZ-UDID-SIMULATOR"
```
should also throw the error: 



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
