### PR TITLE
fix: adjust log in install Cocoapods prompt

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -292,7 +292,7 @@ async function createFromTemplate({
               type: 'confirm',
               name: 'installCocoapods',
               message: `Do you want to install CocoaPods now? ${chalk.reset.dim(
-                'Only needed if you run your project in Xcode directly',
+                'Needed for running iOS project',
               )}`,
             });
             didInstallPods = installCocoapods;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

It's also required for running with `run-ios` :)
