### PR TITLE
fix: Remove hardcoded npm registry url 

### DIFF
--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -9,6 +9,7 @@
 import {execSync} from 'child_process';
 import findUp from 'find-up';
 import semver from 'semver';
+import { TEMPLATE_PACKAGE_COMMUNITY } from '../'
 
 export function getNpmVersionIfAvailable() {
   let npmVersion;
@@ -119,8 +120,6 @@ class Template {
   }
 }
 
-const TEMPLATE_VERSIONS_URL =
-  'https://registry.npmjs.org/@react-native-community/template';
 const minorVersion = (version: string) => {
   const v = semver.parse(version)!;
   return `${v.major}.${v.minor}`;
@@ -129,7 +128,7 @@ const minorVersion = (version: string) => {
 export async function getTemplateVersion(
   reactNativeVersion: string,
 ): Promise<TemplateVersion | undefined> {
-  const json = await fetch(TEMPLATE_VERSIONS_URL).then(
+  const json = await fetch(getNpmRegistryUrl() + '@react-native-community/template').then(
     (resp) => resp.json() as Promise<NpmTemplateResponse>,
   );
 

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -9,7 +9,6 @@
 import {execSync} from 'child_process';
 import findUp from 'find-up';
 import semver from 'semver';
-import { TEMPLATE_PACKAGE_COMMUNITY } from '../'
 
 export function getNpmVersionIfAvailable() {
   let npmVersion;

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -127,9 +127,9 @@ const minorVersion = (version: string) => {
 export async function getTemplateVersion(
   reactNativeVersion: string,
 ): Promise<TemplateVersion | undefined> {
-  const json = await fetch(getNpmRegistryUrl() + '@react-native-community/template').then(
-    (resp) => resp.json() as Promise<NpmTemplateResponse>,
-  );
+  const json = await fetch(
+    new URL('@react-native-community/template', getNpmRegistryUrl()),
+  ).then((resp) => resp.json() as Promise<NpmTemplateResponse>);
 
   // We are abusing which npm metadata is publicly available through the registry. Scripts
   // is always captured, and we use this in the Github Action that manages our releases to


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------
fixes: #2519
Official npm registry url is hardcoded, the "cli" can't run successfully in a closed environment.

Following error is displayed when running `npx @react-native-community/cli@latest init AwesomeProject --verbose`.

```
error fetch failed.
TypeError: fetch failed
    at node:internal/deps/undici/undici:13178:13
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async getTemplateVersion (/Users/jilingyun/.npm/_npx/2788f5fbd47acb89/node_modules/@react-native-community/cli/build/tools/npm.js:121:16)
    at async createTemplateUri (/Users/jilingyun/.npm/_npx/2788f5fbd47acb89/node_modules/@react-native-community/cli/build/commands/init/version.js:53:29)
    at async createProject (/Users/jilingyun/.npm/_npx/2788f5fbd47acb89/node_modules/@react-native-community/cli/build/commands/init/init.js:341:23)
    at async Object.initialize [as func] (/Users/jilingyun/.npm/_npx/2788f5fbd47acb89/node_modules/@react-native-community/cli/build/commands/init/init.js:422:7)
    at async Command.handleAction (/Users/jilingyun/.npm/_npx/2788f5fbd47acb89/node_modules/@react-native-community/cli/build/index.js:116:9)
```

My solution is using `getNpmRegistryUrl()` to get real npm registry url in user's local environment, then it can avoid using official npm registry directly.

Test Plan:
----------

Build and run `node /path/to/react-native-cli/packages/cli/build/bin.js init AwesomeProject`

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
