### PR TITLE
fix: force server to always start in a new window on macOS

### DIFF
--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -100,7 +100,7 @@ function startServerInNewWindow(
     try {
       return execa.sync(
         'open',
-        ['-a', terminal, launchPackagerScript],
+        ['-na', terminal, launchPackagerScript],
         procConfig,
       );
     } catch (error) {


### PR DESCRIPTION
## Summary

This PR fixes an issue on macOS where the server wasn't reliably being launched in a new terminal window. The solution involves using the `-na` flag combination with the `open` command instead of just `-a`, which ensures that a new instance of the terminal application is always created.

As per the man entry for `open`:

```man

DESCRIPTION
     The open command opens a file (or a directory or URL), just as if you had double-clicked the file's icon. If no application name is specified, the default application as determined
     via LaunchServices is used to open the specified files.

     [...]

     -n  Open a new instance of the application(s) even if one is already running.
```

The issue was identified in a [Ghostty discussion](https://github.com/ghostty-org/ghostty/discussions/4839) which pointed out that some terminals work around the fact that `open -a` does not inherit the current environment it's being run in by explicitly injecting the environment variables, the standard and reliable way to ensure a new window is created and the environment variables are correctly set is to use the `-n` flag explicitly with the macOS `open` command.

This change ensures consistent behavior across all terminal emulators on macOS.

## Test Plan

I've verified this change by:

1. Testing on macOS with multiple terminal emulators (Terminal.app, iTerm2, Ghostty)
2. Ensuring that running the server now consistently opens in a new terminal window
3. Checking that the server starts correctly in all cases

To test this yourself:

- Clone the repo and make this change
- Launch a React Native project using `npx react-native start`
- Verify that a new terminal window opens with the Metro server
- Try multiple times to confirm consistent behavior, especially with different terminal applications already running

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).