### PR TITLE
fix: handle libraries using build.gradle.kts files

### DIFF
--- a/packages/cli-platform-android/src/config/__tests__/findLibraryName.test.ts
+++ b/packages/cli-platform-android/src/config/__tests__/findLibraryName.test.ts
@@ -86,7 +86,7 @@ describe('android::findLibraryName', () => {
   });
 
   it('returns the library name if declared with inside a build.gradle.kts file', () => {
-    expect(findLibraryName('/', '/valid/singlequotes')).toBe('justalibrary');
+    expect(findLibraryName('/', '/valid/gradlekts')).toBe('justalibrary');
   });
 
   it('returns the library name if defined inside codegenConfig', () => {

--- a/packages/cli-platform-android/src/config/findLibraryName.ts
+++ b/packages/cli-platform-android/src/config/findLibraryName.ts
@@ -15,18 +15,16 @@ export function findLibraryName(root: string, sourceDir: string) {
   }
 
   // If not, we check if the library specified it in the build.gradle file.
-  let buildGradleContents = '';
+  let match: RegExpMatchArray | null = null;
   if (fs.existsSync(buildGradlePath)) {
-    buildGradleContents = fs.readFileSync(buildGradlePath, 'utf-8');
+    const buildGradleContents = fs.readFileSync(buildGradlePath, 'utf-8');
+    match = buildGradleContents.match(/libraryName = ["'](.+)["']/);
   } else if (fs.existsSync(buildGradleKtsPath)) {
-    buildGradleContents = fs.readFileSync(buildGradleKtsPath, 'utf-8');
+    const buildGradleContents = fs.readFileSync(buildGradleKtsPath, 'utf-8');
+    match = buildGradleContents.match(/libraryName\.set\(["'](.+)["']\)/);
   } else {
     return undefined;
   }
-
-  const match =
-    buildGradleContents.match(/libraryName = ["'](.+)["']/) ??
-    buildGradleContents.match(/libraryName\.set\(["'](.+)["']\)/);
 
   if (match) {
     return match[1];

--- a/packages/cli-platform-android/src/config/findLibraryName.ts
+++ b/packages/cli-platform-android/src/config/findLibraryName.ts
@@ -24,7 +24,9 @@ export function findLibraryName(root: string, sourceDir: string) {
     return undefined;
   }
 
-  const match = buildGradleContents.match(/libraryName = ["'](.+)["']/);
+  const match =
+    buildGradleContents.match(/libraryName = ["'](.+)["']/) ??
+    buildGradleContents.match(/libraryName\.set\(["'](.+)["']\)/);
 
   if (match) {
     return match[1];


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

While working on the fix for #2542, I discovered that tests intended for build.gradle.kts were actually being run on build.gradle file, so I'm correcting this.


Test Plan:
----------

- Update tests to run correctly on build.gradle.kts files and modify them to pass successfully.


Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
