### PR TITLE
chore: remove specifying `-PreactNativeDebugArchitectures` in Android builds

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -77,11 +77,6 @@ async function runOnAllDevices(
 
         if (architectures.length > 0) {
           logger.info(`Detected architectures ${architectures.join(', ')}`);
-          // `reactNativeDebugArchitectures` was renamed to `reactNativeArchitectures` in 0.68.
-          // Can be removed when 0.67 no longer needs to be supported.
-          gradleArgs.push(
-            '-PreactNativeDebugArchitectures=' + architectures.join(','),
-          );
           gradleArgs.push(
             '-PreactNativeArchitectures=' + architectures.join(','),
           );


### PR DESCRIPTION

Summary:
---------

React Native 0.67 is not longer supported.

Test Plan:
----------

N/A

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
