### PR TITLE
feat: install Cocoapods by default in all projects

### DIFF
--- a/docs/projects.md
+++ b/docs/projects.md
@@ -95,6 +95,8 @@ Array of strings that will be passed to the `npx react-native run-ios` command w
 
 #### project.ios.automaticPodsInstallation
 
+> Default: `true`
+
 A boolean value to determine if you want to automatically install CocoaPods when running `run-ios` or `build-ios` command when:
 
 - they are not yet installed
@@ -103,7 +105,7 @@ A boolean value to determine if you want to automatically install CocoaPods when
 
 If set to `true`, you can skip running `pod install` manually whenever it's needed.
 
-> Note: Starting from React Native 0.73, CLI's `init` command scaffolds the project with `react-native.config.js` file with this value set to `true` by default. Older projects can opt-in after migrating to 0.73. Please note that if your setup does not follow the standard React Native template, e.g. you are not using Gems to install CocoaPods, this might not work properly for you.
+> Note: Starting from React Native 0.73, CLI's `init` command scaffolds the project with `react-native.config.js` file with this value set to `true` by default. Older projects can opt-in after migrating to 0.73. Please note that if your setup does not follow the standard React Native template, e.g. you are not using Gems to install CocoaPods, this might not work properly for you. Starting from React Native 0.79, users shouldn't install CocoaPods manually, but can still opt-out of automatic installation by setting this value to `false`.
 
 ### project.ios.assets
 

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -155,7 +155,7 @@ export const projectConfig = t
           .object({
             sourceDir: t.string(),
             watchModeCommandParams: t.array().items(t.string()),
-            automaticPodsInstallation: t.bool().default(false),
+            automaticPodsInstallation: t.bool().default(true),
             assets: t.array().items(t.string()).default([]),
           })
           .default({}),


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

In https://github.com/react-native-community/cli/pull/2116 we introduced opt-in way to install Cocoapods in `run-ios` commands, this PR changes that to be opt-out.

## Test Plan

With empty `react-native.config.js` Cocoapods should still install.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
