### PR TITLE
fix: config fails to load with --platform flag

### DIFF
--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -42,7 +42,7 @@ function getDependencyConfig(
               ? null
               : platformConfig.dependencyConfig(
                   root,
-                  config.dependency.platforms[platform],
+                  config.dependency.platforms?.[platform],
                 );
           return dependency;
         },


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
If dependency does not have native code, it does not have `platforms` property in dependency config. Passing `--platform [platformName]` was breaking when it was trying to read `platforms` from such dependencies.

Closes #2463 

Test Plan:
----------
1. Run `node ./path-to-cli/cli/build/bin.js config --platform ios`
2. Verify the output was returned properly
3. Run `node ./path-to-cli/cli/build/bin.js config --platform android`
4. Verify the output was returned properly
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------
- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
