### PR TITLE
chore: remove `@react-native-community/cli` from `bin` entrypoints

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,8 +8,7 @@
     "access": "public"
   },
   "bin": {
-    "rnccli": "build/bin.js",
-    "@react-native-community/cli": "build/bin.js"
+    "rnccli": "build/bin.js"
   },
   "files": [
     "build",


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

`@react-native-community/cli` as a bin entrypoint causes a warning (it cannot contain `@ and `/`) when installing packages:

```
❯ yarn
yarn install v1.22.19
warning @react-native-community/cli@14.0.0-alpha.5: Invalid bin entry for "@react-native-community/cli" (in "@react-native-community/cli").
```

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
yarn
```
3. There's no warnings presented in console ✅


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
