### PR TITLE
perf: skip getting package class name inside expo module

### DIFF
--- a/packages/cli-platform-android/src/config/findPackageClassName.ts
+++ b/packages/cli-platform-android/src/config/findPackageClassName.ts
@@ -29,9 +29,6 @@ export function getMainActivityFiles(
 }
 
 export default function getPackageClassName(folder: string) {
-  let files = getMainActivityFiles(folder);
-  let packages = getClassNameMatches(files, folder);
-
   /*
     When module contains `expo-module.config.json` we return null
     because expo modules follow other practices and don't implement
@@ -60,6 +57,9 @@ export default function getPackageClassName(folder: string) {
   ) {
     return null;
   }
+
+  let files = getMainActivityFiles(folder);
+  let packages = getClassNameMatches(files, folder);
 
   if (!packages.length) {
     files = getMainActivityFiles(folder, false);

--- a/packages/cli-platform-android/src/config/findPackageClassName.ts
+++ b/packages/cli-platform-android/src/config/findPackageClassName.ts
@@ -29,6 +29,13 @@ export function getMainActivityFiles(
 }
 
 export default function getPackageClassName(folder: string) {
+  let files = getMainActivityFiles(folder);
+  let packages = getClassNameMatches(files, folder);
+
+  if (packages && packages.length > 0 && Array.isArray(packages[0])) {
+    return packages[0][1];
+  }
+
   /*
     When module contains `expo-module.config.json` we return null
     because expo modules follow other practices and don't implement
@@ -36,35 +43,17 @@ export default function getPackageClassName(folder: string) {
     to scan and read hundreds of files to get package class name.
 
     Exception is `expo` package itself which contains `expo-module.config.json`
-    and implements `ReactPackage/TurboReactPackage` inside `ExpoModulesPackage.kt`.
+    and implements `ReactPackage/TurboReactPackage`.
 
     Following logic is done due to performance optimization.
   */
 
-  if (
-    fs.existsSync(path.join(folder, '..', 'expo-module.config.json')) &&
-    !fs.existsSync(
-      path.join(
-        folder,
-        'src',
-        'main',
-        'java',
-        'expo',
-        'modules',
-        'ExpoModulesPackage.kt',
-      ),
-    )
-  ) {
+  if (fs.existsSync(path.join(folder, '..', 'expo-module.config.json'))) {
     return null;
   }
 
-  let files = getMainActivityFiles(folder);
-  let packages = getClassNameMatches(files, folder);
-
-  if (!packages.length) {
-    files = getMainActivityFiles(folder, false);
-    packages = getClassNameMatches(files, folder);
-  }
+  files = getMainActivityFiles(folder, false);
+  packages = getClassNameMatches(files, folder);
 
   // @ts-ignore
   return packages.length ? packages[0][1] : null;

--- a/packages/cli-platform-android/src/config/findPackageClassName.ts
+++ b/packages/cli-platform-android/src/config/findPackageClassName.ts
@@ -32,6 +32,35 @@ export default function getPackageClassName(folder: string) {
   let files = getMainActivityFiles(folder);
   let packages = getClassNameMatches(files, folder);
 
+  /*
+    When module contains `expo-module.config.json` we return null
+    because expo modules follow other practices and don't implement
+    ReactPackage/TurboReactPackage directly, so it doesn't make sense
+    to scan and read hundreds of files to get package class name.
+
+    Exception is `expo` package itself which contains `expo-module.config.json`
+    and implements `ReactPackage/TurboReactPackage` inside `ExpoModulesPackage.kt`.
+
+    Following logic is done due to performance optimization.
+  */
+
+  if (
+    fs.existsSync(path.join(folder, '..', 'expo-module.config.json')) &&
+    !fs.existsSync(
+      path.join(
+        folder,
+        'src',
+        'main',
+        'java',
+        'expo',
+        'modules',
+        'ExpoModulesPackage.kt',
+      ),
+    )
+  ) {
+    return null;
+  }
+
   if (!packages.length) {
     files = getMainActivityFiles(folder, false);
     packages = getClassNameMatches(files, folder);


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Recently [blog post](https://github.com/react-native-community/discussions-and-proposals/discussions/814) regarding performance improvements inside autolinking was published, as it turns between implementations there's a big difference.

After my investigation it is due getting package class name from classes which are implementing `ReactPackage` or `TurboReactPackage`. In past we landed improvements to this logic (read more [here](https://github.com/react-native-community/cli/pull/2384)).

But as mentioned in the blog post the difference is still big and the root cause of this issue is because of reading hundreds of files from expo modules and trying to find classes that implements `ReactPackage` or `TurboReactPackage`, but expo modules don't implement `ReactPackage` or `TurboReactPackage` directly inside their source code, so the return value will be anyway `null`, so it doesn't make sense to read hundreds of files and check for classes that implements `ReactPackage` or `TurboReactPackage`.

Inside this Pull Request I've added a early return if module is expo module, following logic **doesn't affect** output of `config` command because expo modules follows other rules and are included in native build in different way.

Exception is `expo` package itself which contains `expo-module.config.json` and also implements `ReactPackage` or `TurboReactPackage`, I added appropriate condition for this case.  
 
Benchmark:
---------

Tested on the [`react-conf-app`](https://github.com/expo/react-conf-app).

Before:
```
❯ hyperfine 'node ~/development/cli/packages/cli/build/bin.js config'
Benchmark 1: node ~/development/cli/packages/cli/build/bin.js config
  Time (mean ± σ):      2.353 s ±  0.033 s    [User: 2.067 s, System: 0.313 s]
  Range (min … max):    2.313 s …  2.408 s    10 runs
```

After:
```
❯ hyperfine 'node ~/development/cli/packages/cli/build/bin.js config'
Benchmark 1: node ~/development/cli/packages/cli/build/bin.js config
  Time (mean ± σ):     654.7 ms ±  30.7 ms    [User: 453.2 ms, System: 269.3 ms]
  Range (min … max):   620.0 ms … 711.5 ms    10 runs
```


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js config
```
3. Output should be the same. 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
