### PR TITLE
fix: update react-native version in the template for versions >= 0.75.

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -207,8 +207,11 @@ test('init --platform-name should work for out of tree platform', () => {
   ]);
 
   expect(stdout).toContain('Run instructions');
+  // This will no longer contain react-native-macos@latest, but
+  // react-native-macos@0.74.1 or whatever the concrete version
+  // matching @latest at the time of execution.
   expect(stdout).toContain(
-    `Installing template from ${outOfTreePlatformName}@latest`,
+    `Installing template from ${outOfTreePlatformName}@`,
   );
 
   // make sure we don't leave garbage

--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -11,6 +11,7 @@ import {
   validatePackageName,
   replaceNameInUTF8File,
   updateDependencies,
+  normalizeReactNativeDeps,
 } from '../editTemplate';
 import semver from 'semver';
 
@@ -429,5 +430,27 @@ describe('replaceNameInUTF8File', () => {
 
     expect(beforeReplacement).toEqual(afterReplacement);
     expect(fsWriteFileSpy).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe('normalizeReactNativeDeps', () => {
+  it('returns only @react-native/* dependencies updated to a specific version', () => {
+    const devDependencies = {
+      '@babel/core': '^7.20.0',
+      '@react-native/babel-preset': '0.75.0-main',
+      '@react-native/eslint-config': '0.75.0-main',
+      '@react-native/metro-config': '0.75.0-main',
+      '@react-native/typescript-config': '0.75.0-main',
+      '@types/react': '^18.2.6',
+      '@types/react-test-renderer': '^18.0.0',
+      eslint: '^8.19.0',
+      'react-test-renderer': '19.0.0-rc-fb9a90fa48-20240614',
+    };
+    expect(normalizeReactNativeDeps(devDependencies, '0.75.0')).toMatchObject({
+      '@react-native/babel-preset': '0.75.0',
+      '@react-native/eslint-config': '0.75.0',
+      '@react-native/metro-config': '0.75.0',
+      '@react-native/typescript-config': '0.75.0',
+    });
   });
 });

--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -10,6 +10,7 @@ import {
   replacePlaceholderWithPackageName,
   validatePackageName,
   replaceNameInUTF8File,
+  updateDependencies,
 } from '../editTemplate';
 import semver from 'semver';
 
@@ -173,7 +174,7 @@ describe('changePlaceholderInTemplate', () => {
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   skipIfNode20(
@@ -200,13 +201,74 @@ describe('changePlaceholderInTemplate', () => {
   );
 });
 
+const samplePackageJson: string = `{
+  "name": "HelloWorld",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "android": "react-native run-android",
+    "ios": "react-native run-ios",
+    "lint": "eslint .",
+    "start": "react-native start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "19.0.0-rc-fb9a90fa48-20240614",
+    "react-native": "1000.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0",
+    "@babel/preset-env": "^7.20.0",
+    "@babel/runtime": "^7.20.0",
+    "@react-native/babel-preset": "0.75.0-main",
+    "@react-native/eslint-config": "0.75.0-main",
+    "@react-native/metro-config": "0.75.0-main",
+    "@react-native/typescript-config": "0.75.0-main",
+    "@types/react": "^18.2.6",
+    "@types/react-test-renderer": "^18.0.0",
+    "babel-jest": "^29.6.3",
+    "eslint": "^8.19.0",
+    "jest": "^29.6.3",
+    "prettier": "2.8.8",
+    "react-test-renderer": "19.0.0-rc-fb9a90fa48-20240614",
+    "typescript": "5.0.4"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}`;
+
+describe('updateDependencies', () => {
+  beforeEach(() => {
+    jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
+    jest.spyOn(fs, 'writeFileSync');
+    jest.spyOn(fs, 'readFileSync').mockImplementation(() => samplePackageJson);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('updates react-native', () => {
+    updateDependencies({
+      dependencies: {
+        'react-native': '0.75.0',
+      },
+    });
+    expect(fs.writeFileSync as jest.Mock).toHaveBeenCalledWith(
+      expect.anything(),
+      samplePackageJson.replace('1000.0.0', '0.75.0'),
+    );
+  });
+});
+
 describe('replacePlaceholderWithPackageName', () => {
   beforeEach(() => {
     jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
+    jest.restoreAllMocks();
   });
 
   skipIfNode20(

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -307,3 +307,25 @@ export async function changePlaceholderInTemplate({
     }
   }
 }
+
+type Packages = {
+  [pkgs: string]: string;
+};
+
+const REACT_NATIVE_SCOPE = '@react-native/';
+
+/**
+ * Packages that are scoped under @react-native need a consistent version
+ */
+export function normalizeReactNativeDeps(
+  deps: Packages | undefined,
+  version: string,
+): Packages {
+  const updated: Packages = {};
+  for (const key of Object.keys(deps ?? {}).filter((pkg) =>
+    pkg.startsWith(REACT_NATIVE_SCOPE),
+  )) {
+    updated[key] = version;
+  }
+  return updated;
+}

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -15,6 +15,15 @@ interface PlaceholderConfig {
   packageName?: string;
 }
 
+interface NpmPackageDependencies {
+  dependencies?: {
+    [name: string]: string;
+  };
+  devDependencies?: {
+    [name: string]: string;
+  };
+}
+
 /**
   TODO: This is a default placeholder for title in react-native template.
   We should get rid of this once custom templates adapt `placeholderTitle` in their configurations.
@@ -224,6 +233,35 @@ export async function replacePlaceholderWithPackageName({
 
     await processDotfiles(filePath);
   }
+}
+
+export function updateDependencies(update: NpmPackageDependencies) {
+  logger.debug('Updating package.json dependencies:');
+  const pkgJsonPath = path.join(process.cwd(), 'package.json');
+
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+
+  for (const [pkg, value] of Object.entries(update.dependencies ?? {})) {
+    const old = pkgJson.dependencies[pkg];
+    if (old) {
+      logger.debug(`${pkg}: ${old} → ${value}`);
+    } else {
+      logger.debug(`${pkg}: ${value}`);
+    }
+    pkgJson.dependencies[pkg] = value;
+  }
+
+  for (const [pkg, value] of Object.entries(update.devDependencies ?? {})) {
+    const old = pkgJson.devDependencies[pkg];
+    if (old) {
+      logger.debug(`${pkg}: ${old} → ${value}`);
+    } else {
+      logger.debug(`${pkg}: ${value}`);
+    }
+    pkgJson.devDependencies[pkg] = value;
+  }
+
+  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
 }
 
 export async function changePlaceholderInTemplate({

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -28,3 +28,17 @@ export function getNpmVersionIfAvailable() {
 export function isProjectUsingNpm(cwd: string) {
   return findUp.sync('package-lock.json', {cwd});
 }
+
+/**
+ * Convert an npm tag to a concrete version, for example:
+ * - next -> 0.75.0-rc.0
+ * - nightly -> 0.75.0-nightly-20240618-5df5ed1a8
+ */
+export async function npmResolveConcreteVersion(
+  tagOrVersion: string,
+): Promise<string> {
+  const json: any = await fetch(
+    `https://registry.npmjs.org/react-native/${tagOrVersion}`,
+  ).then((resp) => resp.json());
+  return json.version;
+}

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -29,16 +29,55 @@ export function isProjectUsingNpm(cwd: string) {
   return findUp.sync('package-lock.json', {cwd});
 }
 
+const registry = getNpmRegistryUrl();
+
 /**
  * Convert an npm tag to a concrete version, for example:
  * - next -> 0.75.0-rc.0
  * - nightly -> 0.75.0-nightly-20240618-5df5ed1a8
  */
 export async function npmResolveConcreteVersion(
+  packageName: string,
   tagOrVersion: string,
 ): Promise<string> {
-  const json: any = await fetch(
-    `https://registry.npmjs.org/react-native/${tagOrVersion}`,
-  ).then((resp) => resp.json());
+  const url = new URL(registry);
+  url.pathname = `${packageName}/${tagOrVersion}`;
+  const json: any = await fetch(url).then((resp) => resp.json());
   return json.version;
+}
+
+export async function npmCheckPackageVersionExists(
+  packageName: string,
+  tagOrVersion: string,
+): Promise<boolean> {
+  const url = new URL(registry);
+  url.pathname = `${packageName}/${tagOrVersion}`;
+  return await urlExists(url);
+}
+
+async function urlExists(url: string | URL): Promise<boolean> {
+  try {
+    // @ts-ignore-line: TS2304
+    const {status} = await fetch(url, {method: 'HEAD'});
+    return (
+      [
+        200, // OK
+        301, // Moved Permanemently
+        302, // Found
+        304, // Not Modified
+        307, // Temporary Redirect
+        308, // Permanent Redirect
+      ].indexOf(status) !== -1
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function getNpmRegistryUrl(): string {
+  try {
+    return execSync('npm config get registry').toString().trim();
+  } catch {
+    return 'https://registry.npmjs.org/';
+  }
 }


### PR DESCRIPTION
The new template handling in @react-native-community/template means that these are shipped with version 1000.0.0 for React Native. The CLI now owns having to update to the correct version.

**NOTE:** This will only apply if the template has a `react-native@1000.0.0`, i.e. is from `@react-native-community/template`.

Summary:
---------

1. Allow using `--template` and `--version` when `--version` is >= 0.75.  Added a warning about doing this, but it's valid if the user gets into trouble or more advanced users want to do fun stuff.
2. `@react-native/` scoped dependencies **must** match the version of `react-native`.  `init` now enforces this.
3. Done some work to normalise tags into concrete versions.  Going forward `@react-native-community/template` will release matching version for each React Native release.  It's important to normalise version at the time of constructing the project otherwise the template will gradually become invalidate as `react-native@latest` (for example) moves.

For example, now running:
```
node ./packages/cli/build/bin.js init Test75RC0 --version next  --skip-install --verbose
```

## Updated `react-native` version on template
![CleanShot 2024-06-19 at 15 55 24@2x](https://github.com/react-native-community/cli/assets/49578/602c30b6-30f8-46c4-b9ad-48963edf9a45)

## Added some logs for the version update in the template
![CleanShot 2024-06-19 at 15 49 03@2x](https://github.com/react-native-community/cli/assets/49578/67dce656-3f5f-49d6-93c6-bce9b606f53d)

## Scoped Version Matching
![CleanShot 2024-06-19 at 18 04 38@2x](https://github.com/react-native-community/cli/assets/49578/e4fc8100-2d77-4429-bbd7-4f63747aac38)


Test Plan:
----------

- additional unit test
- built and run locally: 
```
node ./packages/cli/build/bin.js init Test75RC0 --version next  --skip-install --verbose
node ./packages/cli/build/bin.js init Test75RC0  --skip-install --verbose
```

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
