### PR TITLE
fix(apple): include check if `Podfile` and `Podfile.lock` changed when deciding to install Cocoapods 

### DIFF
--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -13,7 +13,6 @@ import {
   IOSDependencyConfig,
 } from '@react-native-community/cli-types';
 import {ApplePlatform} from '../types';
-import readline from 'readline';
 
 interface ResolvePodsOptions {
   forceInstall?: boolean;
@@ -65,26 +64,20 @@ export function compareMd5Hashes(hash1?: string, hash2?: string) {
   return hash1 === hash2;
 }
 
-async function getChecksum(podfileLockPath: string) {
-  const fileStream = fs.createReadStream(podfileLockPath);
+async function getChecksum(
+  podfileLockPath: string,
+): Promise<string | undefined> {
+  const file = fs.readFileSync(podfileLockPath, 'utf8');
 
-  const rl = readline.createInterface({
-    input: fileStream,
-    crlfDelay: Infinity,
-  });
+  const checksumLine = file
+    .split('\n')
+    .find((line) => line.includes('PODFILE CHECKSUM'));
 
-  let lines = [];
-  for await (const line of rl) {
-    lines.push(line);
+  if (checksumLine) {
+    return checksumLine.split(': ')[1];
+  } else {
+    return undefined;
   }
-
-  lines = lines.reverse();
-
-  return lines
-    .filter((line) => line.includes('PODFILE CHECKSUM'))[0]
-    .split(': ')[1]
-
-  return undefined;
 }
 
 async function install(

--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -80,11 +80,9 @@ async function getChecksum(podfileLockPath: string) {
 
   lines = lines.reverse();
 
-  for (const line of lines) {
-    if (line.includes('PODFILE CHECKSUM')) {
-      return line.split(': ')[1];
-    }
-  }
+  return lines
+    .filter((line) => line.includes('PODFILE CHECKSUM'))[0]
+    .split(': ')[1]
 
   return undefined;
 }

--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -67,15 +67,19 @@ export function compareMd5Hashes(hash1?: string, hash2?: string) {
 async function getChecksum(
   podfileLockPath: string,
 ): Promise<string | undefined> {
-  const file = fs.readFileSync(podfileLockPath, 'utf8');
+  try {
+    const file = fs.readFileSync(podfileLockPath, 'utf8');
 
-  const checksumLine = file
-    .split('\n')
-    .find((line) => line.includes('PODFILE CHECKSUM'));
+    const checksumLine = file
+      .split('\n')
+      .find((line) => line.includes('PODFILE CHECKSUM'));
 
-  if (checksumLine) {
-    return checksumLine.split(': ')[1];
-  } else {
+    if (checksumLine) {
+      return checksumLine.split(': ')[1];
+    }
+
+    return undefined;
+  } catch {
     return undefined;
   }
 }

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -29,10 +29,16 @@ const createBuild =
         ? await getArchitecture(platformConfig.sourceDir)
         : undefined;
 
-      await resolvePods(ctx.root, ctx.dependencies, platformName, {
-        forceInstall: args.forcePods,
-        newArchEnabled: isAppRunningNewArchitecture,
-      });
+      await resolvePods(
+        ctx.root,
+        platformConfig.sourceDir,
+        ctx.dependencies,
+        platformName,
+        {
+          forceInstall: args.forcePods,
+          newArchEnabled: isAppRunningNewArchitecture,
+        },
+      );
 
       installedPods = true;
     }

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -84,10 +84,16 @@ const createRun =
         ? await getArchitecture(platformConfig.sourceDir)
         : undefined;
 
-      await resolvePods(ctx.root, ctx.dependencies, platformName, {
-        forceInstall: args.forcePods,
-        newArchEnabled: isAppRunningNewArchitecture,
-      });
+      await resolvePods(
+        ctx.root,
+        platformConfig.sourceDir,
+        ctx.dependencies,
+        platformName,
+        {
+          forceInstall: args.forcePods,
+          newArchEnabled: isAppRunningNewArchitecture,
+        },
+      );
 
       installedPods = true;
     }

--- a/packages/cli-tools/src/cacheManager.ts
+++ b/packages/cli-tools/src/cacheManager.ts
@@ -10,6 +10,8 @@ type CacheKey =
   | 'lastChecked'
   | 'latestVersion'
   | 'dependencies'
+  | 'podfile'
+  | 'podfileLock'
   | 'lastUsedIOSDeviceId';
 type Cache = {[key in CacheKey]?: string};
 


### PR DESCRIPTION

Summary:
---------

Comparing only `dependencies` field from `config`'s command output takes into account only autolinked dependencies, however users can add manually Pods inside `Podfile`, in this Pull Request I added validating hash for `Podfile` and `Podfile.lock`. 


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create `react-native.config.js` and enable [automaticPodsInstallation](https://github.com/react-native-community/cli/blob/main/docs/projects.md#projectiosautomaticpodsinstallation) 
3. Whenever `Podfile` or `Podfile.lock` content changes installation of Cocoapods should be triggered

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init
```



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
