### PR TITLE
fix: correctly check Yarn version

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -90,7 +90,7 @@ const bumpYarnVersion = async (silent: boolean, root: string) => {
     if (yarnVersion) {
       // `yarn set` is unsupported until 1.22, however it's a alias (yarnpkg/yarn/pull/7862) calling `policies set-version`.
       let setVersionArgs = ['set', 'version', YARN_VERSION];
-      if (yarnVersion.major === 1 && yarnVersion.minor <= 22) {
+      if (yarnVersion.major === 1 && yarnVersion.minor < 22) {
         setVersionArgs = ['policies', 'set-version', YARN_VERSION];
       }
       await executeCommand('yarn', setVersionArgs, {

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -89,12 +89,10 @@ const bumpYarnVersion = async (silent: boolean, root: string) => {
 
     if (yarnVersion) {
       // `yarn set` is unsupported until 1.22, however it's a alias (yarnpkg/yarn/pull/7862) calling `policies set-version`.
-      const setVersionArgs =
-        (yarnVersion.major > 1 && yarnVersion.minor >= 22) ||
-        yarnVersion.major >= 2
-          ? ['set', 'version', YARN_VERSION]
-          : ['policies', 'set-version', YARN_VERSION];
-
+      let setVersionArgs = ['set', 'version', YARN_VERSION];
+      if (yarnVersion.major === 1 && yarnVersion.minor <= 22) {
+        setVersionArgs = ['policies', 'set-version', YARN_VERSION];
+      }
       await executeCommand('yarn', setVersionArgs, {
         root,
         silent,

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -90,7 +90,8 @@ const bumpYarnVersion = async (silent: boolean, root: string) => {
     if (yarnVersion) {
       // `yarn set` is unsupported until 1.22, however it's a alias (yarnpkg/yarn/pull/7862) calling `policies set-version`.
       const setVersionArgs =
-        yarnVersion.major > 1 && yarnVersion.minor >= 22
+        (yarnVersion.major > 1 && yarnVersion.minor >= 22) ||
+        yarnVersion.major >= 2
           ? ['set', 'version', YARN_VERSION]
           : ['policies', 'set-version', YARN_VERSION];
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

We were checking for Yarn major to be higher than 1, which is okay ✅ but we also checked in every scenario for minor to be higher than 22, which e.g for Yarn version 3.6.4 is not the case and CLI was running `yarn policies set-version x.y.z` for Yarn v3 which was throwing an error, and PnP was used.


Test Plan:
----------

1. Use Yarn v3/v4 globally 
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init
```
3. Packages should be installed with yarn and `nodeLinker: node-modules` should be used.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
