### PR TITLE
fix(cli-config): include peer dependencies when finding dependencies

### DIFF
--- a/packages/cli-config/src/__tests__/findDependencies-test.ts
+++ b/packages/cli-config/src/__tests__/findDependencies-test.ts
@@ -1,23 +1,35 @@
 import findDependencies from '../findDependencies';
 import {cleanup, writeFiles, getTempDirectory} from '../../../../jest/helpers';
 
-beforeEach(async () => {
-  cleanup(DIR);
-  jest.resetModules();
-});
+describe('findDependencies', () => {
+  const DIR = getTempDirectory('find_dependencies_test');
 
-afterEach(() => cleanup(DIR));
-
-const DIR = getTempDirectory('find_dependencies_test');
-
-test('returns plugins from both dependencies and dev dependencies', () => {
-  writeFiles(DIR, {
-    'package.json': `
-      {
-        "dependencies": {"rnpm-plugin-test": "*"},
-        "devDependencies": {"rnpm-plugin-test-2": "*"}
-      }
-    `,
+  beforeEach(() => {
+    cleanup(DIR);
+    jest.resetModules();
   });
-  expect(findDependencies(DIR)).toHaveLength(2);
+
+  afterEach(() => cleanup(DIR));
+
+  test('returns packages from dependencies, peer and dev dependencies', () => {
+    writeFiles(DIR, {
+      'package.json': JSON.stringify({
+        dependencies: {'rnpm-plugin-test': '*'},
+        peerDependencies: {'rnpm-plugin-test-2': '*'},
+        devDependencies: {'rnpm-plugin-test-3': '*'},
+      }),
+    });
+    expect(findDependencies(DIR)).toHaveLength(3);
+  });
+
+  test('dedupes dependencies', () => {
+    writeFiles(DIR, {
+      'package.json': JSON.stringify({
+        dependencies: {'rnpm-plugin-test': '*'},
+        peerDependencies: {'rnpm-plugin-test-2': '*'},
+        devDependencies: {'rnpm-plugin-test-2': '*'},
+      }),
+    });
+    expect(findDependencies(DIR)).toHaveLength(2);
+  });
 });

--- a/packages/cli-config/src/findDependencies.ts
+++ b/packages/cli-config/src/findDependencies.ts
@@ -8,17 +8,17 @@ export default function findDependencies(root: string): Array<string> {
   let pjson;
 
   try {
-    pjson = JSON.parse(
-      fs.readFileSync(path.join(root, 'package.json'), 'utf8'),
-    );
+    const content = fs.readFileSync(path.join(root, 'package.json'), 'utf8');
+    pjson = JSON.parse(content);
   } catch (e) {
     return [];
   }
 
-  const deps = [
+  const deps = new Set([
     ...Object.keys(pjson.dependencies || {}),
+    ...Object.keys(pjson.peerDependencies || {}),
     ...Object.keys(pjson.devDependencies || {}),
-  ];
+  ]);
 
-  return deps;
+  return Array.from(deps);
 }


### PR DESCRIPTION
Summary:
---------

`config` currently ignores `peerDependencies` and instead reads `devDependencies`, leading to missing dependencies.

Resolves #2419.

Test Plan:
----------

In any project, run the following:

```
yarn add @react-native-webapis/web-storage@0.2.6
cd node_modules/@react-native-webapis/web-storage
yarn react-native config
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
