### PR TITLE
Put an upper bound on "**/Podfile" search depth

### DIFF
--- a/packages/cli-platform-apple/src/config/findAllPodfilePaths.ts
+++ b/packages/cli-platform-apple/src/config/findAllPodfilePaths.ts
@@ -15,5 +15,9 @@ export default function findAllPodfilePaths(cwd: string) {
   return glob.sync('**/Podfile', {
     cwd: unixifyPaths(cwd),
     ignore: GLOB_EXCLUDE_PATTERN,
+    // Stop unbounded globbing and infinite loops for projects
+    // with deeply nested subdirectories. The most likely result
+    // is `ios/Podfile`, so this depth should be plenty:
+    deep: 10,
   });
 }


### PR DESCRIPTION
Summary:
---------

This PR addresses https://github.com/react-native-community/cli/issues/2479. Basically the unbounded search for `**/Podfile` never finishes on my machine. Normally the required depth should be `2`, since `ios/Podfile` is the default location. So this still provides significantly more depth than most users should need.


Test Plan:
----------

To be honest I'm not sure what causes this issue on my system, I only investigated what fixes it so far. It's clearly an issue with a deeply-nested submodule that we have, but I can't see what about it is causing the issue. If I run `find .` in my project root, all files (including the deeply-nested ones) can be printed within a few seconds, whereas `fast-glob` appears to never finish its search without this `deep: 10` limitation.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
