### PR TITLE
ci: always print debug log from lerna

### DIFF
--- a/.github/workflows/nigthly-release.yml
+++ b/.github/workflows/nigthly-release.yml
@@ -72,7 +72,7 @@ jobs:
           npx lerna version "$VERSION" --force-publish --no-push --allow-branch 'main' --preid $PRERELEASE_NAME --yes
           npx lerna publish from-git --dist-tag $PRERELEASE_NAME --no-changelog --yes --loglevel verbose
       - name: 'Print Lerna Debug Log'
-        if: steps.check.outputs.changed == 'true'
+        if: always() && steps.check.outputs.changed == 'true'
         run: |
           echo "Contents of lerna-debug.log:"
           cat lerna-debug.log


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

When Prerelease step fails logs are not printed, in this PR I've changed to log it always regardless of the previous step output.
