### PR TITLE
fix: skip if there's no `action` or `category`

### DIFF
--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-className.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-className.xml
@@ -3,9 +3,9 @@
 
 	<application android:name=".MainApplication">
 		<activity android:name="com.example.ExampleAppActivity">
-      <intent-filter>
-        <action android:name="android.intent.action.VIEW" />
-      </intent-filter>
+			<intent-filter>
+			  <action android:name="android.intent.action.VIEW" />
+			</intent-filter>
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-className.xml
+++ b/packages/cli-platform-android/src/config/__fixtures__/files/AndroidManifest-className.xml
@@ -3,6 +3,9 @@
 
 	<application android:name=".MainApplication">
 		<activity android:name="com.example.ExampleAppActivity">
+      <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+      </intent-filter>
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />

--- a/packages/cli-platform-android/src/config/getMainActivity.ts
+++ b/packages/cli-platform-android/src/config/getMainActivity.ts
@@ -54,6 +54,10 @@ export default function getMainActivity(manifestPath: string): string | null {
         return intentFilters.find((intentFilter: IntentFilter) => {
           const {action, category} = intentFilter;
 
+          if (!action || !category) {
+            return false;
+          }
+
           let actions;
           let categories;
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2392

If `intent-filter` with `android.intent.action.MAIN` and `android.intent.category.LAUNCHER` was preceded by an `intent-filter` without `action`/`category` `getMainActivity` function would fail.

Test Plan:
----------
1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Put this snippet inside `AndroidManifest.xml`

```
      <intent-filter>
        <action android:name="android.intent.action.VIEW" />
      </intent-filter>
```
3. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js run-android
```
4. App should launch correctly ✅


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
