### PR TITLE
feat: improve error message when cannot find Xcode project

### DIFF
--- a/packages/cli-link-assets/src/linkAssets.ts
+++ b/packages/cli-link-assets/src/linkAssets.ts
@@ -97,7 +97,7 @@ async function linkAssets(_argv: string[], ctx: CLIConfig): Promise<void> {
 
     if (!iosProjectInfo) {
       throw new CLIError(
-        `Could not find Xcode project files in "${iosPath}" folder`,
+        `Could not find Xcode project files in "${iosPath}" folder. Please make sure that you have installed Cocoapods and "${iosPath}" is a valid path`,
       );
     }
 

--- a/packages/cli-platform-apple/src/commands/buildCommand/getXcodeProjectAndDir.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/getXcodeProjectAndDir.ts
@@ -22,7 +22,7 @@ export function getXcodeProjectAndDir(
 
   if (!xcodeProject) {
     throw new CLIError(
-      `Could not find Xcode project files in "${sourceDir}" folder`,
+      `Could not find Xcode project files in "${sourceDir}" folder. Please make sure that you have installed Cocoapods and "${sourceDir}" is a valid path`,
     );
   }
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Guides user to maybe install Cocoapods when Xcode project is not available (there are some project when running `pod install` generates projects).

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Create a project with `npx --package react-native-test-app@latest init`
3. Run `yarn react-native run-ios`.

 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
