### PR TITLE
feat: add `RCT_IGNORE_PODS_DEPRECATION` env variable to `pod install`

### DIFF
--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -34,6 +34,7 @@ async function runPodInstall(loader: Ora, options?: RunPodInstallOptions) {
     await execa('bundle', ['exec', 'pod', 'install'], {
       env: {
         RCT_NEW_ARCH_ENABLED: options?.newArchEnabled ? '1' : '0',
+        RCT_IGNORE_PODS_DEPRECATION: '1', // From React Native 0.79 onwards, users shouldn't install CocoaPods manually.
       },
     });
   } catch (error) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Now it's not recommended to run manually `pod install`, and users should invoke CLI instead, but under the hood in CLI we also execute `pod install` so to skip the warning we need to pass `RCT_IGNORE_PODS_DEPRECATION` env variable

## Test Plan

1. `yarn ios` should install Cocoapods without emitting warning.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
