### PR TITLE
fix: ignore commented lines when finding libraryName

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/findLibraryName.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/findLibraryName.test.ts
@@ -49,10 +49,75 @@ const packageJsonWithoutCodegenConfig = `
   }
   `;
 
+const buildGradleWithSingleLineComments = `
+  apply plugin: "com.android.application"
+  apply plugin: "com.facebook.react"
+
+  // react {
+  //   libraryName = "justalibrary"
+  // }
+  `;
+
+const buildGradleWithMultiLineComments = `
+  apply plugin: "com.android.application"
+  apply plugin: "com.facebook.react"
+
+  /*
+  react {
+    libraryName = "justalibrary"
+  }
+  */
+  `;
+
+const buildGradleValidWithComments = `
+  apply plugin: "com.android.application"
+  apply plugin: "com.facebook.react"
+
+  // react {
+  //   libraryName = "justalibrary"
+  // }
+  react {
+    libraryName = "justalibrary2"
+  }
+  `;
+
+const buildGradleKtsWithSingleLineComments = `
+  apply(id = "com.android.application")
+  apply(id = "com.facebook.react")
+
+  // react {
+  //   libraryName.set("justalibrary")
+  // }
+  `;
+
+const buildGradleKtsWithMultiLineComments = `
+  apply(id = "com.android.application")
+  apply(id = "com.facebook.react")
+
+  /*
+  react {
+    libraryName.set("justalibrary")
+  }
+  */
+  `;
+
 describe('android::findLibraryName', () => {
   beforeAll(() => {
     fs.__setMockFilesystem({
-      empty: {},
+      empty: {
+        singlelinecomments: {
+          'build.gradle': buildGradleWithSingleLineComments,
+        },
+        multilinecomments: {
+          'build.gradle': buildGradleWithMultiLineComments,
+        },
+        singllinecommentskts: {
+          'build.gradle.kts': buildGradleKtsWithSingleLineComments,
+        },
+        multilinecommentskts: {
+          'build.gradle.kts': buildGradleKtsWithMultiLineComments,
+        },
+      },
       valid: {
         android: mocks.valid,
         singlequotes: {
@@ -72,6 +137,9 @@ describe('android::findLibraryName', () => {
           android: {
             'build.gradle': buildGradleWithSingleQuotes,
           },
+        },
+        withcomments: {
+          'build.gradle': buildGradleValidWithComments,
         },
       },
     });
@@ -98,6 +166,10 @@ describe('android::findLibraryName', () => {
     ).toBe('my-awesome-library');
   });
 
+  it('returns the library name if declared in the build.gradle file with comments', () => {
+    expect(findLibraryName('/', '/valid/withcomments')).toBe('justalibrary2');
+  });
+
   it('falls back to reading from build.gradle when codegenConfig is not there', () => {
     expect(
       findLibraryName(
@@ -109,5 +181,21 @@ describe('android::findLibraryName', () => {
 
   it('returns null if there is no build.gradle file', () => {
     expect(findLibraryName('/', '/empty')).toBeUndefined();
+  });
+
+  it('returns null if the library name is declared as a single line comment', () => {
+    expect(findLibraryName('/', '/empty/singlelinecomments')).toBeUndefined();
+  });
+
+  it('returns null if the library name is declared as a multi line comment', () => {
+    expect(findLibraryName('/', '/empty/multilinecomments')).toBeUndefined();
+  });
+
+  it('returns null if the library name is declared as a single line comment in build.gradle.kts', () => {
+    expect(findLibraryName('/', '/empty/singllinecommentskts')).toBeUndefined();
+  });
+
+  it('returns null if the library name is declared as a multi line comment in build.gradle.kts', () => {
+    expect(findLibraryName('/', '/empty/multilinecommentskts')).toBeUndefined();
   });
 });

--- a/packages/cli-platform-android/src/config/findLibraryName.ts
+++ b/packages/cli-platform-android/src/config/findLibraryName.ts
@@ -17,10 +17,16 @@ export function findLibraryName(root: string, sourceDir: string) {
   // If not, we check if the library specified it in the build.gradle file.
   let match: RegExpMatchArray | null = null;
   if (fs.existsSync(buildGradlePath)) {
-    const buildGradleContents = fs.readFileSync(buildGradlePath, 'utf-8');
+    const buildGradleContents = fs
+      .readFileSync(buildGradlePath, 'utf-8')
+      .replace(/\/\/.*$/gm, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
     match = buildGradleContents.match(/libraryName = ["'](.+)["']/);
   } else if (fs.existsSync(buildGradleKtsPath)) {
-    const buildGradleContents = fs.readFileSync(buildGradleKtsPath, 'utf-8');
+    const buildGradleContents = fs
+      .readFileSync(buildGradleKtsPath, 'utf-8')
+      .replace(/\/\/.*$/gm, '') // Remove single-line comments
+      .replace(/\/\*[\s\S]*?\*\//g, ''); // Remove multi-line comments
     match = buildGradleContents.match(/libraryName\.set\(["'](.+)["']\)/);
   } else {
     return undefined;


### PR DESCRIPTION
Summary:
---------
This PR modifies the `findLibraryName` function to ignore lines that are commented out when searching for `libraryName`.

The library I maintain previously had `libraryName` commented out to prepare for support of the new architecture.

Now that the new architecture is enabled by default, during testing for the interop layer, this comment caused an issue where, despite being on the old architecture, the [autolinking process treated it as a target for cmake](https://github.com/facebook/react-native/blob/main/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateAutolinkingNewArchitecturesFileTask.kt#L60-L65).
As a result, the Android build fails.

In conclusion, while removing the comment resolves the issue, it was quite challenging to trace back from the CMake and Gradle errors all the way to the CLI config extraction to identify the comment as the cause. This could potentially lead to issues for others, so I'm implementing this fix.


Test Plan:
----------
1. Verified that all existing tests pass successfully to ensure no regressions were introduced.
2. Added new test cases specifically for handling commented lines within the `findLibraryName` function.
   - Checked that `libraryName` is found correctly, ignoring commented lines.
   - Verified that these new test cases pass as expected.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)

---

resolves #2545