### PR TITLE
fix(clean): make sure to delete `node_modules` as last item

### DIFF
--- a/packages/cli-clean/src/clean.ts
+++ b/packages/cli-clean/src/clean.ts
@@ -153,26 +153,6 @@ export async function clean(
         },
       ],
     },
-    npm: {
-      description:
-        '`node_modules` folder in the current package, and optionally verify npm cache',
-      tasks: [
-        {
-          label: 'Remove node_modules',
-          action: () => cleanDir(`${projectRoot}/node_modules`),
-        },
-        ...(verifyCache
-          ? [
-              {
-                label: 'Verify npm cache',
-                action: async () => {
-                  await execa('npm', ['cache', 'verify'], {cwd: projectRoot});
-                },
-              },
-            ]
-          : []),
-      ],
-    },
     bun: {
       description: 'Bun cache',
       tasks: [
@@ -214,6 +194,26 @@ export async function clean(
             await execa('yarn', ['cache', 'clean'], {cwd: projectRoot});
           },
         },
+      ],
+    },
+    npm: {
+      description:
+        '`node_modules` folder in the current package, and optionally verify npm cache',
+      tasks: [
+        {
+          label: 'Remove node_modules',
+          action: () => cleanDir(`${projectRoot}/node_modules`),
+        },
+        ...(verifyCache
+          ? [
+              {
+                label: 'Verify npm cache',
+                action: async () => {
+                  await execa('npm', ['cache', 'verify'], {cwd: projectRoot});
+                },
+              },
+            ]
+          : []),
       ],
     },
   };


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

In this Pull Request I've moved `npm` to the end of list → removing `node_modules` at the end of `clean` command makes sure that we don't remove CLI itself before finish command 😅

Fixes https://github.com/react-native-community/cli/issues/2353


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js clean
```
3. `npm` should be always as last item ✅

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
