### PR TITLE
fix: read config process output before waiting exit code #2528

### DIFF
--- a/packages/cli-platform-android/native_modules.gradle
+++ b/packages/cli-platform-android/native_modules.gradle
@@ -414,8 +414,8 @@ class ReactNativeModules {
                           .directory(directory)
                           .redirectErrorStream(true)
                           .start()
-          int exitCode = process.waitFor()
           def output = process.inputStream.text.trim()
+          int exitCode = process.waitFor()
           if (exitCode != 0) {
               throw new Exception("Command '${command}' failed with exit code ${exitCode}.")
           }


### PR DESCRIPTION
Summary:
---------

Fixes #2528 

Read config process output before awaiting exit code, thus allowing output larger than the OS pipe buffer to be output.


Test Plan:
----------

Simply make sure output from the config process is read correctly even if output exceeds the buffer size.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
