### PR TITLE
feat: add `--only-pods` option to `run/build-ios` commands

### DIFF
--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -4,7 +4,7 @@ exports[`shows up current config without unnecessary output 1`] = `
 {
   "root": "<<REPLACED_ROOT>>/TestProject",
   "reactNativePath": "<<REPLACED_ROOT>>/TestProject/node_modules/react-native",
-  "reactNativeVersion": "0.77",
+  "reactNativeVersion": "0.78",
   "dependencies": {},
   "commands": [
     {

--- a/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
@@ -12,6 +12,7 @@ export type BuildFlags = {
   destination?: string;
   extraParams?: string[];
   forcePods?: boolean;
+  onlyPods?: boolean;
 };
 
 export const getBuildOptions = ({platformName}: BuilderCommand) => {
@@ -61,6 +62,10 @@ export const getBuildOptions = ({platformName}: BuilderCommand) => {
     {
       name: '--force-pods',
       description: 'Force CocoaPods installation',
+    },
+    {
+      name: '--only-pods',
+      description: 'Only install Cocoapods, do not build the app',
     },
     !isMac && {
       name: '--device [string]', // here we're intentionally using [] over <> to make passed value optional to allow users to run only on physical devices

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -24,7 +24,11 @@ const createBuild =
     }
 
     let installedPods = false;
-    if (platformConfig.automaticPodsInstallation || args.forcePods) {
+    if (
+      platformConfig.automaticPodsInstallation ||
+      args.forcePods ||
+      args.onlyPods
+    ) {
       const isAppRunningNewArchitecture = platformConfig.sourceDir
         ? await getArchitecture(platformConfig.sourceDir)
         : undefined;
@@ -41,6 +45,10 @@ const createBuild =
       );
 
       installedPods = true;
+    }
+
+    if (args.onlyPods) {
+      return;
     }
 
     let {xcodeProject, sourceDir} = getXcodeProjectAndDir(

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -39,7 +39,7 @@ const createBuild =
         ctx.dependencies,
         platformName,
         {
-          forceInstall: args.forcePods,
+          forceInstall: args.forcePods || args.onlyPods,
           newArchEnabled: isAppRunningNewArchitecture,
         },
       );

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -94,7 +94,7 @@ const createRun =
         ctx.dependencies,
         platformName,
         {
-          forceInstall: args.forcePods,
+          forceInstall: args.forcePods || args.onlyPods,
           newArchEnabled: isAppRunningNewArchitecture,
         },
       );

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -79,7 +79,11 @@ const createRun =
     let {packager, port} = args;
     let installedPods = false;
     // check if pods need to be installed
-    if (platformConfig.automaticPodsInstallation || args.forcePods) {
+    if (
+      platformConfig.automaticPodsInstallation ||
+      args.forcePods ||
+      args.onlyPods
+    ) {
       const isAppRunningNewArchitecture = platformConfig.sourceDir
         ? await getArchitecture(platformConfig.sourceDir)
         : undefined;
@@ -96,6 +100,10 @@ const createRun =
       );
 
       installedPods = true;
+    }
+
+    if (args.onlyPods) {
+      return;
     }
 
     if (packager) {

--- a/packages/cli-platform-ios/README.md
+++ b/packages/cli-platform-ios/README.md
@@ -118,6 +118,10 @@ List all available iOS devices and simulators and let you choose one to run the 
 
 Force running `pod install` before running an app
 
+#### `--only-pods`,
+
+Only install Cocoapods, do not build the app.
+
 ### `build-ios`
 
 Usage:
@@ -176,6 +180,10 @@ npx react-native build-ios --extra-params "-jobs 4"
 #### `--force-pods`,
 
 Force running `pod install` before building an app
+
+#### `--only-pods`,
+
+Only install Cocoapods, do not build the app.
 
 ### `log-ios`
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Adds `--only-pods` option

## Test Plan

1. `yarn ios --only-pods` should just install Cocoapods`

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
