### PR TITLE
**fix** findComponentDescriptors should look in codegenConfig/jsSrcsDir

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/getDependencyConfig.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/getDependencyConfig.test.ts
@@ -22,6 +22,7 @@ describe('android::getDependencyConfig', () => {
     fs.__setMockFilesystem({
       empty: {},
       nested: {
+        'package.json': JSON.stringify({codegenConfig: {jsSrcsDir: 'src'}}),
         android: {
           app: mocks.valid,
         },


### PR DESCRIPTION
only and it should look into components starging with Native or ending with NativeComponent

Fixes: #2455

Summary:
---------

findComponentDescriptors looks in all javascript files for regex `codegenNativeComponent...`. And android build uses that for autolinking.  

Note that this is not 100% solution, as we still use regex parsing instead of parsing typescript and we also duplicate the logic from codegen. A better solution could be using codegen schema to parse for components.

Test Plan:
----------

```sh
git clone https://github.com/mfazekas/rn-075-autolink
cd rn-075-autolink
git checkout autolink-wrong-files
cd ReproducerApp
```

```sh
node $RNCLI/packages/cli/build/bin.js config | grep componentDescriptors -A 3
          "componentDescriptors": [
            "RTNCenteredTextComponentDescriptor"
          ],
```

### Works with .android platform extension
```sh
mv ../RTNCenteredText/js/RTNCenteredTextNativeComponent.ts ../RTNCenteredText/js/RTNCenteredTextNativeComponent.android.ts
node $RNCLI/packages/cli/build/bin.js config | grep componentDescriptors -A 3
          "componentDescriptors": [
            "RTNCenteredTextComponentDescriptor"
          ],
```

### File matching Native*

```sh
echo 'codegenNativeComponent<NativeProps>("Foo")' > ../RTNCenteredText/js/NativeFoo.jsx
node $RNCLI/packages/cli/build/bin.js config | grep componentDescriptors -A 3
          "componentDescriptors": [
            "FooComponentDescriptor",
            "RTNCenteredTextComponentDescriptor"
          ],
```

### File not matching Native* or NativeComponent 

```sh
echo 'codegenNativeComponent<NativeProps>("Bar")' > ../RTNCenteredText/js/_Bar.jsx
node $RNCLI/packages/cli/build/bin.js config | grep componentDescriptors -A 3
          "componentDescriptors": [
            "FooComponentDescriptor",
            "RTNCenteredTextComponentDescriptor"
          ],
```

Checklist
----------

