### PR TITLE
fix: Correctly display errors in react-native init

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -333,8 +333,8 @@ async function createFromTemplate({
             }
           }
         } catch (e) {
-          throw new CLIError(
-            'Installing pods failed. This doesn\'t affect project initialization and you can safely proceed. \nHowever, you will need to install pods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n',
+          logger.error(
+            'Installing Cocoapods failed. This doesn\'t affect project initialization and you can safely proceed. \nHowever, you will need to install Cocoapods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n',
           );
         }
       }
@@ -343,16 +343,15 @@ async function createFromTemplate({
       loader.succeed('Dependencies installation skipped');
     }
   } catch (e) {
+    logger.log('\n');
     if (e instanceof CLIError) {
       logger.error(e.message);
     } else if (e instanceof Error) {
-      const unknownErrorMessage = 'Please report this issue';
-      logger.error(
-        `An unexpected error occurred: ${e.message}. ${unknownErrorMessage}`,
-      );
-      logger.debug(e as any);
+      logger.error(`An unexpected error occurred: ${e.message}.`);
     }
     didInstallPods = false;
+    logger.debug(e as any);
+    process.exit(1);
   } finally {
     fs.removeSync(templateSourceDir);
   }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -337,8 +337,9 @@ async function createFromTemplate({
       loader.succeed('Dependencies installation skipped');
     }
   } catch (e) {
-    loader.fail();
-    if (e instanceof Error) {
+    if (e instanceof CLIError) {
+      logger.error(e.message);
+    } else if (e instanceof Error) {
       logger.error(
         'Installing pods failed. This doesn\'t affect project initialization and you can safely proceed. \nHowever, you will need to install pods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n',
       );

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -344,6 +344,8 @@ async function createFromTemplate({
       didInstallPods = false;
       loader.succeed('Dependencies installation skipped');
     }
+
+    fs.removeSync(templateSourceDir);
   } catch (e) {
     logger.log('\n');
     if (e instanceof CLIError) {
@@ -353,9 +355,8 @@ async function createFromTemplate({
     }
     didInstallPods = false;
     logger.debug(e as any);
-    process.exit(1);
-  } finally {
     fs.removeSync(templateSourceDir);
+    process.exit(1);
   }
 
   if (process.platform === 'darwin') {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -332,9 +332,11 @@ async function createFromTemplate({
               setEmptyHashForCachedDependencies(projectName);
             }
           }
-        } catch (e) {
+        } catch (error) {
           logger.error(
-            'Installing Cocoapods failed. This doesn\'t affect project initialization and you can safely proceed. \nHowever, you will need to install Cocoapods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n',
+            `Installing Cocoapods failed. This doesn't affect project initialization and you can safely proceed. However, you will need to install Cocoapods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n\nError: ${
+              (error as Error).message as string
+            }\n`,
           );
         }
       }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
The problem I noticed was that when I specified the wrong template, the error wording was funny.
```
$ react-native init TestProduct --template typescript
                                                          
               ######                ######               
             ###     ####        ####     ###             
            ##          ###    ###          ##            
            ##             ####             ##            
            ##             ####             ##            
            ##           ##    ##           ##            
            ##         ###      ###         ##            
             ##  ########################  ##             
          ######    ###            ###    ######          
      ###     ##    ##              ##    ##     ###      
   ###         ## ###      ####      ### ##         ###   
  ##           ####      ########      ####           ##  
 ##             ###     ##########     ###             ## 
  ##           ####      ########      ####           ##  
   ###         ## ###      ####      ### ##         ###   
      ###     ##    ##              ##    ##     ###      
          ######    ###            ###    ######          
             ##  ########################  ##             
            ##         ###      ###         ##            
            ##           ##    ##           ##            
            ##             ####             ##            
            ##             ####             ##            
            ##          ###    ###          ##            
             ###     ####        ####     ###             
               ######                ######               
                                                          

                  Welcome to React Native!                
                 Learn once, write anywhere               

✔ Downloading template
⠋ Copying templateerror Installing pods failed. This doesn't affect project initialization and you can safely proceed. 
However, you will need to install pods manually when running iOS, follow additional steps in "Run instructions for iOS" section.
```


However, looking at the source code, this issue as well as many other errors are not displayed correctly.
The error handling part of cocoapods seems to be wrong.
Moved pods error handling out of the way of the others, and added additional unknown error handling.

Test Plan:
----------

Run `react-native init TestProduct --template typescript` and check correct error message.
Confirmation of pod error on pod failure.

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
