### PR TITLE
chore: bumps `ws` package which patches a security vulnerability

### DIFF
--- a/packages/cli-server-api/package.json
+++ b/packages/cli-server-api/package.json
@@ -15,7 +15,7 @@
     "nocache": "^3.0.1",
     "pretty-format": "^26.6.2",
     "serve-static": "^1.13.1",
-    "ws": "^6.2.2"
+    "ws": "^6.2.3"
   },
   "devDependencies": {
     "@types/compression": "^1.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11862,7 +11862,7 @@ write-pkg@4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
-ws@^6.2.2:
+ws@^6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.3.tgz#ccc96e4add5fd6fedbc491903075c85c5a11d9ee"
   integrity sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
Related to https://github.com/facebook/react-native/pull/45147
[INTERNAL] [SECURITY] - Fixes [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q)

<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------

NA
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
