### PR TITLE
chore: remove deprecated --npm flag

### DIFF
--- a/__e2e__/init.test.ts
+++ b/__e2e__/init.test.ts
@@ -155,44 +155,6 @@ test('init skips installation of dependencies with --skip-install', () => {
   );
 });
 
-test('init uses npm as the package manager with --npm', () => {
-  createCustomTemplateFiles();
-
-  const {stdout} = runCLI(DIR, [
-    'init',
-    '--template',
-    templatePath,
-    PROJECT_NAME,
-    '--npm',
-    '--install-pods',
-    'false',
-  ]);
-
-  expect(stdout).toContain('Run instructions');
-
-  // make sure we don't leave garbage
-  expect(fs.readdirSync(DIR)).toContain('custom');
-
-  const initDirPath = path.join(DIR, PROJECT_NAME);
-
-  // Remove yarn specific files and node_modules
-  const filteredFiles = customTemplateCopiedFiles.filter(
-    (file) =>
-      !['yarn.lock', 'node_modules', '.yarnrc.yml', '.yarn'].includes(file),
-  );
-
-  // Add package-lock.json
-  const customTemplateCopiedFilesForNpm = [
-    ...filteredFiles,
-    'package-lock.json',
-  ];
-
-  // Assert for existence
-  customTemplateCopiedFilesForNpm.forEach((file) => {
-    expect(fs.existsSync(path.join(initDirPath, file))).toBe(true);
-  });
-});
-
 // react-native-macos stopped shipping `template.config.js` for 0.75, so this test is disabled. in future releases we should re-enable once `template.config.js` will be there again.
 test.skip('init --platform-name should work for out of tree platform', () => {
   createCustomTemplateFiles();

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -100,13 +100,6 @@ Skip dependencies installation
 
 Determine if CocoaPods should be installed when initializing a project. If set to `true` it will install pods, if set to `false`, it will skip the step entirely. If not used, prompt will be displayed
 
-#### `--npm`
-
-> [!WARNING]  
-> `--npm` is deprecated and will be removed in the future. Please use `--pm npm` instead.
-
-Force use of npm during initialization
-
 #### `--pm <string>`
 
 Use specific package manager to initialize the project. Available options: `yarn`, `npm`, `bun`. Default: `yarn`

--- a/docs/init.md
+++ b/docs/init.md
@@ -31,7 +31,7 @@ npx react-native@${VERSION} init ProjectName
 It is possible to initialize a new application with a custom template with
 a `--template` option.
 
-It should point to a valid package that can be installed with `yarn` or `npm` (if you're using `--npm` option).
+It should point to a valid package that can be installed with `npm` or `yarn` (if you're using `--pm yarn` option).
 
 The most common options are:
 

--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -14,11 +14,7 @@ export default {
     {
       name: '--template <string>',
       description:
-        'Uses a custom template. Valid arguments are the ones supported by `yarn add [package]` or `npm install [package]`, if you are using `--npm` option',
-    },
-    {
-      name: '--npm',
-      description: 'Forces using npm for initialization',
+        'Uses a custom template. Valid arguments are the ones supported by `npm install [package]` or `yarn add [package]`, if you are using `--pm yarn` option',
     },
     {
       name: '--pm <string>',

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -48,7 +48,6 @@ interface TemplateOptions {
   projectName: string;
   shouldBumpYarnVersion: boolean;
   templateUri: string;
-  npm?: boolean;
   pm?: PackageManager.PackageManager;
   directory: string;
   projectTitle?: string;
@@ -186,7 +185,6 @@ async function createFromTemplate({
   projectName,
   shouldBumpYarnVersion,
   templateUri,
-  npm,
   pm,
   directory,
   projectTitle,
@@ -211,14 +209,6 @@ async function createFromTemplate({
     const userAgentPM = userAgentPackageManager();
     // if possible, use the package manager from the user agent. Otherwise fallback to default (yarn)
     packageManager = userAgentPM || 'yarn';
-  }
-
-  if (npm) {
-    logger.warn(
-      'Flag --npm is deprecated and will be removed soon. In the future, please use --pm npm instead.',
-    );
-
-    packageManager = 'npm';
   }
 
   // if the project with the name already has cache, remove the cache to avoid problems with pods installation
@@ -425,7 +415,6 @@ async function createProject(
     projectName,
     shouldBumpYarnVersion,
     templateUri,
-    npm: options.npm,
     pm: options.pm,
     directory,
     projectTitle: options.title,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
The `--npm` flag in `init` command has been deprecated for more than a year now in favor of using `--pm` flag. Since `npm` will become a default package manager when initializing new project (#2503), I think it's a good time to remove this flag.
<!-- Help us understand your motivation by explaining why you decided to make this change: -->


Test Plan:
----------
1. Run `init` command locally and use `--npm` flag
2. Verify error is displayed:
```
error: unknown option '--npm'
(Did you mean --pm?)
```
<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
