### PR TITLE
perf(autolinking): get platform's specific properties

### DIFF
--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -66,7 +66,7 @@ test('should have a valid structure by default', () => {
       reactNativePath: "."
     }`,
   });
-  const config = loadConfig(DIR);
+  const config = loadConfig({projectRoot: DIR});
   expect(removeString(config, DIR)).toMatchSnapshot();
 });
 
@@ -83,7 +83,7 @@ test('should return dependencies from package.json', () => {
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(removeString(dependencies, DIR)).toMatchSnapshot();
 });
 
@@ -122,7 +122,7 @@ test('should read a config of a dependency and use it to load other settings', (
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(
     removeString(dependencies['react-native-test'], DIR),
   ).toMatchSnapshot();
@@ -173,7 +173,7 @@ test('command specified in root config should overwrite command in "react-native
       ],
     };`,
   });
-  const {commands} = loadConfig(DIR);
+  const {commands} = loadConfig({projectRoot: DIR});
   const commandsNames = commands.map(({name}) => name);
   const commandIndex = commandsNames.indexOf('foo-command');
 
@@ -206,7 +206,7 @@ test('should merge project configuration with default values', () => {
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(removeString(dependencies['react-native-test'], DIR)).toMatchSnapshot(
     'snapshoting `react-native-test` config',
   );
@@ -241,7 +241,7 @@ test('should load commands from "react-native-foo" and "react-native-bar" packag
       }
     }`,
   });
-  const {commands} = loadConfig(DIR);
+  const {commands} = loadConfig({projectRoot: DIR});
   expect(commands).toMatchSnapshot();
 });
 
@@ -261,7 +261,7 @@ test('should not skip packages that have invalid configuration (to avoid breakin
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(removeString(dependencies, DIR)).toMatchSnapshot(
     'dependencies config',
   );
@@ -281,7 +281,7 @@ test('does not use restricted "react-native" key to resolve config from package.
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(dependencies).toHaveProperty('react-native-netinfo');
   expect(spy).not.toHaveBeenCalled();
 });
@@ -327,7 +327,7 @@ module.exports = {
     }`,
   });
 
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(removeString(dependencies['local-lib'], DIR)).toMatchInlineSnapshot(`
     Object {
       "name": "local-lib",
@@ -367,7 +367,7 @@ test('should apply build types from dependency config', () => {
       }
     }`,
   });
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(
     removeString(dependencies['react-native-test'], DIR),
   ).toMatchSnapshot();
@@ -400,7 +400,7 @@ test('supports dependencies from user configuration with custom build type', () 
     }`,
   });
 
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(
     removeString(dependencies['react-native-test'], DIR),
   ).toMatchSnapshot();
@@ -429,7 +429,7 @@ test('supports disabling dependency for ios platform', () => {
     }`,
   });
 
-  const {dependencies} = loadConfig(DIR);
+  const {dependencies} = loadConfig({projectRoot: DIR});
   expect(
     removeString(dependencies['react-native-test'], DIR),
   ).toMatchSnapshot();
@@ -494,7 +494,7 @@ test('should convert project sourceDir relative path to absolute', () => {
     `,
   });
 
-  const config = loadConfig(DIR);
+  const config = loadConfig({projectRoot: DIR});
 
   expect(config.project.ios?.sourceDir).toBe(path.join(DIR, iosProjectDir));
   expect(config.project.android?.sourceDir).toBe(

--- a/packages/cli-config/src/commands/config.ts
+++ b/packages/cli-config/src/commands/config.ts
@@ -21,6 +21,12 @@ function filterConfig(config: Config) {
 export default {
   name: 'config',
   description: 'Print CLI configuration',
+  options: [
+    {
+      name: '--platform <platform>',
+      description: 'Output configuration for a specific platform',
+    },
+  ],
   func: async (_argv: string[], ctx: Config) => {
     console.log(JSON.stringify(filterConfig(ctx), null, 2));
   },

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -85,10 +85,13 @@ const removeDuplicateCommands = <T extends boolean>(commands: Command<T>[]) => {
 /**
  * Loads CLI configuration
  */
-function loadConfig(
-  projectRoot: string = findProjectRoot(),
-  selectedPlatform?: string,
-): Config {
+function loadConfig({
+  projectRoot = findProjectRoot(),
+  selectedPlatform,
+}: {
+  projectRoot?: string;
+  selectedPlatform?: string;
+}): Config {
   let lazyProject: ProjectConfig;
   const userConfig = readConfigFromDisk(projectRoot);
 

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -86,8 +86,8 @@ const removeDuplicateCommands = <T extends boolean>(commands: Command<T>[]) => {
  * Loads CLI configuration
  */
 function loadConfig(
-  selectedPlatform?: string,
   projectRoot: string = findProjectRoot(),
+  selectedPlatform?: string,
 ): Config {
   let lazyProject: ProjectConfig;
   const userConfig = readConfigFromDisk(projectRoot);

--- a/packages/cli-doctor/src/commands/__tests__/info.test.ts
+++ b/packages/cli-doctor/src/commands/__tests__/info.test.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
   jest.resetAllMocks();
 });
 
-const config = loadConfig();
+const config = loadConfig({});
 
 test('prints output without arguments', async () => {
   await info.func([], config);

--- a/packages/cli-doctor/src/tools/healthchecks/index.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/index.ts
@@ -36,7 +36,7 @@ export const getHealthchecks = ({contributor}: Options): Healthchecks => {
 
   // Doctor can run in a detached mode, where there isn't a config so this can fail
   try {
-    config = loadConfig();
+    config = loadConfig({});
     additionalChecks = config.healthChecks;
 
     if (config.reactNativePath) {

--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -432,7 +432,7 @@ class ReactNativeModules {
     String[] nodeCommand = ["node", "-e", cliResolveScript]
     def cliPath = this.getCommandOutput(nodeCommand, this.root)
 
-    String[] reactNativeConfigCommand = ["node", cliPath, "config"]
+    String[] reactNativeConfigCommand = ["node", cliPath, "config", "--platform", "android"]
     def reactNativeConfigOutput = this.getCommandOutput(reactNativeConfigCommand, this.root)
 
     def json

--- a/packages/cli-platform-ios/native_modules.rb
+++ b/packages/cli-platform-ios/native_modules.rb
@@ -28,7 +28,7 @@ def use_native_modules!(config = nil)
   if (!config)
     json = []
 
-    IO.popen(["node", cli_bin, "config"]) do |data|
+    IO.popen(["node", cli_bin, "config", '--platform', 'ios']) do |data|
       while line = data.gets
         json << line
       end

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -179,7 +179,21 @@ async function setupAndRun(platformName?: string) {
 
   let config: Config | undefined;
   try {
-    config = loadConfig();
+    let platform: string | undefined;
+
+    /*
+      When linking dependencies in iOS and Android build we're passing `--platform` argument,
+    to only load the configuration for the specific platform.
+    */
+    if (isCommandPassed('config')) {
+      const platformIndex = process.argv.indexOf('--platform');
+
+      if (platformIndex !== -1 && platformIndex < process.argv.length - 1) {
+        platform = process.argv[platformIndex + 1];
+      }
+    }
+
+    config = loadConfig(platform);
 
     logger.enable();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -179,7 +179,7 @@ async function setupAndRun(platformName?: string) {
 
   let config: Config | undefined;
   try {
-    let platform: string | undefined;
+    let selectedPlatform: string | undefined;
 
     /*
       When linking dependencies in iOS and Android build we're passing `--platform` argument,
@@ -189,11 +189,13 @@ async function setupAndRun(platformName?: string) {
       const platformIndex = process.argv.indexOf('--platform');
 
       if (platformIndex !== -1 && platformIndex < process.argv.length - 1) {
-        platform = process.argv[platformIndex + 1];
+        selectedPlatform = process.argv[platformIndex + 1];
       }
     }
 
-    config = loadConfig(platform);
+    config = loadConfig({
+      selectedPlatform,
+    });
 
     logger.enable();
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This Pull Request implements fetching only platform's specific properties. It means when passing `--platform` option to `config` command, config logic will only get platform's properties, because it doesn't make sense to get informations about Android platform when running `native_modules.rb`, and same deal with `native_modules.gradle`.

I did some benchmarks in project with 50 linked dependencies, and results are:
| Command | Result |
|--------|--------|
| Standalone `config` | 7.62s |
| `config --platform ios` | 0.66s |
| `config --platform android` | 7.43s | 

So it means that linking dependencies during `pod install` got ~7 seconds faster _in this specific scenario_. If there are more dependencies to be linked, the results are higher.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js config
```
Same output as before, if there are tools that depends on `config`'s command response they won't be affected by this change.
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js config --platform ios
```
Returns only `ios` as in `platforms` field, and also for each entry in `dependencies` only `ios` platform should be presented. And this should be valid for any other platform that is available with linked dependency. 
4. Installing Cocoapods inside `ios/` folder should work in the same way as before.
5. Android app should build correctly and link all native dependencies.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
