### PR TITLE
chore: Link to test setup in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,15 @@
 <!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->
 
-Summary:
----------
+## Summary
 
 <!-- Help us understand your motivation by explaining why you decided to make this change: -->
 
-
-Test Plan:
-----------
+## Test Plan
 
 <!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
 
-Checklist
-----------
+## Checklist
 
-- [ ] Documentation is up to date to reflect these changes.
-- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
+- [ ] Documentation is up to date.
+- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
+- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Clarify the requirement to test CLI changes with a local `react-native` checkout for new PRs, by pointing to the existing instructions.

- This aims to reduce ambiguity / enable self-serve in more cases, e.g. https://github.com/react-native-community/cli/pull/2491.

## Test Plan

—

## Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention)
