### PR TITLE
docs: Remove ram-bundle from README

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11,7 +11,6 @@ React Native CLI comes with following commands:
 - [`info`](/packages/cli-doctor/README.md#info)
 - [`log-android`](/packages/cli-platform-android/README.md#log-android)
 - [`log-ios`](/packages/cli-platform-ios/README.md#log-ios)
-- [`ram-bundle`](https://github.com/facebook/react-native/tree/main/packages/community-cli-plugin#ram-bundle)
 - [`run-android`](/packages/cli-platform-android/README.md#run-android)
 - [`build-android`](/packages/cli-platform-android/README.md#build-android)
 - [`run-ios`](/packages/cli-platform-ios/README.md#run-ios)


### PR DESCRIPTION
Ram bundle was removed in https://github.com/facebook/react-native/pull/43292 Readme points to non existing command since.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Remove dead-end from readme.

Test Plan:
----------

None.

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
