### PR TITLE
ci: remove wrong option passed to command

### DIFF
--- a/.github/workflows/nigthly-release.yml
+++ b/.github/workflows/nigthly-release.yml
@@ -67,5 +67,5 @@ jobs:
           # Create a version string that includes the commit hash and date
           VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}-${PRERELEASE_NAME}-${DATE}-${COMMIT_HASH}"
 
-          npx lerna version "$VERSION" from-package --force-publish --no-push --allow-branch 'main' --preid $PRERELEASE_NAME --yes
+          npx lerna version "$VERSION" --force-publish --no-push --allow-branch 'main' --preid $PRERELEASE_NAME --yes
           npx lerna publish from-git --dist-tag $PRERELEASE_NAME --no-changelog --yes


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

`version` command doesn't accept `from-package` option:

```
❯ npx lerna version from-package
ERR! lerna bump must be an explicit version string _or_ one of: 'major', 'minor', 'patch', 'premajor', 'preminor', 'prepatch', or 'prerelease'.
```


Test Plan:
----------

After margining this Pull Request let's wait for 00:00 UTC for actions to trigger.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
