### PR TITLE
fix: config with --platform flag to work with platforms defined in multiple packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
     "**/build": true
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "flow.useNPMPackagedFlow": true,
   "javascript.validate.enable": false,

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -167,7 +167,9 @@ export default function loadConfig({
           ...acc.platforms,
           ...(selectedPlatform && config.platforms[selectedPlatform]
             ? {[selectedPlatform]: config.platforms[selectedPlatform]}
-            : config.platforms),
+            : !selectedPlatform
+            ? config.platforms
+            : undefined),
         },
         healthChecks: [...acc.healthChecks, ...config.healthChecks],
       }) as Config;
@@ -267,7 +269,9 @@ export async function loadConfigAsync({
           ...acc.platforms,
           ...(selectedPlatform && config.platforms[selectedPlatform]
             ? {[selectedPlatform]: config.platforms[selectedPlatform]}
-            : config.platforms),
+            : !selectedPlatform
+            ? config.platforms
+            : undefined),
         },
         healthChecks: [...acc.healthChecks, ...config.healthChecks],
       }) as Config;


### PR DESCRIPTION

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Selecting particular platform wouldn't work for out-of-tree platforms, as extra platforms would be added to the `config.platforms` objects anyway. This PR fixes it and adds tests.


Test Plan:
----------

Added ✅ 

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
