### PR TITLE
chore(run-android): deprecate `--deviceId` in favour of `--device`

### DIFF
--- a/packages/cli-platform-android/README.md
+++ b/packages/cli-platform-android/README.md
@@ -36,9 +36,15 @@ Specify an `applicationIdSuffix` to launch after build.
 
 Name of the activity to start.
 
+#### `--device [string]`
+
+Explicitly set the device to use by name. The value is not required if you have a single device connected.
+
 #### `--deviceId <string>`
 
-builds your app and starts it on a specific device/simulator with the given device id (listed by running "adb devices" on the command line).
+> **DEPRECATED** - use `--device [string]` instead
+
+Builds your app and starts it on a specific device with the given device id (listed by running "adb devices" on the command line).
 
 #### `--no-packager`
 

--- a/packages/cli-platform-android/README.md
+++ b/packages/cli-platform-android/README.md
@@ -36,13 +36,13 @@ Specify an `applicationIdSuffix` to launch after build.
 
 Name of the activity to start.
 
-#### `--device [string]`
+#### `--device <string>`
 
 Explicitly set the device to use by name. The value is not required if you have a single device connected.
 
 #### `--deviceId <string>`
 
-> **DEPRECATED** - use `--device [string]` instead
+> **DEPRECATED** - use `--device <string>` instead
 
 Builds your app and starts it on a specific device with the given device id (listed by running "adb devices" on the command line).
 

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -38,7 +38,7 @@ export interface Flags extends BuildFlags {
   port: number;
   terminal?: string;
   packager?: boolean;
-  device?: string | true;
+  device?: string;
   deviceId?: string;
   listDevices?: boolean;
   binaryPath?: string;
@@ -337,7 +337,7 @@ export default {
       description: 'Name of the activity to start',
     },
     {
-      name: '--device [string]',
+      name: '--device <string>',
       description:
         'Explicitly set the device to use by name. The value is not required ' +
         'if you have a single device connected.',

--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -125,7 +125,7 @@ async function getAvailableDevicePort(
 async function buildAndRun(args: Flags, androidProject: AndroidProject) {
   if (args.deviceId) {
     logger.warn(
-      'The `deviceId` parameter is deprecated. Please use `device` instead.',
+      'The `deviceId` parameter is renamed to `device`. Please use the new `device` argument next time to avoid this warning.',
     );
     args.device = args.deviceId;
   }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

To avoid confusion between `run-android` and `run-ios`, I deprecated `--device-id` in favour of `--device. When someone will use `--device-id` a warning will be presented, so that users can migrate their scripts.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-android --deviceId "asdf"
```
Should give the warning and pass id the same way as before.
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-android --device "asdf"
```
Should launch an app on passed id.
 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
