### PR TITLE
ci: disable `react-native-macos` test

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -193,7 +193,8 @@ test('init uses npm as the package manager with --npm', () => {
   });
 });
 
-test('init --platform-name should work for out of tree platform', () => {
+// react-native-macos stopped shipping `template.config.js` for 0.75, so this test is disabled. in future releases we should re-enable once `template.config.js` will be there again.
+test.skip('init --platform-name should work for out of tree platform', () => {
   createCustomTemplateFiles();
   const outOfTreePlatformName = 'react-native-macos';
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

`react-native-macos` stopped shipping `template.config.js` in the latest release and it caused our current test suite to fail, in the nearest future we should revisit logic for mapping template location for supported OOT platforms.

Test Plan:
----------

CI green

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
