### PR TITLE
feat: Export `createDevServerMiddleware` from `cli`

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,8 @@ import {Command as CommanderCommand} from 'commander';
 import path from 'path';
 import {detachedCommands, projectCommands} from './commands';
 
+export {createDevServerMiddleware} from '@react-native-community/cli-server-api';
+
 const pkgJson = require('../package.json');
 
 const program = new CommanderCommand()


### PR DESCRIPTION
## Summary

`@react-native/community-cli-plugin` depends on `createDevServerMiddleware` from `@react-native-community/cli-server-api`. `@react-native/community-cli-plugin` currently [declares an optional peer dependency](https://github.com/facebook/react-native/blob/bae895500052bda2f55e1832b0c8a63a1b449de3/packages/community-cli-plugin/package.json#L39-L45) on `@react-native-community/cli-server-api`, however because the latter isn't a dependency of `react-native` or the community template, the peer dependency is not available to package managers that enforce isolated node_modules - see https://github.com/facebook/react-native/issues/47309.

Rather than add an unnecessary dependency to the template (https://github.com/react-native-community/template/pull/105), my proposal is to have `@react-native/community-cli-plugin` depend only on `@react-native-community/cli`, switch to a peer dependency on that package, because that *is* a dependency of the community template and therefore will be resolvable.

For that to work, we need to re-export `createDevServerMiddleware` from `@react-native-community/cli`, which already has a dependency on `@react-native-community/cli-server-api`:

https://github.com/react-native-community/cli/blob/45cbbfa96965266ce0c435d08069c783fde25443/packages/cli/package.json#L30

## Test Plan

`yarn build`, verify `createDevServerMiddleware` is exported from `cli/build/index.js`:

```js
Object.defineProperty(exports, "createDevServerMiddleware", {
  enumerable: true,
  get: function () {
    return _cliServerApi().createDevServerMiddleware;
  }
});
```

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
