### PR TITLE
chore: bump `envinfo` package

### DIFF
--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -16,7 +16,7 @@
     "chalk": "^4.1.2",
     "command-exists": "^1.2.8",
     "deepmerge": "^4.3.0",
-    "envinfo": "^7.10.0",
+    "envinfo": "^7.13.0",
     "execa": "^5.0.0",
     "node-stream-zip": "^1.9.1",
     "ora": "^5.4.1",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@react-native-community/cli-types": "14.0.0-alpha.9",
     "@types/command-exists": "^1.2.0",
-    "@types/envinfo": "^7.8.1",
+    "@types/envinfo": "^7.8.4",
     "@types/ip": "^1.1.0",
     "@types/prompts": "^2.4.4",
     "@types/semver": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,10 +2931,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/envinfo@^7.8.1":
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/@types/envinfo/-/envinfo-7.8.1.tgz#1915df82c16d637e92146645c70db9360eb099c6"
-  integrity sha512-pTyshpmGxqB9lRwG75v2YR0oqKYpCrklOYlZWQ88z/JB0fimT8EVmYekuIwpU3IxPZDHSXCqXKzkCrtAcKY25g==
+"@types/envinfo@^7.8.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@types/envinfo/-/envinfo-7.8.4.tgz#f13ec1050b8e260d6d7c149ba5b99f65d2b74058"
+  integrity sha512-K5WaRgSlqjc408IyPbxOFnz7rVG9E8ELhj7XR3Ncui15EgeyIXTcCfmwrRnU4uEOCJQhzZRAQurYznEEc1dD2g==
 
 "@types/errorhandler@^1.5.0":
   version "1.5.0"
@@ -5050,10 +5050,10 @@ envinfo@7.8.1:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
 
-envinfo@^7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.10.0.tgz#55146e3909cc5fe63c22da63fb15b05aeac35b13"
-  integrity sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==
+envinfo@^7.13.0:
+  version "7.13.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.13.0.tgz#81fbb81e5da35d74e814941aeab7c325a606fb31"
+  integrity sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==
 
 err-code@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

New version of `envinfo` contains a fix for detecting Android Studio: https://github.com/tabrindle/envinfo/releases/tag/v7.13.0

Related: https://github.com/react-native-community/cli/issues/2354

Test Plan:
----------

n/a

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
