### PR TITLE
feat: add `-i` alias for `--interactive` option

### DIFF
--- a/packages/cli-platform-android/README.md
+++ b/packages/cli-platform-android/README.md
@@ -79,7 +79,7 @@ Build native libraries only for the current device architecture for debug builds
 
 List all available Android devices and simulators and let you choose one to run the app.
 
-#### `--interactive`
+#### `--interactive`, `-i`
 
 Manually select a task and device/simulator you want to run your app on.
 

--- a/packages/cli-platform-android/src/commands/buildAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/buildAndroid/index.ts
@@ -118,7 +118,7 @@ export const options = [
     parse: (val: string) => val.split(' '),
   },
   {
-    name: '--interactive',
+    name: '-i --interactive',
     description:
       'Explicitly select build type and flavour to use before running a build',
   },

--- a/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
@@ -52,7 +52,7 @@ export const getBuildOptions = ({platformName}: BuilderCommand) => {
       description: 'Explicitly set Xcode target to use.',
     },
     {
-      name: '--interactive',
+      name: '-i --interactive',
       description:
         'Explicitly select which scheme and configuration to use before running a build',
     },

--- a/packages/cli-platform-apple/src/commands/logCommand/logOptions.ts
+++ b/packages/cli-platform-apple/src/commands/logCommand/logOptions.ts
@@ -2,7 +2,7 @@ import {BuilderCommand} from '../../types';
 
 export const getLogOptions = ({}: BuilderCommand) => [
   {
-    name: '--interactive',
+    name: '-i --interactive',
     description:
       'Explicitly select simulator to tail logs from. By default it will tail logs from the first booted and available simulator.',
   },

--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -185,6 +185,6 @@ Starts iOS device syslog tail.
 
 #### Options
 
-#### `--interactive`
+#### `--interactive`, `-i`
 
 Explicitly select simulator to tail logs from. By default it will tail logs from the first booted and available simulator.


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

`-i` is easier and faster to type. 

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-ios -i
```
3. Should work the same as with `--interactive`


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
