### PR TITLE
docs: fix broken link to Podfile in React Native template

### DIFF
--- a/docs/autolinking.md
+++ b/docs/autolinking.md
@@ -40,7 +40,7 @@ The implementation ensures that a library is imported only once. If you need to 
 
 ### Example
 
-See example usage in React Native template's [Podfile](https://github.com/facebook/react-native/blob/main/packages/react-native/template/ios/Podfile).
+See example usage in React Native template's [Podfile](https://github.com/react-native-community/template/blob/main/template/ios/Podfile).
 
 ## Platform Android
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fix broken link in autolinking.md due to moving template code to the community repository.



Test Plan:
----------

[rendered diff](https://github.com/react-native-community/cli/pull/2448/files?short_path=30560cb#diff-30560cbb6b72f5d4b12a887cfdecd79911c3cff868ec8ef828585bcc2dd4ee79) is displayed correctly, and the link works.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
