### PR TITLE
Improve and clarify error for missing scheme file

### DIFF
--- a/packages/cli-platform-apple/src/tools/__tests__/getBuildConfigurationFromXcScheme.test.ts
+++ b/packages/cli-platform-apple/src/tools/__tests__/getBuildConfigurationFromXcScheme.test.ts
@@ -77,8 +77,8 @@ describe('getBuildConfigurationFromXcScheme', () => {
       );
     } catch (err) {
       const msg = (err as CLIError).message;
-      expect(msg).toContain(`Could not find scheme ${scheme}`);
-      expect(msg).toContain(`Available schemas are: ${scheme}`);
+      expect(msg).toContain(`Could not load the shared scheme for ${scheme}`);
+      expect(msg).toContain(`includes: ${projectInfo.schemes[0]}`);
     }
   });
 

--- a/packages/cli-platform-apple/src/tools/__tests__/getBuildConfigurationFromXcScheme.test.ts
+++ b/packages/cli-platform-apple/src/tools/__tests__/getBuildConfigurationFromXcScheme.test.ts
@@ -78,7 +78,7 @@ describe('getBuildConfigurationFromXcScheme', () => {
     } catch (err) {
       const msg = (err as CLIError).message;
       expect(msg).toContain(`Could not find scheme ${scheme}`);
-      expect(msg).toContain(`Available schemas are: ${scheme}'`);
+      expect(msg).toContain(`Available schemas are: ${scheme}`);
     }
   });
 

--- a/packages/cli-platform-apple/src/tools/__tests__/getBuildConfigurationFromXcScheme.test.ts
+++ b/packages/cli-platform-apple/src/tools/__tests__/getBuildConfigurationFromXcScheme.test.ts
@@ -1,0 +1,100 @@
+import {getBuildConfigurationFromXcScheme} from '../getBuildConfigurationFromXcScheme';
+import fs from 'fs';
+import path from 'path';
+import {CLIError} from '@react-native-community/cli-tools';
+
+jest.mock('fs', () => ({
+  readFileSync: jest.fn(),
+  readdirSync: jest.fn(),
+}));
+
+describe('getBuildConfigurationFromXcScheme', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns build configuration when the shared scheme file exists', () => {
+    (fs.readdirSync as jest.Mock).mockReturnValue(['Test.xcodeproj']);
+
+    const xmlContent = `<Scheme>
+  <LaunchAction buildConfiguration="Debug"/>
+</Scheme>`;
+    (fs.readFileSync as jest.Mock).mockReturnValue(xmlContent);
+
+    const sourceDir = '/some/dir';
+    const scheme = 'Test';
+    const defaultConfig = 'Release';
+    const projectInfo = {name: 'Test', schemes: [scheme]};
+
+    const result = getBuildConfigurationFromXcScheme(
+      scheme,
+      defaultConfig,
+      sourceDir,
+      projectInfo,
+    );
+
+    expect(result).toBe('Debug');
+
+    const expectedPath = path.join(
+      sourceDir,
+      'Test.xcodeproj',
+      'xcshareddata',
+      'xcschemes',
+      `${scheme}.xcscheme`,
+    );
+    expect(fs.readFileSync).toHaveBeenCalledWith(expectedPath, {
+      encoding: 'utf-8',
+    });
+  });
+
+  it('throws CLIError when reading the shared scheme file fails', () => {
+    process.env.FORCE_COLOR = '0'; // To disable chalk
+    (fs.readdirSync as jest.Mock).mockReturnValue(['Test.xcodeproj']);
+    (fs.readFileSync as jest.Mock).mockImplementation(() => {
+      throw new Error('File not found');
+    });
+
+    const sourceDir = '/some/dir';
+    const scheme = 'Test';
+    const defaultConfig = 'Release';
+    const projectInfo = {name: 'Test', schemes: [scheme]};
+
+    expect(() => {
+      getBuildConfigurationFromXcScheme(
+        scheme,
+        defaultConfig,
+        sourceDir,
+        projectInfo,
+      );
+    }).toThrow(CLIError);
+
+    try {
+      getBuildConfigurationFromXcScheme(
+        scheme,
+        defaultConfig,
+        sourceDir,
+        projectInfo,
+      );
+    } catch (err) {
+      const msg = (err as CLIError).message;
+      expect(msg).toContain(`Could not find scheme ${scheme}`);
+      expect(msg).toContain(`Available schemas are: ${scheme}'`);
+    }
+  });
+
+  it('returns the default configuration when no .xcodeproj folder is found', () => {
+    (fs.readdirSync as jest.Mock).mockReturnValue([]);
+
+    const sourceDir = '/some/dir';
+    const scheme = 'Test';
+    const defaultConfig = 'Release';
+    const result = getBuildConfigurationFromXcScheme(
+      scheme,
+      defaultConfig,
+      sourceDir,
+      undefined,
+    );
+
+    expect(result).toBe(defaultConfig);
+  });
+});

--- a/packages/cli-platform-apple/src/tools/getBuildConfigurationFromXcScheme.ts
+++ b/packages/cli-platform-apple/src/tools/getBuildConfigurationFromXcScheme.ts
@@ -43,7 +43,7 @@ export function getBuildConfigurationFromXcScheme(
       projectInfo && projectInfo.schemes && projectInfo.schemes.length > 0
         ? `Available schemas are: ${projectInfo.schemes
             .map((name) => chalk.bold(name))
-            .join(', ')}'`
+            .join(', ')}`
         : '';
 
     throw new CLIError(

--- a/packages/cli-platform-apple/src/tools/getBuildConfigurationFromXcScheme.ts
+++ b/packages/cli-platform-apple/src/tools/getBuildConfigurationFromXcScheme.ts
@@ -39,15 +39,13 @@ export function getBuildConfigurationFromXcScheme(
       return Scheme.LaunchAction['@_buildConfiguration'];
     }
   } catch {
-    const availableSchemas =
-      projectInfo && projectInfo.schemes && projectInfo.schemes.length > 0
-        ? `Available schemas are: ${projectInfo.schemes
-            .map((name) => chalk.bold(name))
-            .join(', ')}`
-        : '';
+    const projectSchemes =
+      projectInfo?.schemes && projectInfo.schemes.length > 0
+        ? `${projectInfo.schemes.map((name) => chalk.bold(name)).join(', ')}`
+        : 'No schemes';
 
     throw new CLIError(
-      `Could not find scheme ${scheme}. Please make sure the schema you want to run exists. ${availableSchemas}`,
+      `Could not load the shared scheme for ${scheme}. Your project configuration includes: ${projectSchemes}. Please ensure a valid .xcscheme file exists in xcshareddata/xcschemes.`,
     );
   }
 


### PR DESCRIPTION
## Summary

This improves and clarifies the error message printed by React Native CLI when the shared scheme file is missing.

## Problem

I recently attempted to run an app with `yarn ios`, and received an error:

```
error Could not find scheme MyApp. Please make sure the schema you want to run exists. Available schemas are: MyApp'.
```

Subsequently I spent 1h+ digging through the code and local caches etc trying to figure out where that mysterious trailing apostrophe originated from (note, it mentions `MyApp'` is available, but it is looking for `MyApp`). It was nowhere to be found. As it turned out, the issue was with how RN CLI formatted the error.

Additionally, the existing error message makes it sound like the first reference to "MyApp" is directly related to or equivalent to the second reference. That's not the case. The first reference represents the shared scheme **file** it is trying to load, while the second reference is a list of schemes declared in the **project configuration**.

Lastly, the error message (as well as an internal variable in code) contains the term "schema", which should be "scheme". Minor difference, but to be consistent with the Apple/iOS ecosystem only "scheme" should be used.

## Solution

1. Remove misleading `'` (apostrophe) from error message
2. Slightly reword error message to clarify what schemes are declared in project config vs. expected files on file system
3. Replace all usage of "schema" with the proper term "scheme" 

## Test Plan

First, I created a new test file for `getBuildConfigurationFromXcScheme`, ensuring 100% line coverage in the _existing_ file. Then, in two additional commits, I made the changes, ensuring the tests will continue to run. When reviewing the PR commit-by-commit, it will be easiest to see.

### Before

```
error Could not find scheme MyApp. Please make sure the schema you want to run exists. Available schemas are: MyApp'.
```

### After

```
error Could not load the shared scheme for MyApp. Your project configuration includes: MyApp. Please ensure a valid .xcscheme file exists in xcshareddata/xcschemes.
```