### PR TITLE
docs: note that `root` property should use `__dirname`

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -141,7 +141,7 @@ module.exports = {
 };
 ```
 
-> Note: In the root field, it's recommended to use `__dirname` instead of `process.cwd()`. This ensures the path is consistently resolved, regardless of the current working directory.
+> Note: In the `root` field, it's recommended to use `__dirname` instead of `process.cwd()`. This ensures the path is consistently resolved, regardless of the current working directory.
 
 ## How can I use autolinking in a monorepo?
 

--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -135,11 +135,13 @@ We can leverage CLI configuration to make it "see" React Native libraries that a
 module.exports = {
   dependencies: {
     'local-rn-library': {
-      root: '/root/libraries',
+      root: path.join(__dirname, '/path/to/local-rn-library'),
     },
   },
 };
 ```
+
+> Note: In the root field, it's recommended to use `__dirname` instead of `process.cwd()`. This ensures the path is consistently resolved, regardless of the current working directory.
 
 ## How can I use autolinking in a monorepo?
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -222,7 +222,7 @@ Another use-case would be supporting local libraries that are not discoverable f
 module.exports = {
   dependencies: {
     'local-rn-library': {
-      root: '/root/libraries',
+      root: path.join(__dirname, '/path/to/library'),
     },
   },
 };


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Closes https://github.com/react-native-community/cli/issues/1137

Users when linking libraries should leverage `__dirname` instead of `processs.cwd()`.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
