### PR TITLE
fix(init): install Cocoapods with New Architecture enabled by default

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -298,7 +298,7 @@ async function createFromTemplate({
             didInstallPods = installCocoapods;
 
             if (installCocoapods) {
-              await installPods(loader);
+              await installPods(loader, {newArchEnabled: true});
               loader.succeed();
               setEmptyHashForCachedDependencies(projectName);
             }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

New Architecture was enabled by default for React Native 0.76, so inside `init` we should install Cocoapods with New Architecture enabled by default. 


Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Run `node ~/path/to/cli/packages/cli/build/bin.js init`
3. Press `y` when the prompts ask whether to install Cocoapods
4. "Installing CocoaPods dependencies with **New Architecture**" log should be visible

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
