### PR TITLE
breaking: Remove secondary exports of cli-server-api

### DIFF
--- a/packages/cli-server-api/src/index.ts
+++ b/packages/cli-server-api/src/index.ts
@@ -20,15 +20,6 @@ import createDebuggerProxyEndpoint from './websocket/createDebuggerProxyEndpoint
 import createMessageSocketEndpoint from './websocket/createMessageSocketEndpoint';
 import createEventsSocketEndpoint from './websocket/createEventsSocketEndpoint';
 
-export {devToolsMiddleware};
-export {indexPageMiddleware};
-export {openStackFrameInEditorMiddleware};
-export {openURLMiddleware};
-export {rawBodyMiddleware};
-export {securityHeadersMiddleware};
-export {statusPageMiddleware};
-export {systraceProfileMiddleware};
-
 type MiddlewareOptions = {
   host?: string;
   watchFolders: ReadonlyArray<string>;
@@ -49,6 +40,7 @@ export function createDevServerMiddleware(options: MiddlewareOptions) {
     // @ts-ignore compression and connect types mismatch
     .use(compression())
     .use(nocache())
+    .use('/', indexPageMiddleware)
     .use('/debugger-ui', debuggerUIMiddleware())
     .use(
       '/launch-js-devtools',

--- a/packages/cli-server-api/src/indexPageMiddleware.ts
+++ b/packages/cli-server-api/src/indexPageMiddleware.ts
@@ -13,7 +13,7 @@ export default function indexPageMiddleware(
   res: http.ServerResponse,
   next: (err?: any) => void,
 ) {
-  if (req.url === '/') {
+  if (req.method === 'GET' && req.url === '/') {
     res.setHeader('Content-Type', 'text/html');
     res.end(fs.readFileSync(path.join(__dirname, 'index.html')));
   } else {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

Summary:
---------

Around #2583, I'm taking the opportunity to review the API boundary of the `cli-server-api` package.

- This PR is an opinionated narrowing of the API exported by this package.
- Functionally, `indexPageMiddleware` is moved into the middleware stack returned by `createDevServerMiddleware`.

Test Plan:
----------

✅ Builds
✅ GitHub-wide code search to look for references to these imports outside of `react-native`.

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
