### PR TITLE
fix: issue calling init from 0.75.0-rc.1 release

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -400,7 +400,7 @@ async function createTemplateUri(
   options: Options,
   version: string,
 ): Promise<string> {
-  if (options.platformName) {
+  if (options.platformName && options.platformName !== 'react-native') {
     logger.debug('User has specified an out-of-tree platform, using it');
     return `${options.platformName}@${version}`;
   }


### PR DESCRIPTION
Summary:
---------

When users call the cli through react-native (a deprecated path), it hard-codes the platform name to 'react-native'. This is an error, and doing this bypasses all template selection logic.

This excludes setting the platform name to 'react-native', which is assumed.


Test Plan:
----------

Replicates these changes to the npx cache `~/.npx/_cache/.../index.js` to confirm this fixes the issue holding up the release.  Added some logging to show:

![CleanShot 2024-06-25 at 17 41 10@2x](https://github.com/react-native-community/cli/assets/49578/7a424f1a-50fb-411a-9a16-f50813cb434e)

1. The `run()` method is called with `react-native`, which we should ignore.
2. The raw `process.argv` used to call
3. The expected outcome with out change.

Checklist
----------

- [X] Documentation is up to date to reflect these changes.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
