### PR TITLE
feat: add `--version` option

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,7 @@ const pkgJson = require('../package.json');
 
 const program = new CommanderCommand()
   .usage('[command] [options]')
-  .version(pkgJson.version, '-v', 'Output the current version')
+  .version(pkgJson.version, '-v --version', 'Output the current version')
   .enablePositionalOptions();
 
 const handleError = (err: Error) => {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Add `--version` option, we already have abbreviation one `-v`.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js --version
```
3. Should output current CLI version.

 
Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
