### PR TITLE
refactor: init now expects templates to have react-native version set

### DIFF
--- a/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
+++ b/packages/cli/src/commands/init/__tests__/editTemplate.test.ts
@@ -10,8 +10,6 @@ import {
   replacePlaceholderWithPackageName,
   validatePackageName,
   replaceNameInUTF8File,
-  updateDependencies,
-  normalizeReactNativeDeps,
 } from '../editTemplate';
 import semver from 'semver';
 
@@ -202,67 +200,6 @@ describe('changePlaceholderInTemplate', () => {
   );
 });
 
-const samplePackageJson: string = `{
-  "name": "HelloWorld",
-  "version": "0.0.1",
-  "private": true,
-  "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
-    "lint": "eslint .",
-    "start": "react-native start",
-    "test": "jest"
-  },
-  "dependencies": {
-    "react": "19.0.0-rc-fb9a90fa48-20240614",
-    "react-native": "1000.0.0"
-  },
-  "devDependencies": {
-    "@babel/core": "^7.20.0",
-    "@babel/preset-env": "^7.20.0",
-    "@babel/runtime": "^7.20.0",
-    "@react-native/babel-preset": "0.75.0-main",
-    "@react-native/eslint-config": "0.75.0-main",
-    "@react-native/metro-config": "0.75.0-main",
-    "@react-native/typescript-config": "0.75.0-main",
-    "@types/react": "^18.2.6",
-    "@types/react-test-renderer": "^18.0.0",
-    "babel-jest": "^29.6.3",
-    "eslint": "^8.19.0",
-    "jest": "^29.6.3",
-    "prettier": "2.8.8",
-    "react-test-renderer": "19.0.0-rc-fb9a90fa48-20240614",
-    "typescript": "5.0.4"
-  },
-  "engines": {
-    "node": ">=18"
-  }
-}`;
-
-describe('updateDependencies', () => {
-  beforeEach(() => {
-    jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
-    jest.spyOn(fs, 'writeFileSync');
-    jest.spyOn(fs, 'readFileSync').mockImplementation(() => samplePackageJson);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('updates react-native', () => {
-    updateDependencies({
-      dependencies: {
-        'react-native': '0.75.0',
-      },
-    });
-    expect(fs.writeFileSync as jest.Mock).toHaveBeenCalledWith(
-      expect.anything(),
-      samplePackageJson.replace('1000.0.0', '0.75.0'),
-    );
-  });
-});
-
 describe('replacePlaceholderWithPackageName', () => {
   beforeEach(() => {
     jest.spyOn(process, 'cwd').mockImplementation(() => testPath);
@@ -430,27 +367,5 @@ describe('replaceNameInUTF8File', () => {
 
     expect(beforeReplacement).toEqual(afterReplacement);
     expect(fsWriteFileSpy).toHaveBeenCalledTimes(0);
-  });
-});
-
-describe('normalizeReactNativeDeps', () => {
-  it('returns only @react-native/* dependencies updated to a specific version', () => {
-    const devDependencies = {
-      '@babel/core': '^7.20.0',
-      '@react-native/babel-preset': '0.75.0-main',
-      '@react-native/eslint-config': '0.75.0-main',
-      '@react-native/metro-config': '0.75.0-main',
-      '@react-native/typescript-config': '0.75.0-main',
-      '@types/react': '^18.2.6',
-      '@types/react-test-renderer': '^18.0.0',
-      eslint: '^8.19.0',
-      'react-test-renderer': '19.0.0-rc-fb9a90fa48-20240614',
-    };
-    expect(normalizeReactNativeDeps(devDependencies, '0.75.0')).toMatchObject({
-      '@react-native/babel-preset': '0.75.0',
-      '@react-native/eslint-config': '0.75.0',
-      '@react-native/metro-config': '0.75.0',
-      '@react-native/typescript-config': '0.75.0',
-    });
   });
 });

--- a/packages/cli/src/commands/init/editTemplate.ts
+++ b/packages/cli/src/commands/init/editTemplate.ts
@@ -15,15 +15,6 @@ interface PlaceholderConfig {
   packageName?: string;
 }
 
-interface NpmPackageDependencies {
-  dependencies?: {
-    [name: string]: string;
-  };
-  devDependencies?: {
-    [name: string]: string;
-  };
-}
-
 /**
   TODO: This is a default placeholder for title in react-native template.
   We should get rid of this once custom templates adapt `placeholderTitle` in their configurations.
@@ -235,35 +226,6 @@ export async function replacePlaceholderWithPackageName({
   }
 }
 
-export function updateDependencies(update: NpmPackageDependencies) {
-  logger.debug('Updating package.json dependencies:');
-  const pkgJsonPath = path.join(process.cwd(), 'package.json');
-
-  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-
-  for (const [pkg, value] of Object.entries(update.dependencies ?? {})) {
-    const old = pkgJson.dependencies[pkg];
-    if (old) {
-      logger.debug(`${pkg}: ${old} → ${value}`);
-    } else {
-      logger.debug(`${pkg}: ${value}`);
-    }
-    pkgJson.dependencies[pkg] = value;
-  }
-
-  for (const [pkg, value] of Object.entries(update.devDependencies ?? {})) {
-    const old = pkgJson.devDependencies[pkg];
-    if (old) {
-      logger.debug(`${pkg}: ${old} → ${value}`);
-    } else {
-      logger.debug(`${pkg}: ${value}`);
-    }
-    pkgJson.devDependencies[pkg] = value;
-  }
-
-  fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson, null, 2));
-}
-
 export async function changePlaceholderInTemplate({
   projectName,
   placeholderName,
@@ -306,26 +268,4 @@ export async function changePlaceholderInTemplate({
       await processDotfiles(filePath);
     }
   }
-}
-
-type Packages = {
-  [pkgs: string]: string;
-};
-
-const REACT_NATIVE_SCOPE = '@react-native/';
-
-/**
- * Packages that are scoped under @react-native need a consistent version
- */
-export function normalizeReactNativeDeps(
-  deps: Packages | undefined,
-  version: string,
-): Packages {
-  const updated: Packages = {};
-  for (const key of Object.keys(deps ?? {}).filter((pkg) =>
-    pkg.startsWith(REACT_NATIVE_SCOPE),
-  )) {
-    updated[key] = version;
-  }
-  return updated;
 }

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -337,19 +337,19 @@ async function createFromTemplate({
       loader.succeed('Dependencies installation skipped');
     }
   } catch (e) {
+    loader.fail();
     if (e instanceof Error) {
       logger.error(
         'Installing pods failed. This doesn\'t affect project initialization and you can safely proceed. \nHowever, you will need to install pods manually when running iOS, follow additional steps in "Run instructions for iOS" section.\n',
       );
+      logger.debug(e as any);
     }
-    loader.fail();
     didInstallPods = false;
   } finally {
     fs.removeSync(templateSourceDir);
   }
 
   if (process.platform === 'darwin') {
-    logger.log('\n');
     logger.info(
       `💡 To enable automatic CocoaPods installation when building for iOS you can create react-native.config.js with automaticPodsInstallation field. \n${chalk.reset.dim(
         `For more details, see ${chalk.underline(

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -46,34 +46,6 @@ export async function npmResolveConcreteVersion(
   return json.version;
 }
 
-export async function npmCheckPackageVersionExists(
-  packageName: string,
-  tagOrVersion: string,
-): Promise<boolean> {
-  const url = new URL(registry);
-  url.pathname = `${packageName}/${tagOrVersion}`;
-  return await urlExists(url);
-}
-
-async function urlExists(url: string | URL): Promise<boolean> {
-  try {
-    // @ts-ignore-line: TS2304
-    const {status} = await fetch(url, {method: 'HEAD'});
-    return (
-      [
-        200, // OK
-        301, // Moved Permanemently
-        302, // Found
-        304, // Not Modified
-        307, // Temporary Redirect
-        308, // Permanent Redirect
-      ].indexOf(status) !== -1
-    );
-  } catch {
-    return false;
-  }
-}
-
 export function getNpmRegistryUrl(): string {
   try {
     return execSync('npm config get registry').toString().trim();


### PR DESCRIPTION
Summary:
---------

This will take advantage of changes coming in the way we publish the template: react-native-community/template/pull/30

    refactor: init now expects templates to have react-native version set

    For 0.75's previous RCs, we didn't have the infrastructure in place to
    tag @react-native-community/templates 0.75-stable branch correctly, as
    well as publishing the corresponding version to npm.

    For example:

    If @react-native-community/template@0.75.1 is the latest version
    published, and I specified --version next: I'd expect 0.75.1 of the
    template to be used with 0.75.1 of react-native.

    The downside of this approach is, if you init an older version then
    things might not work.  You'd have to specify the matching template
    using --template @react-native-community/template@<some version>. Given
    that init is intended for new projects this isn't a concern for most
    users.

    We could look at abusing the `scripts` field to expose the corresponding
    version of react native in the npm registry:

      https://registry.npmjs.org/@react-native-community/template

    Something like: "scripts": { "version": "0.75.1-rc.2" }

Test Plan:
----------

TODO: Run each of the combinations of the update table in the code.  Might be difficult to do with unpublished @react-native-community/template npm packages published.

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
