### PR TITLE
chore: remove deprecated react legacy components from config

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -93,24 +93,10 @@ multiple `Podfile` files in your project.
 
 Array of strings that will be passed to the `npx react-native run-ios` command when running in watch mode.
 
-#### project.ios.unstable_reactLegacyComponentNames
-
-> [!CAUTION]
-> Deprecated in React Native 0.74, where this behavior is detected automatically and this config does nothing. You can safely remove it from your project. 
-
-Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
-hence the `unstable_` prefix.
-
-An array with a list of Legacy Component Name that you want to be registered with the Fabric Interop Layer.
-This will allow you to use libraries that haven't been migrated yet on the New Architecture.
-
-The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
-
-Since React Native 0.74, this property is ignored as the Interop Layer is **Automatic**, you don't need to register the Legacy Components anymore and they will be discovered automatically.
-
 #### project.ios.automaticPodsInstallation
 
 A boolean value to determine if you want to automatically install CocoaPods when running `run-ios` or `build-ios` command when:
+
 - they are not yet installed
 - a new dependency visible for autolinking is installed
 - a version of existing native dependency has changed
@@ -146,21 +132,6 @@ See [`dependency.platforms.android.configuration`](dependencies.md#platformsandr
 #### project.android.watchModeCommandParams
 
 Array of strings that will be passed to the `npx react-native run-android` command when running in watch mode.
-
-#### project.android.unstable_reactLegacyComponentNames
-
-> [!CAUTION]
-> Deprecated in React Native 0.74, where this behavior is detected automatically and this config does nothing. You can safely remove it from your project. 
-
-Please note that this is part of the **Unstable Fabric Interop Layer**, and might be subject to breaking change in the future,
-hence the `unstable_` prefix.
-
-An array with a list of Legacy Component Name that you want to be registered with the Fabric Interop Layer.
-This will allow you to use libraries that haven't been migrated yet on the New Architecture.
-
-The list should contain the name of the components, as they're registered in the ViewManagers (i.e. just `"Button"`).
-
-Since React Native 0.74, this property is ignored as the Interop Layer is **Automatic**, you don't need to register the Legacy Components anymore and they will be discovered automatically.
 
 ### project.android.assets
 

--- a/packages/cli-config-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-config-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -9,7 +9,6 @@ Object {
   "mainActivity": ".MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/flat/android",
-  "unstable_reactLegacyComponentNames": undefined,
   "watchModeCommandParams": undefined,
 }
 `;
@@ -23,7 +22,6 @@ Object {
   "mainActivity": ".MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/multiple/android",
-  "unstable_reactLegacyComponentNames": undefined,
   "watchModeCommandParams": undefined,
 }
 `;
@@ -37,7 +35,6 @@ Object {
   "mainActivity": ".MainActivity",
   "packageName": "com.some.example",
   "sourceDir": "/nested/android",
-  "unstable_reactLegacyComponentNames": undefined,
   "watchModeCommandParams": undefined,
 }
 `;

--- a/packages/cli-config-android/src/config/index.ts
+++ b/packages/cli-config-android/src/config/index.ts
@@ -24,7 +24,7 @@ import {
 import {findLibraryName} from './findLibraryName';
 import {findComponentDescriptors} from './findComponentDescriptors';
 import {findBuildGradle} from './findBuildGradle';
-import {CLIError, logger} from '@react-native-community/cli-tools';
+import {CLIError} from '@react-native-community/cli-tools';
 import getMainActivity from './getMainActivity';
 
 /**
@@ -68,13 +68,6 @@ export function projectConfig(
     : packageName;
   const mainActivity = getMainActivity(manifestPath || '') ?? '';
 
-  // @todo remove for RN 0.75
-  if (userConfig.unstable_reactLegacyComponentNames) {
-    logger.warn(
-      'The "project.android.unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.',
-    );
-  }
-
   return {
     sourceDir,
     appName,
@@ -83,8 +76,6 @@ export function projectConfig(
     mainActivity,
     dependencyConfiguration: userConfig.dependencyConfiguration,
     watchModeCommandParams: userConfig.watchModeCommandParams,
-    // @todo remove for RN 0.75
-    unstable_reactLegacyComponentNames: undefined,
     assets: userConfig.assets ?? [],
   };
 }

--- a/packages/cli-config-apple/src/config/index.ts
+++ b/packages/cli-config-apple/src/config/index.ts
@@ -18,7 +18,7 @@ import {
   IOSProjectConfig,
   IOSDependencyConfig,
 } from '@react-native-community/cli-types';
-import {CLIError, logger} from '@react-native-community/cli-tools';
+import {CLIError} from '@react-native-community/cli-tools';
 import {BuilderCommand} from '../types';
 
 /**
@@ -46,13 +46,6 @@ export const getProjectConfig =
     const sourceDir = path.dirname(podfile);
 
     const xcodeProject = findXcodeProject(fs.readdirSync(sourceDir));
-
-    // @ts-ignore @todo remove for RN 0.75
-    if (userConfig.unstable_reactLegacyComponentNames) {
-      logger.warn(
-        'The "project.ios.unstable_reactLegacyComponentNames" config option is not necessary anymore for React Native 0.74 and does nothing. Please remove it from the "react-native.config.js" file.',
-      );
-    }
 
     return {
       sourceDir,

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -155,11 +155,6 @@ export const projectConfig = t
           .object({
             sourceDir: t.string(),
             watchModeCommandParams: t.array().items(t.string()),
-            // @todo remove for RN 0.75
-            unstable_reactLegacyComponentNames: t
-              .array()
-              .items(t.string())
-              .optional(),
             automaticPodsInstallation: t.bool().default(false),
             assets: t.array().items(t.string()).default([]),
           })
@@ -173,11 +168,6 @@ export const projectConfig = t
             packageName: t.string(),
             dependencyConfiguration: t.string(),
             watchModeCommandParams: t.array().items(t.string()),
-            // @todo remove for RN 0.75
-            unstable_reactLegacyComponentNames: t
-              .array()
-              .items(t.string())
-              .optional(),
             assets: t.array().items(t.string()).default([]),
           })
           .default({}),

--- a/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/__tests__/tryLaunchAppOnDevice.test.ts
@@ -27,7 +27,6 @@ let androidProject: AndroidProjectConfig = {
   mainActivity: '.MainActivity',
   dependencyConfiguration: undefined,
   watchModeCommandParams: undefined,
-  unstable_reactLegacyComponentNames: undefined,
 };
 
 const shellStartCommand = ['shell', 'am', 'start'];

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -6,8 +6,6 @@ export interface AndroidProjectConfig {
   mainActivity: string;
   dependencyConfiguration?: string;
   watchModeCommandParams?: string[];
-  // @todo remove for RN 0.75
-  unstable_reactLegacyComponentNames?: string[] | null;
   assets: string[];
 }
 
@@ -18,8 +16,6 @@ export type AndroidProjectParams = {
   packageName?: string;
   dependencyConfiguration?: string;
   watchModeCommandParams?: string[];
-  // @todo remove for RN 0.75
-  unstable_reactLegacyComponentNames?: string[] | null;
   assets?: string[];
 };
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

It was deprecated in 0.74 and currently automatic mechanism is collecting which components to render with old renderer.  


Test Plan:
----------

CI

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
