### PR TITLE
fix(macCatalyst): construct correct path for executable

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/__tests__/getBuildPath.test.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/__tests__/getBuildPath.test.ts
@@ -1,0 +1,97 @@
+import path from 'path';
+import fs from 'fs';
+import {getTempDirectory} from '../../../../../../jest/helpers';
+import {BuildSettings} from '../getBuildSettings';
+import {getBuildPath} from '../getBuildPath';
+
+const targetBuildDirName = 'foo';
+const targetBuildDirNameWithMaccatalyst = `${targetBuildDirName}-maccatalyst`;
+const executableFolderPath = path.join('foo.app', 'Contents', 'MacOS', 'foo');
+
+test('correctly determines macCatalyst build artifact path new style', async () => {
+  // setup:
+  const tmpBuildPath = getTempDirectory('maccatalyst-test-dir');
+  fs.mkdirSync(path.join(tmpBuildPath, targetBuildDirNameWithMaccatalyst), {
+    recursive: true,
+  });
+
+  // - create buildSettings object that represents this to CLI
+  const buildSettings: BuildSettings = {
+    TARGET_BUILD_DIR: path.join(
+      tmpBuildPath,
+      targetBuildDirNameWithMaccatalyst,
+    ),
+    EXECUTABLE_FOLDER_PATH: executableFolderPath,
+    FULL_PRODUCT_NAME: 'unused-in-this-test',
+    INFOPLIST_PATH: 'unused-in-this-test',
+  };
+
+  // test:
+  // - send our buildSettings in and see what build path comes out
+  const buildPath = await getBuildPath(buildSettings, 'ios', true);
+
+  // assert:
+  expect(buildPath).toBe(
+    path.join(
+      tmpBuildPath,
+      targetBuildDirNameWithMaccatalyst,
+      executableFolderPath,
+    ),
+  );
+});
+
+test('correctly determines macCatalyst build artifact path old style', async () => {
+  // setup:
+  const tmpBuildPath = getTempDirectory('maccatalyst-test-dir');
+  fs.mkdirSync(path.join(tmpBuildPath, targetBuildDirNameWithMaccatalyst), {
+    recursive: true,
+  });
+
+  // - create buildSettings object that represents this to CLI
+  // FIXME get the build settings as side effect from project definition,
+  //       because it's the translation of project settings to path that fails
+  const buildSettings: BuildSettings = {
+    TARGET_BUILD_DIR: path.join(tmpBuildPath, targetBuildDirName),
+    EXECUTABLE_FOLDER_PATH: executableFolderPath,
+    FULL_PRODUCT_NAME: 'unused-in-this-test',
+    INFOPLIST_PATH: 'unused-in-this-test',
+  };
+
+  // test:
+  // - send our buildSettings in and see what build path comes out
+  const buildPath = await getBuildPath(buildSettings, 'ios', true);
+
+  // assert:
+  expect(buildPath).toBe(
+    path.join(
+      tmpBuildPath,
+      targetBuildDirNameWithMaccatalyst,
+      executableFolderPath,
+    ),
+  );
+});
+
+test('correctly determines iOS build artifact path', async () => {
+  // setup:
+  const tmpBuildPath = getTempDirectory('ios-test-dir');
+  fs.mkdirSync(path.join(tmpBuildPath, targetBuildDirName), {
+    recursive: true,
+  });
+
+  // - create buildSettings object that represents this to CLI
+  const buildSettings: BuildSettings = {
+    TARGET_BUILD_DIR: path.join(tmpBuildPath, targetBuildDirName),
+    EXECUTABLE_FOLDER_PATH: executableFolderPath,
+    FULL_PRODUCT_NAME: 'unused-in-this-test',
+    INFOPLIST_PATH: 'unused-in-this-test',
+  };
+
+  // test:
+  // - send our buildSettings in and see what build path comes out
+  const buildPath = await getBuildPath(buildSettings);
+
+  // assert:
+  expect(buildPath).toBe(
+    path.join(tmpBuildPath, targetBuildDirName, executableFolderPath),
+  );
+});

--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildPath.ts
@@ -1,5 +1,6 @@
 import {CLIError} from '@react-native-community/cli-tools';
 import path from 'path';
+import fs from 'fs';
 import {BuildSettings} from './getBuildSettings';
 import {ApplePlatform} from '../../types';
 
@@ -8,7 +9,7 @@ export async function getBuildPath(
   platform: ApplePlatform = 'ios',
   isCatalyst: boolean = false,
 ) {
-  const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
+  let targetBuildDir = buildSettings.TARGET_BUILD_DIR;
   const executableFolderPath = buildSettings.EXECUTABLE_FOLDER_PATH;
   const fullProductName = buildSettings.FULL_PRODUCT_NAME;
 
@@ -24,11 +25,31 @@ export async function getBuildPath(
     throw new CLIError('Failed to get product name.');
   }
 
-  if (isCatalyst) {
-    return path.join(`${targetBuildDir}-maccatalyst`, executableFolderPath);
-  } else if (platform === 'macos') {
-    return path.join(targetBuildDir, fullProductName);
-  } else {
-    return path.join(targetBuildDir, executableFolderPath);
+  // Default is platform == ios && isCatalyst == false
+  let buildPath = path.join(targetBuildDir, executableFolderPath);
+
+  // platform == ios && isCatalyst == true needs build path suffix,
+  // but this regresses from time to time with suffix present or not
+  // so check - there may be one already, or we may need to add suffix
+  if (platform === 'ios' && isCatalyst) {
+    // make sure path has one and only one '-maccatalyst' suffix on end
+    if (!targetBuildDir.match(/-maccatalyst$/)) {
+      targetBuildDir = `${targetBuildDir}-maccatalyst`;
+    }
+    buildPath = path.join(targetBuildDir, executableFolderPath);
   }
+
+  // macOS gets the product name, not the executable folder path
+  if (platform === 'macos') {
+    buildPath = path.join(targetBuildDir, fullProductName);
+  }
+
+  // Make sure the directory exists and fail fast vs silently failing
+  if (!fs.existsSync(targetBuildDir)) {
+    throw new CLIError(
+      `target build directory ${targetBuildDir} does not exist`,
+    );
+  }
+
+  return buildPath;
 }


### PR DESCRIPTION
Summary:
---------

it appears targetBuildDir var now has `-maccatalyst` in it before it gets to this method, so no need to add it again

This was tweaked in #2312 but appears to have regressed again - are macCatalyst builds checked in CI 🤔 ?

Without this change, the path is incorrect (note the duplicate `-maccatalyst` in path):

```

Error: spawn /Users/mike/Library/Developer/Xcode/DerivedData/rnfbdemo-gsuyjvwnbefbzvbfqtovnhthepew/Build/Products/Debug-maccatalyst-maccatalyst/rnfbdemo.app/Contents/MacOS/rnfbdemo ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:284:19)
    at onErrorNT (node:internal/child_process:477:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:290:12)
    at onErrorNT (node:internal/child_process:477:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn /Users/mike/Library/Developer/Xcode/DerivedData/rnfbdemo-gsuyjvwnbefbzvbfqtovnhthepew/Build/Products/Debug-maccatalyst-maccatalyst/rnfbdemo.app/Contents/MacOS/rnfbdemo',
  path: '/Users/mike/Library/Developer/Xcode/DerivedData/rnfbdemo-gsuyjvwnbefbzvbfqtovnhthepew/Build/Products/Debug-maccatalyst-maccatalyst/rnfbdemo.app/Contents/MacOS/rnfbdemo',
  spawnargs: []
}
```

Highlight:

> /Users/mike/Library/Developer/Xcode/DerivedData/rnfbdemo-gsuyjvwnbefbzvbfqtovnhthepew/Build/Products/Debug-maccatalyst-maccatalyst/rnfbdemo.app/Contents/MacOS/rnfbdemo


Test Plan:
----------

I build and test with macCatalyst all the time: https://github.com/mikehardy/rnfbdemo/blob/main/make-demo.sh

I added a unit test that exercises the method, sending it old (without -maccatalyst) and new (with -maccatalyst) inputs to verify it handles both, and verify I didn't regress the more common ios build code path

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
