### PR TITLE
fix(cli-tools): declare dependency on `prompts`

### DIFF
--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -14,6 +14,7 @@
     "mime": "^2.4.1",
     "open": "^6.2.0",
     "ora": "^5.4.1",
+    "prompts": "^2.4.2",
     "semver": "^7.5.2",
     "shell-quote": "^1.7.3",
     "sudo-prompt": "^9.0.0"
@@ -23,6 +24,7 @@
     "@types/lodash": "^4.14.149",
     "@types/mime": "^2.0.1",
     "@types/node": "^18.0.0",
+    "@types/prompts": "^2.4.4",
     "@types/shell-quote": "^1.7.1"
   },
   "files": [


### PR DESCRIPTION
Summary:
---------

`prompts` is used in `cli-tools`, but never declared as a dependency, causing commands to fail in pnpm setups:

```
Error: Cannot find module 'prompts'
Require stack:
- /~/node_modules/.store/@react-native-community-cli-tools-npm-14.0.1-fb5b1d1033/package/build/prompt.js
- /~/node_modules/.store/@react-native-community-cli-tools-npm-14.0.1-fb5b1d1033/package/build/index.js
- /~/node_modules/.store/@react-native-community-cli-npm-14.0.1-d30aee3125/package/build/commands/init/errors/InvalidNameError.js
- /~/node_modules/.store/@react-native-community-cli-npm-14.0.1-d30aee3125/package/build/commands/init/validate.js
- /~/node_modules/.store/@react-native-community-cli-npm-14.0.1-d30aee3125/package/build/commands/init/init.js
```

Test Plan:
----------

n/a