### PR TITLE
fix: support linking of BaseReactPackage subclasses

### DIFF
--- a/packages/cli-config-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-config-android/src/config/__fixtures__/android.ts
@@ -204,6 +204,10 @@ export const findPackagesClassNameKotlinValid = [
   class SomeExampleKotlinPackage : TurboReactPackage {
 
   }`,
+  `
+  class SomeExampleKotlinPackage : BaseReactPackage {
+
+  }`,
 ];
 
 export const findPackagesClassNameKotlinNotValid = [
@@ -264,6 +268,13 @@ export const findPackagesClassNameJavaValid = [
   class SomeExampleKotlinPackage
     extends
     TurboReactPackage {
+
+  }
+  `,
+  `
+  class SomeExampleKotlinPackage
+    extends
+    BaseReactPackage {
 
   }
   `,

--- a/packages/cli-config-android/src/config/__tests__/findPackageClassName.test.ts
+++ b/packages/cli-config-android/src/config/__tests__/findPackageClassName.test.ts
@@ -79,6 +79,7 @@ describe('android:FindPackageClassNameRegex', () => {
   ].forEach((files) => {
     it('returns the name of the kotlin/java class implementing ReactPackage', () => {
       files.forEach((file) => {
+        console.log({file});
         expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
       });
     });

--- a/packages/cli-config-android/src/config/__tests__/findPackageClassName.test.ts
+++ b/packages/cli-config-android/src/config/__tests__/findPackageClassName.test.ts
@@ -79,7 +79,6 @@ describe('android:FindPackageClassNameRegex', () => {
   ].forEach((files) => {
     it('returns the name of the kotlin/java class implementing ReactPackage', () => {
       files.forEach((file) => {
-        console.log({file});
         expect(matchClassName(file)[1]).toBe('SomeExampleKotlinPackage');
       });
     });

--- a/packages/cli-config-android/src/config/findPackageClassName.ts
+++ b/packages/cli-config-android/src/config/findPackageClassName.ts
@@ -76,7 +76,7 @@ export function matchClassName(file: string) {
     return nativeModuleMatch;
   } else {
     return file.match(
-      /class\s+(\w+[^(\s]*)[\s\w():]*(\s+extends\s+|:)[\s\w():,]*[^{]*TurboReactPackage/,
+      /class\s+(\w+[^(\s]*)[\s\w():]*(\s+extends\s+|:)[\s\w():,]*[^{]*(Turbo|Base)ReactPackage/,
     );
   }
 }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

`TurboReactPackage`  is [deprecated](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.kt) and the advice is to use `BaseReactPackage`. However, the cli does not recognize `BaseReactPackage` as something that should be autolinked, so following the advice actually breaks apps with:

```
com.facebook.react.common.JavascriptException: Invariant Violation: TurboModuleRegistry.getEnforcing(...): 'RNCDatePicker' could not be found. Verify that a module by this name is registered in the native binary. Bridgeless mode: false. TurboModule interop: false. Modules loaded: {"NativeModules":["HeadlessJsTaskSupport","PlatformConstants","SourceCode","DeviceInfo","UIManager","DeviceEventManager"],"TurboModules":[],"NotFound":["NativePerformanceObserverCxx","NativePerformanceCxx","NativeReactNativeFeatureFlagsCxx","RedBox","BugReporting","RNCDatePicker"]}, js engine: hermes
```

Would be nice to have this picked to older cli versions too.

Test Plan:
----------

You can see test failures in https://github.com/react-native-datetimepicker/datetimepicker/pull/950 prior to applying the patch and after patching, tests are green.

Checklist
----------

- [ ] Documentation is up to date to reflect these changes.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
