### PR TITLE
fix: be able to read more complex buildToolsVersion definitions

### DIFF
--- a/packages/cli-doctor/src/tools/healthchecks/__tests__/androidSDK.test.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/__tests__/androidSDK.test.ts
@@ -75,6 +75,29 @@ describe('androidSDK', () => {
     expect(diagnostics.needsToBeFixed).toBe(true);
   });
 
+  it('reads buildToolsVersion when using more complex definition', async () => {
+    // Override mock file
+    writeFiles(mockWorkingDir, {
+      'android/build.gradle': `
+        buildscript {
+          ext {
+            buildToolsVersion = findProperty('android.buildToolsVersion') ?: '34.0.0' 
+            minSdkVersion = 16
+            compileSdkVersion = 28
+            targetSdkVersion = 28
+          }
+        }
+      `,
+    });
+    // @ts-ignore
+    environmentInfo.SDKs['Android SDK'] = {
+      'Build Tools': ['34.0.0'],
+    };
+    (execa as unknown as jest.Mock).mockResolvedValue({stdout: ''});
+    const diagnostics = await androidSDK.getDiagnostics(environmentInfo);
+    expect(diagnostics.needsToBeFixed).toBe(false);
+  });
+
   it('returns false if the SDK version is in range', async () => {
     // To avoid having to provide fake versions for all the Android SDK tools
     // @ts-ignore

--- a/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
@@ -49,9 +49,9 @@ const getBuildToolsVersion = (projectRoot = ''): string => {
       // Get only the portion of the declaration of `buildToolsVersion`
       .substring(buildToolsVersionIndex)
       .split('\n')[0]
-      // Get only the the value of `buildToolsVersion`
-      .match(/\d|\../g) || []
-  ).join('');
+      // Get only the value of `buildToolsVersion`
+      .match(/\d+\.\d+\.\d+/g) || []
+  ).at(0);
 
   return buildToolsVersion || 'Not Found';
 };


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

As highlighted in https://github.com/react-native-community/cli/issues/2221, the way some projects (like expo ones) define the `buildToolsVersion` is breaking `react-native doctor`. 

```gradle
buildscript {
    ext {
        buildToolsVersion = findProperty('android.buildToolsVersion') ?: '34.0.0'
        minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '23')
   ...
```

leads to `buildToolsVersion => .b34.0.0`.

The PR is slightly tweaking the parsing to account for those cases.

Test Plan:
----------

- A new test has been added to demonstrate code is now able to properly read the `buildToolsVersion`
- Existing tests are already covering the basic ` buildToolsVersion = "a version"` syntax

Checklist
----------

- ~~[ ] Documentation is up to date to reflect these changes.~~ NA
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
