### PR TITLE
feat: allow providing current directory in `init` command

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -166,7 +166,7 @@ async function setProjectDirectory(
 
   try {
     if (deleteDirectory) {
-      fs.removeSync(directory);
+      fs.emptyDirSync(directory);
     }
 
     fs.mkdirSync(directory, {recursive: true});
@@ -242,6 +242,10 @@ async function createFromTemplate({
 
   // if the project with the name already has cache, remove the cache to avoid problems with pods installation
   cacheManager.removeProjectCache(projectName);
+
+  if (directory === '') {
+    directory = process.cwd();
+  }
 
   const projectDirectory = await setProjectDirectory(
     directory,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------


Context: https://github.com/react-native-community/cli/pull/365#issuecomment-2298684999.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run this command:

```sh
node /path/to/react-native-cli/packages/cli/build/bin.js init asdf --directory ./
```
3. Should create project in current directory, if it contains some files it should ask what to do before.



Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
