### PR TITLE
ci: install dependencies before releasing nightly version

### DIFF
--- a/.github/workflows/nigthly-release.yml
+++ b/.github/workflows/nigthly-release.yml
@@ -24,8 +24,6 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: 'Setup git user'
         run: |
@@ -48,6 +46,7 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           # Get the current commit hash
           COMMIT_HASH=$(git rev-parse --short HEAD)

--- a/.github/workflows/nigthly-release.yml
+++ b/.github/workflows/nigthly-release.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
+          cache: yarn
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Latest nightly failed because it pulled latest `lerna` version which fails with current arguments, in this Pull Request I added a step to install (and build) packages before publishing. 

Test Plan:
----------

After margining this Pull Request let's wait for 00:00 UTC for actions to trigger.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
