### PR TITLE
chore: set npm as default package manager to init

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -22,13 +22,10 @@ function createCustomTemplateFiles() {
 
 const customTemplateCopiedFiles = [
   '.git',
-  '.yarn',
-  '.yarnrc.yml', // .yarnrc.yml for Yarn versions >= 2.0.0
   'dir',
   'file',
-  'node_modules',
+  'package-lock.json',
   'package.json',
-  'yarn.lock',
 ];
 
 beforeEach(() => {
@@ -150,7 +147,7 @@ test('init skips installation of dependencies with --skip-install', () => {
 
   expect(dirFiles).toEqual(
     customTemplateCopiedFiles.filter(
-      (file) => !['node_modules', 'yarn.lock'].includes(file),
+      (file) => !['node_modules', 'package-lock.json'].includes(file),
     ),
   );
 });

--- a/docs/init.md
+++ b/docs/init.md
@@ -6,7 +6,7 @@ There are couple of ways to initialize new React Native projects.
 npx react-native@latest init ProjectName
 ```
 
-> Note: If you have both `yarn` and `npm` installed on your machine, React Native CLI will always try to use `yarn`, so even if you use `npx` utility, only `react-native` executable will be installed using `npm` and the rest of the work will be delegated to `yarn`. You can force usage of `npm` adding `--pm npm` flag to the command.
+> Note: If you have both `yarn` and `npm` installed on your machine, React Native CLI will always try to use `npm`. You can force usage of `yarn` by adding `--pm yarn` flag to the command.
 
 > Note: for Yarn users, `yarn dlx` command similar to `npx` will be featured in Yarn 2.0: <https://github.com/yarnpkg/berry/pull/40> so we'll be able to use it in a similar fashion.
 
@@ -49,10 +49,10 @@ npx react-native@latest init ProjectName --template ${TEMPLATE_NAME}
 npx react-native@${VERSION} init ProjectName --template ${TEMPLATE_NAME}
 ```
 
-You can force usage of `npm` if you have both `yarn` and `npm` installed on your machine:
+You can force usage of `yarn` if you have both `yarn` and `npm` installed on your machine:
 
 ```sh
-npx react-native@latest init ProjectName --pm npm
+npx react-native@latest init ProjectName --pm yarn
 ```
 
 ## Creating custom template

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -23,7 +23,7 @@ export default {
     {
       name: '--pm <string>',
       description:
-        'Use specific package manager to initialize the project. Available options: `yarn`, `npm`, `bun`. Default: `yarn`',
+        'Use specific package manager to initialize the project. Available options: `yarn`, `npm`, `bun`. Default: `npm`',
     },
     {
       name: '--directory <string>',

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -209,8 +209,8 @@ async function createFromTemplate({
     packageManager = pm;
   } else {
     const userAgentPM = userAgentPackageManager();
-    // if possible, use the package manager from the user agent. Otherwise fallback to default (yarn)
-    packageManager = userAgentPM || 'yarn';
+    // if possible, use the package manager from the user agent. Otherwise fallback to default (npm)
+    packageManager = userAgentPM || 'npm';
   }
 
   if (npm) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
After discussing it internally, we decided to make npm a default package manager for projects created with `init`. `yarn` in version >= 3 generates a lot of issues and makes the first experience with React Native worse.

Test Plan:
----------

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
1. Run `init` command locally
2. Once the process is complete, verify `package-lock.json` is in the folder, and there is no `yarn.lock` file
Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
