### PR TITLE
fix(cli): fix `ENOWORKSPACES` when running any command on latest npm

### DIFF
--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -36,7 +36,11 @@ export const getNpmRegistryUrl = (() => {
   return () => {
     if (!registryUrl) {
       try {
-        registryUrl = execSync('npm config get registry --workspaces=false --include-workspace-root').toString().trim();
+        registryUrl = execSync(
+          'npm config get registry --workspaces=false --include-workspace-root',
+        )
+          .toString()
+          .trim();
       } catch {
         registryUrl = 'https://registry.npmjs.org/';
       }

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -36,7 +36,7 @@ export const getNpmRegistryUrl = (() => {
   return () => {
     if (!registryUrl) {
       try {
-        registryUrl = execSync('npm config get registry').toString().trim();
+        registryUrl = execSync('npm config get registry --workspaces=false --include-workspace-root').toString().trim();
       } catch {
         registryUrl = 'https://registry.npmjs.org/';
       }


### PR DESCRIPTION
Summary:
---------

Commands are failing on npm 10.7.0 (and Node 20.15.1) when inside a monorepo. Example when building Android:

```
Error executing command '[node, npm error code ENOWORKSPACES
npm error This command does not support workspaces.

npm error A complete log of this run can be found in: ~/.npm/_logs/2024-07-15T08_41_45_432Z-debug-0.log
/~/node_modules/@react-native-community/cli/build/bin.js, config, --platform, android]': Command '[node, npm error code ENOWORKSPACES
npm error This command does not support workspaces.

npm error A complete log of this run can be found in: ~/.npm/_logs/2024-07-15T08_41_45_432Z-debug-0.log
/~/node_modules/@react-native-community/cli/build/bin.js, config, --platform, android]' failed with exit code 1.
```

The culprit seems to be this command, which is called unconditionally when importing [`npm.ts`](https://github.com/react-native-community/cli/blob/d6982fc9a56812b0deff42cabcab09528f72fdca/packages/cli/src/tools/npm.ts#L32):

```
% npm config get registry
npm error code ENOWORKSPACES
npm error This command does not support workspaces.
```

Test Plan:
----------

```
node -p 'require("@react-native-community/cli").bin'
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
