### PR TITLE
chore: use fast-glob for link-assets and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-import": "^2.25.3",
     "execa": "^5.0.0",
     "fast-glob": "^3.3.2",
-    "glob": "^7.1.3",
     "husky": "^8.0.2",
     "jest": "^26.6.2",
     "jest-circus": "^26.6.2",

--- a/packages/cli-link-assets/package.json
+++ b/packages/cli-link-assets/package.json
@@ -14,6 +14,7 @@
     "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
     "@react-native-community/cli-tools": "15.0.0-alpha.2",
     "chalk": "^4.1.2",
+    "fast-glob": "^3.3.2",
     "fast-xml-parser": "^4.4.1",
     "opentype.js": "^1.3.4",
     "plist": "^3.1.0",

--- a/packages/cli-link-assets/src/tools/helpers/font/androidFontAssetHelpers.ts
+++ b/packages/cli-link-assets/src/tools/helpers/font/androidFontAssetHelpers.ts
@@ -2,7 +2,7 @@ import {isProjectUsingKotlin} from '@react-native-community/cli-platform-android
 import {CLIError, logger} from '@react-native-community/cli-tools';
 import {XMLBuilder, XMLParser} from 'fast-xml-parser';
 import fs from 'fs-extra';
-import {sync as globSync} from 'glob';
+import glob from 'fast-glob';
 import OpenType from 'opentype.js';
 import path from 'path';
 
@@ -77,7 +77,7 @@ function convertToAndroidResourceName(str: string) {
 function getProjectFilePath(rootPath: string, name: string) {
   const isUsingKotlin = isProjectUsingKotlin(rootPath);
   const ext = isUsingKotlin ? 'kt' : 'java';
-  const filePath = globSync(
+  const filePath = glob.sync(
     path.join(rootPath, `app/src/main/java/**/${name}.${ext}`),
   )[0];
   return filePath;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -20,7 +20,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const glob = require('fast-glob');
 const babel = require('@babel/core');
 const chalk = require('chalk');
 const micromatch = require('micromatch');

--- a/scripts/linkPackages.js
+++ b/scripts/linkPackages.js
@@ -1,7 +1,7 @@
 const execa = require('execa');
 const chalk = require('chalk');
 const path = require('path');
-const glob = require('glob');
+const glob = require('fast-glob');
 
 const projects = glob.sync('packages/*/package.json');
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

`link-assets` package was using `glob` dependency that was not declared. Replaced it with `fast-glob`. Done the same for local scripts too and removed the `glob` entirely.


Test Plan:
----------

Green CI, please test locally

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
