### PR TITLE
perf(autolinking)!: prioritise files with `*Package.java|*Package.kt` in `getPackageClassName`

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-platform-android/src/config/__fixtures__/android.ts
@@ -75,6 +75,12 @@ export const valid = generateValidFileStructureForLib('ReactPackage.java');
 
 export const validKotlin = generateValidFileStructureForLib('ReactPackage.kt');
 
+export const validWithDifferentFileName =
+  generateValidFileStructureForLib('React.java');
+
+export const validKotlinWithDifferentFileName =
+  generateValidFileStructureForLib('React.kt');
+
 export const validApp = generateValidFileStructureForApp();
 
 export const userConfigManifest = {

--- a/packages/cli-platform-android/src/config/__fixtures__/files/React.java
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/React.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.some.example;
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class SomeExampleJavaPackage implements ReactPackage {
+
+  @Override
+  public List<NativeModule> createNativeModules(
+      ReactApplicationContext reactContext) {
+    List<NativeModule> modules = new ArrayList<>();
+    modules.add(new SomeExampleModule(reactContext));
+    return modules;
+  }
+
+  @Override
+  public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+    return Collections.emptyList();
+  }
+}

--- a/packages/cli-platform-android/src/config/__fixtures__/files/React.kt
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/React.kt
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.some.example;
+
+import android.view.View
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ReactShadowNode
+import com.facebook.react.uimanager.ViewManager
+import java.util.*
+
+class SomeExampleKotlinPackage : ReactPackage {
+
+    override fun createNativeModules(reactContext: ReactApplicationContext): MutableList<NativeModule>
+            = mutableListOf(MaterialPaletteModule(reactContext))
+
+    override fun createViewManagers(reactContext: ReactApplicationContext?):
+            MutableList<ViewManager<View, ReactShadowNode>> = Collections.emptyList()
+
+}

--- a/packages/cli-platform-android/src/config/__tests__/findPackageClassName.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/findPackageClassName.test.ts
@@ -24,8 +24,14 @@ const fs = require('fs');
           flatJava: {
             android: mocks.valid,
           },
+          flatJavaDifferentName: {
+            android: mocks.validWithDifferentFileName,
+          },
           flatKotlin: {
             android: mocks.validKotlin,
+          },
+          flatKotlinDifferentName: {
+            android: mocks.validKotlinWithDifferentFileName,
           },
         },
         platform,
@@ -42,8 +48,20 @@ const fs = require('fs');
       );
     });
 
+    it('returns the name of the java class implementing ReactPackage with different file name', () => {
+      expect(findPackageClassName(`${root}flatJavaDifferentName`)).toBe(
+        'SomeExampleJavaPackage',
+      );
+    });
+
     it('returns the name of the kotlin class implementing ReactPackage', () => {
       expect(findPackageClassName(`${root}flatKotlin`)).toBe(
+        'SomeExampleKotlinPackage',
+      );
+    });
+
+    it('returns the name of the kotlin class implementing ReactPackage with different file name', () => {
+      expect(findPackageClassName(`${root}flatKotlinDifferentName`)).toBe(
         'SomeExampleKotlinPackage',
       );
     });

--- a/packages/cli-platform-android/src/config/isProjectUsingKotlin.ts
+++ b/packages/cli-platform-android/src/config/isProjectUsingKotlin.ts
@@ -1,7 +1,7 @@
 import {getMainActivityFiles} from './findPackageClassName';
 
 export default function isProjectUsingKotlin(sourceDir: string): boolean {
-  const mainActivityFiles = getMainActivityFiles(sourceDir);
+  const mainActivityFiles = getMainActivityFiles(sourceDir, false);
 
   return mainActivityFiles.some((file) => file.endsWith('.kt'));
 }


### PR DESCRIPTION


<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

This Pull Request changes schema that looks for files to check to find class name, after my tests in various application the match results were included almost in every library in files with `Package` at the end. But our previous logic was going through every file in library with `.kt` and `.java` extension until it found file with `implements ReactPackage`, some libraries can have 100+ files and we were reading them until we matched relevant Regex schema 😅

I also added a fallback which checks files with `*.kt` and `*.java` extensions if it couldn't find `implements ReactPackage` in file with `*Package` at the end, which ensures us that we don't introduce any breaking change. **The output of `config` command stays the same.**


Performance improvement
---------

I did a test in [Expensify](https://github.com/Expensify/App) app, which is an open-source app with 50 libraries containing native code. Before my changes, we were reading 490 files to find the class name. Right now, we only check 79 (still there's a room for improvements).

| | Before | After |
|--------|--------|--------|
| Files read | 490 | 79 |
| Time | ~7.85s | ~**1.15s** | 


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js config
```
The `dependencies` field should be the same as before. 


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
