### PR TITLE
fix: only show warning about --template & --version when necessary

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -570,14 +570,16 @@ export default (async function initialize(
 
   // From 0.75 it actually is useful to be able to specify both the template and react-native version.
   // This should only be used by people who know what they're doing.
-  if (semver.gte(version, TEMPLATE_COMMUNITY_REACT_NATIVE_VERSION)) {
-    logger.warn(
-      `Use ${chalk.bold('--template')} and ${chalk.bold(
-        '--version',
-      )} only if you know what you're doing. Here be dragons 🐉.`,
-    );
-  } else if (!!options.template && !!options.version) {
-    throw new TemplateAndVersionError(options.template);
+  if (!!options.template && !!options.version) {
+    if (semver.gte(version, TEMPLATE_COMMUNITY_REACT_NATIVE_VERSION)) {
+      logger.warn(
+        `Use ${chalk.bold('--template')} and ${chalk.bold(
+          '--version',
+        )} only if you know what you're doing. Here be dragons 🐉.`,
+      );
+    } else {
+      throw new TemplateAndVersionError(options.template);
+    }
   }
 
   const root = process.cwd();


### PR DESCRIPTION
- **fix: only show warning about --template & --version when necessary**

Summary:
---------
When running `npx @react-native-community/cli init`, you now get a warning:

```
$ npx @react-native-community/cli@next init TestInit --version next
warn Use --template and --version only if you know what you're doing. Here be dragons 🐉.
```

It's clearly wrong and should only happen when `--version` and `--template` are used together.

Test Plan:
----------

```
node scripts/build
...
$ node ./packages/cli/build/bin.js init --version next --skip-install --verbose TestInit2
debug Initializing new project
$ node ./packages/cli/build/bin.js init --version next  --template @react-native-community/template@next TestInit --skip-install --verbose
warn Use --template and --version only if you know what you're doing. Here be dragons 🐉.
debug Use the user provided --template=@react-native-community/template@next
debug Initializing new project
```
LGTM

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
