### PR TITLE
fix: Use 'fallback simulator' for tvOS

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -194,7 +194,9 @@ const createRun =
     }
 
     const fallbackSimulator =
-      platformName === 'ios' || platformName === 'tvos' ? getFallbackSimulator(args) : devices[0];
+      platformName === 'ios' || platformName === 'tvos'
+        ? getFallbackSimulator(args)
+        : devices[0];
 
     if (args.listDevices || args.interactive) {
       if (args.device || args.udid) {

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -194,7 +194,7 @@ const createRun =
     }
 
     const fallbackSimulator =
-      platformName === 'ios' ? getFallbackSimulator(args) : devices[0];
+      platformName === 'ios' || platformName === 'tvos' ? getFallbackSimulator(args) : devices[0];
 
     if (args.listDevices || args.interactive) {
       if (args.device || args.udid) {


### PR DESCRIPTION
## Summary

👋, I am working on adding OOT (Out-of-tree) CLI support to `react-native-tvos`. The update went well, and the OOT will soon have `build-`, `run- `, and `log-` commands for tvos.

**However**, the wrong simulator is selected.

This bug is unique to the tvos platform. When passing the `--simulator` parameter, the **first device** is always chosen, and the simulator parameter is **ignored**.

**tl;dr**
The wrong simulator is selected when the platform is tvos.

## Test Plan
While the fix is straightforward, testing takes a little setup. I created a sample RNTV project for testing and validating this change.

**Pre-requisites**
Xcode is installed, and at least two simulators are installed. The trick to reproducing the issue is to select a simulator that is not first in the device list. 

In this example, I have two simulators installed and one device connected:
(_order from --list-devices_)
- Office (18.3) 
- Apple TV 4K (17.4) 
- Apple TV (17.0) 

I will try to run the app on the **Apple TV (17.0)** simulator.

**Step to reproduce**
1. gh repo clone [cgoldsby/react-native-tvos](https://github.com/cgoldsby/react-native-tvos)
2. cd react-native-tvos
3. git checkout [oot-tvos-rntester](https://github.com/cgoldsby/react-native-tvos/tree/oot-tvos-rntester)
4. git clean -xdf
5. yarn
6. (cd packages/rn-tester ; bundle i ; bundle exec pod install)
7. (cd packages/rn-tester ; npx react-native run-tvos --scheme RNTester --simulator 'Apple TV (17.0)')

```shell
info A dev server is already running for this project on port 8081.
info Found Xcode workspace "RNTesterPods.xcworkspace"
info Launching Office (18.3 (22K557)) // ❌ Wrong simulator is selected. CLI selected first device. Apple TV simulator was expected.
info Building (using "xcodebuild -workspace RNTesterPods.xcworkspace -configuration Debug -scheme RNTester -destination id=2be85da36966f6284f2325c55023e39884a39209")
```
_Expected_
info Launching Apple TV (tvOS 17.0)

_Actual_
info Launching Office (18.3 (22K557))

**Testing the FIX**
We'll continue and test the fix by rerunning `yarn` with the patched file.

8. PATCH=true yarn
9. (cd packages/rn-tester ; npx react-native run-tvos --scheme RNTester --simulator 'Apple TV (17.0)')

```shell
info A dev server is already running for this project on port 8081.
info Found Xcode workspace "RNTesterPods.xcworkspace"
info Launching Apple TV (tvOS 17.0) // ✅ The correct simulator was selected
info Building (using "xcodebuild -workspace RNTesterPods.xcworkspace -configuration Debug -scheme RNTester -destination id=3D7F6892-1820-48B5-84BF-240D821C8986")
```

After the patch,  the correct simulator, **Apple TV (tvOS 17.0)**, was selected.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
