### PR TITLE
fix: correct derivation of fully specified android launch activities

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
@@ -118,6 +118,34 @@ test('launches adb shell with intent to launch com.myapp.MainActivity with diffe
   );
 });
 
+test('launches adb shell with intent to launch fully specified activity with different appId than packageName and an app suffix on a device', () => {
+  tryLaunchAppOnDevice(
+    device,
+    {
+      ...androidProject,
+      mainActivity: 'com.zoontek.rnbootsplash.RNBootSplashActivity',
+    },
+    adbPath,
+    {
+      ...args,
+      appIdSuffix: 'dev',
+    },
+  );
+
+  expect(execa.sync).toHaveBeenCalledWith(
+    'path/to/adb',
+    [
+      '-s',
+      'emulator-5554',
+      ...shellStartCommand,
+      '-n',
+      'com.myapp.custom.dev/com.zoontek.rnbootsplash.RNBootSplashActivity',
+      ...actionCategoryFlags,
+    ],
+    {stdio: 'inherit'},
+  );
+});
+
 test('--appId flag overwrites applicationId setting in androidProject', () => {
   tryLaunchAppOnDevice(undefined, androidProject, adbPath, {
     ...args,

--- a/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryLaunchAppOnDevice.ts
@@ -24,11 +24,13 @@ function tryLaunchAppOnDevice(
     .filter(Boolean)
     .join('.');
 
-  const activityToLaunch = mainActivity.startsWith(packageName)
-    ? mainActivity
-    : mainActivity.startsWith('.')
-    ? [packageName, mainActivity].join('')
-    : [packageName, mainActivity].filter(Boolean).join('.');
+  const activityToLaunch =
+    mainActivity.startsWith(packageName) ||
+    (!mainActivity.startsWith('.') && mainActivity.includes('.'))
+      ? mainActivity
+      : mainActivity.startsWith('.')
+      ? [packageName, mainActivity].join('')
+      : [packageName, mainActivity].filter(Boolean).join('.');
 
   try {
     // Here we're using the same flags as Android Studio to launch the app


### PR DESCRIPTION
Summary:
---------

If you have a main activity that is not in package, and is fully specified, it used to work, but it regressed after adding auto-activity detection

If your launcher / `MAIN` activity either specified by --main-activity or in AndroidManifest.xml is fully specified for example like "com.zoontek.rnbootsplash.RNBootSplashActivity" then it needs to launch for example "com.kullki.kscore.dev/com.zoontek.rnbootsplash.RNBootSplashActivity" not "com.kullki.kscore.dev/com.kullki.kscore.dev.com.zoontek.rnbootsplash.RNBootSplashActivity"

So basically I added an "or" in the first conditional chunk that just uses the `mainActivity` as-is, that will allow that if `    (!mainActivity.startsWith('.') && mainActivity.includes('.'))` which I think captures the spirit of the previous code in this spot that was trying to build the component name


Test Plan:
----------

I added a test case for the failure - when I run `yarn test` before it fails only that test, and after, they all pass

I ran my app with the built `tryLaunchAppOnDevice.js` file before and after the fix, it failed before the fix, it worked after the fix

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
