### PR TITLE
docs: add `link-assets` cli setup guides

### DIFF
--- a/packages/cli-link-assets/README.md
+++ b/packages/cli-link-assets/README.md
@@ -8,6 +8,21 @@ This package is part of the [React Native CLI](../../README.md). It contains com
 yarn add @react-native-community/cli-link-assets
 ```
 
+## Usage
+
+> [!Warning]
+> Currently, this command isn’t shipped by default because it uses a legacy method of modifying Xcode and Gradle files. An improved [autolinking-based](./../../docs/autolinking.md) solution is in development. Until then, please use it with caution.
+
+To enable the command in the CLI, add the following to your `react-native.config.js`:
+
+```js
+const linkAssets = require('@react-native-community/cli-link-assets');
+
+module.exports = {
+  commands: [linkAssets.commands.linkAssets]
+};
+```
+
 ## Commands
 
 ### `link-assets`


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Currently, the newly published `link-asset` command isn’t shipped by default due to DX concerns ([issue](https://github.com/react-native-community/cli/issues/2568)).

This PR updates the documentation to clarify the limitation and include steps to enable the command.

Test Plan:
----------

No code changes; no tests required.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
