### PR TITLE
fix(doctor): update Android Studio detection path on Windows

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
@@ -22,11 +22,13 @@ export default {
 
     // On Windows `doctor` installs Android Studio locally in a well-known place
     if (needsToBeFixed && process.platform === 'win32') {
+      const prefix = process.arch === 'x64' ? '64' : '';
+
       const androidStudioPath = join(
         getUserAndroidPath(),
         'android-studio',
         'bin',
-        'studio.exe',
+        `studio${prefix}.exe`,
       ).replace(/\\/g, '\\\\');
       const {stdout} = await executeCommand(
         `wmic datafile where name="${androidStudioPath}" get Version`,

--- a/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
@@ -22,13 +22,13 @@ export default {
 
     // On Windows `doctor` installs Android Studio locally in a well-known place
     if (needsToBeFixed && process.platform === 'win32') {
-      const prefix = process.arch === 'x64' ? '64' : '';
+      const archSuffix = process.arch === 'x64' ? '64' : '';
 
       const androidStudioPath = join(
         getUserAndroidPath(),
         'android-studio',
         'bin',
-        `studio${prefix}.exe`,
+        `studio${archSuffix}.exe`,
       ).replace(/\\/g, '\\\\');
       const {stdout} = await executeCommand(
         `wmic datafile where name="${androidStudioPath}" get Version`,
@@ -60,11 +60,11 @@ export default {
       installPath: installPath,
     });
 
-    const prefix = process.arch === 'x64' ? '64' : '';
+    const archSuffix = process.arch === 'x64' ? '64' : '';
     const binFolder = join(installPath, 'android-studio', 'bin');
 
     await createShortcut({
-      path: join(binFolder, `studio${prefix}.exe`),
+      path: join(binFolder, `studio${archSuffix}.exe`),
       name: 'Android Studio',
       ico: join(binFolder, 'studio.ico'),
     });


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Android Studio executable can sometimes contain architecture in the file name. Inside CLI we already honor architecture in the AS file name:

https://github.com/react-native-community/cli/blob/b17d969a17b6bfc04306cd151be917dfccd96d00/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts#L67


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js doctor
```
3. Android Studio should be properly detected on Windows ✅ 



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
