### PR TITLE
fix(config): fix `loadConfig()` failing with "missing loader for extension"

### DIFF
--- a/packages/cli-config/src/readConfigFromDisk.ts
+++ b/packages/cli-config/src/readConfigFromDisk.ts
@@ -57,7 +57,7 @@ export async function readConfigFromDiskAsync(
 export function readConfigFromDisk(rootFolder: string): UserConfig {
   const explorer = cosmiconfigSync('react-native', {
     stopDir: rootFolder,
-    searchPlaces,
+    searchPlaces: searchPlacesForCJS,
   });
 
   const searchResult = explorer.search(rootFolder);


### PR DESCRIPTION
Summary:
---------

Part 2 of https://github.com/react-native-community/cli/pull/2549 because I had missed a spot, even though I thought I had tested this properly.

Test Plan:
----------

This is enough to trigger the error:

```
node -p 'require("@react-native-community/cli").loadConfig({})'
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
