### PR TITLE
chore: Upgrade deasync in dependencies

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4525,9 +4525,9 @@ dayjs@^1.8.15:
   integrity sha512-1kbWK0hziklUHkGgiKr7xm59KwAg/K3Tp7H/8X+f58DnNCwY3pKYjOCJpIlVs125FRBukGVZdKZojC073D0IeQ==
 
 deasync@^0.1.14:
-  version "0.1.28"
-  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.28.tgz#9b447b79b3f822432f0ab6a8614c0062808b5ad2"
-  integrity sha512-QqLF6inIDwiATrfROIyQtwOQxjZuek13WRYZ7donU5wJPLoP67MnYxA6QtqdvdBy2mMqv5m3UefBVdJjvevOYg==
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.29.tgz#8bbbf9d0b235c561b36edd440b6272f1de6c572c"
+  integrity sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==
   dependencies:
     bindings "^1.5.0"
     node-addon-api "^1.7.1"


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
We are experiencing a glitch where the installation fails in another pr workflow.
https://github.com/react-native-community/cli/actions/runs/9135399920/job/25154046482?pr=2394

deasync does not seem to support windows-node-20 in version 0.1.28, so I am upgrading it.
https://github.com/abbr/deasync/compare/v0.1.28...v0.1.29



Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

run workflow

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
