### PR TITLE
docs: update table of versions react native to new version 0.76

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Our release cycle is independent of `react-native`. We follow semver and here is
 
 | `@react-native-community/cli`                                      | `react-native`          |
 | ------------------------------------------------------------------ | ----------------------- |
-| [^14.0.0](https://github.com/react-native-community/cli/tree/main) | ^0.75.0                 |
+| [^15.0.0](https://github.com/react-native-community/cli/tree/main) | ^0.76.0                 |
+| [^14.0.0](https://github.com/react-native-community/cli/tree/14.x) | ^0.75.0                 |
 | [^13.0.0](https://github.com/react-native-community/cli/tree/13.x) | ^0.74.0                 |
 | [^12.0.0](https://github.com/react-native-community/cli/tree/12.x) | ^0.73.0                 |
 | [^11.0.0](https://github.com/react-native-community/cli/tree/11.x) | ^0.72.0                 |


### PR DESCRIPTION
### PR: Compatibility and Version Update for React Native Community CLI

This PR updates the documentation and compatibility table to include the latest version of the React Native Community CLI.

#### Main changes:

- **Updated compatibility table** to include the new version `^15.0.0`, compatible with `react-native ^0.76.0`.
- General revisions to the document to maintain consistency and ensure content is up to date.

These changes keep the documentation in line with the latest versions, as well as providing a clear guide for users who are upgrading their projects to newer versions of React Native.