### PR TITLE
fix: show only warnings from Yarn when verbose mode is enabled

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -87,7 +87,7 @@ interface TemplateReturnType {
 // Here we are defining explicit version of Yarn to be used in the new project because in some cases providing `3.x` don't work.
 const YARN_VERSION = '3.6.4';
 
-const bumpYarnVersion = async (silent: boolean, root: string) => {
+const bumpYarnVersion = async (root: string) => {
   try {
     let yarnVersion = semver.parse(getYarnVersionIfAvailable());
 
@@ -99,14 +99,14 @@ const bumpYarnVersion = async (silent: boolean, root: string) => {
       }
       await executeCommand('yarn', setVersionArgs, {
         root,
-        silent,
+        silent: !logger.isVerbose(),
       });
 
       // React Native doesn't support PnP, so we need to set nodeLinker to node-modules. Read more here: https://github.com/react-native-community/cli/issues/27#issuecomment-1772626767
       await executeCommand(
         'yarn',
         ['config', 'set', 'nodeLinker', 'node-modules'],
-        {root, silent},
+        {root, silent: !logger.isVerbose()},
       );
     }
   } catch (e) {
@@ -286,7 +286,7 @@ async function createFromTemplate({
     });
 
     if (packageManager === 'yarn' && shouldBumpYarnVersion) {
-      await bumpYarnVersion(false, projectDirectory);
+      await bumpYarnVersion(projectDirectory);
     }
 
     loader.succeed();


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Sometimes when running `yarn set version` - Yarn produces different warnings that as of my testing are not relevant and for sure not fixable during `init` command.

Test Plan:
----------

`init`'s command output shouldn't produce warnings/success messages from Yarn.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
