### PR TITLE
fix: add missing `--device` option to `build-ios` command

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
@@ -16,6 +16,8 @@ export type BuildFlags = {
 
 export const getBuildOptions = ({platformName}: BuilderCommand) => {
   const {readableName} = getPlatformInfo(platformName);
+  const isMac = platformName === 'macos';
+
   return [
     {
       name: '--mode <string>',
@@ -59,6 +61,12 @@ export const getBuildOptions = ({platformName}: BuilderCommand) => {
     {
       name: '--force-pods',
       description: 'Force CocoaPods installation',
+    },
+    !isMac && {
+      name: '--device [string]', // here we're intentionally using [] over <> to make passed value optional to allow users to run only on physical devices
+      description:
+        'Explicitly set the device to use by name or by unique device identifier . If the value is not provided,' +
+        'the app will run on the first available physical device.',
     },
   ];
 };

--- a/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/runOptions.ts
@@ -42,12 +42,6 @@ export const getRunOptions = ({platformName}: BuilderCommand) => {
         'between parentheses at the end to match an exact version: ' +
         '"iPhone 15 (17.0)"',
     },
-    !isMac && {
-      name: '--device [string]', // here we're intentionally using [] over <> to make passed value optional to allow users to run only on physical devices
-      description:
-        'Explicitly set the device to use by name or by unique device identifier . If the value is not provided,' +
-        'the app will run on the first available physical device.',
-    },
     ...getBuildOptions({platformName}),
   ];
 };

--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -148,6 +148,10 @@ Explicitly set Xcode scheme to use.
 
 Explicitly set Xcode target to use.
 
+#### `--device [string]`
+
+Explicitly set device to use by name. The value is not required if you have a single device connected.
+
 #### `--verbose`
 
 Do not use `xcbeautify` or `xcpretty` even if installed.


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Fixes https://github.com/react-native-community/cli/issues/2473

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js build-ios --device
```

 
Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
