### PR TITLE
fix: run-android device not found on change from deviceId to device

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -178,7 +178,7 @@ async function buildAndRun(args: Flags, androidProject: AndroidProject) {
 
     if (device.connected) {
       return runOnSpecificDevice(
-        {...args, deviceId: device.deviceId},
+        {...args, device: device.deviceId},
         adbPath,
         androidProject,
         selectedTask,
@@ -192,7 +192,7 @@ async function buildAndRun(args: Flags, androidProject: AndroidProject) {
     if (result.success) {
       logger.info('Successfully launched emulator.');
       return runOnSpecificDevice(
-        {...args, deviceId: emulator},
+        {...args, device: emulator},
         adbPath,
         androidProject,
         selectedTask,
@@ -217,7 +217,7 @@ function runOnSpecificDevice(
   selectedTask?: string,
 ) {
   const devices = adb.getDevices(adbPath);
-  const {deviceId} = args;
+  const {device} = args;
 
   // if coming from run-android command and we have selected task
   // from interactive mode we need to create appropriate build task
@@ -226,8 +226,8 @@ function runOnSpecificDevice(
     ? [selectedTask.replace('install', 'assemble')]
     : [];
 
-  if (devices.length > 0 && deviceId) {
-    if (devices.indexOf(deviceId) !== -1) {
+  if (devices.length > 0 && device) {
+    if (devices.indexOf(device) !== -1) {
       let gradleArgs = getTaskNames(
         androidProject.appName,
         args.mode,
@@ -246,7 +246,7 @@ function runOnSpecificDevice(
       }
 
       if (args.activeArchOnly) {
-        const architecture = adb.getCPU(adbPath, deviceId);
+        const architecture = adb.getCPU(adbPath, device);
 
         if (architecture !== null) {
           logger.info(`Detected architecture ${architecture}`);
@@ -263,14 +263,14 @@ function runOnSpecificDevice(
 
       installAndLaunchOnDevice(
         args,
-        deviceId,
+        device,
         adbPath,
         androidProject,
         selectedTask,
       );
     } else {
       logger.error(
-        `Could not find device with the id: "${deviceId}". Please choose one of the following:`,
+        `Could not find device: "${device}". Please choose one of the following:`,
         ...devices,
       );
     }


### PR DESCRIPTION
Summary:
---------

- I have a script that uses `npx react-native run-android --deviceId <deviceId>`
- When upgrading to React Native 75, I started seeing the following deprecation warning ([line link](https://github.com/react-native-community/cli/blob/d0feca0ade86d92270740b5030db23d724e8a7d3/packages/cli-platform-android/src/commands/runAndroid/index.ts#L127-L129)) when using the script mentioned above:
    ```
    warn The `deviceId` parameter is renamed to `device`. Please use the new `device` argument next time to avoid this warning.
    ```
- So I updated my script to use `npx react-native run-android --device <deviceId>`, to remove the deprecation warning. But then, instead of working as expected, I got the following error message ([line link](https://github.com/react-native-community/cli/blob/d0feca0ade86d92270740b5030db23d724e8a7d3/packages/cli-platform-android/src/commands/runAndroid/index.ts#L278)):
    ```
    error No Android device or emulator connected.
    ```
- This issue was introduced in https://github.com/react-native-community/cli/pull/2377
- This PR fixes the error above, so that calling `run-android` with `--device` instead of `--deviceId` works as expected
- Basically this PR converts the remaining references to `deviceId` in [`runAndroid/index.ts`](https://github.com/react-native-community/cli/blob/d0feca0ade86d92270740b5030db23d724e8a7d3/packages/cli-platform-android/src/commands/runAndroid/index.ts) to be `device` instead. Note that references to `device.deviceId` were unchanged to keep this PR as minimal as possible.

Test Plan:
----------

1. Clone the repository and do all the required steps from the [Contributing guide](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md)
2. Observe the current buggy behavior by running the following command
```
node /path/to/react-native-cli/packages/cli/build/bin.js run-android --device "<your_device_id>"
```
3. Apply this patch and rebuild
4. Re-run the command above and observe that the error is not shown, and that Android is built and run as expected
5. Run the command below to verify that this PR didn't cause any regressions to `run-android --list-devices`
```
node /path/to/react-native-cli/packages/cli/build/bin.js run-android --list-devices
```

Checklist
----------

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
