### PR TITLE
fix: readConfigFromDisk should ignore package.json entries

### DIFF
--- a/packages/cli-config/src/readConfigFromDisk.ts
+++ b/packages/cli-config/src/readConfigFromDisk.ts
@@ -20,6 +20,7 @@ const searchPlaces = ['react-native.config.js', 'react-native.config.ts'];
 export function readConfigFromDisk(rootFolder: string): UserConfig {
   const explorer = cosmiconfigSync('react-native', {
     stopDir: rootFolder,
+    searchPlaces,
   });
 
   const searchResult = explorer.search(rootFolder);


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

I was trying out 0.75 and not sure why is worked before, but now the `config` command returned [this value](https://github.com/vonovak/react-native-theme-control/blob/a0a68284f8dbaa011333331632b0ce2bf03d7a15/package.json#L8) - literally "src/index", instead of the value influenced by the config file.

Test Plan:
----------

`npx react-native config` returned a valid result in the [repo](https://github.com/vonovak/react-native-theme-control)

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
