### PR TITLE
fix: remove cocoapods log from `init` command

### DIFF
--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -330,17 +330,6 @@ async function createFromTemplate({
     process.exit(1);
   }
 
-  if (process.platform === 'darwin') {
-    logger.info(
-      `💡 To enable automatic CocoaPods installation when building for iOS you can create react-native.config.js with automaticPodsInstallation field. \n${chalk.reset.dim(
-        `For more details, see ${chalk.underline(
-          'https://github.com/react-native-community/cli/blob/main/docs/projects.md#projectiosautomaticpodsinstallation',
-        )}`,
-      )}
-            `,
-    );
-  }
-
   return {didInstallPods};
 }
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

In #2602 we enabled installing Cocoapods by default, so it doesn't make longer sense to log an information how to enable it in `react-native.config.js`