### PR TITLE
fix(apple): read `Gemfile` & fallback to globally installed `pod`

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -9,6 +9,7 @@ import {
   CLIError,
   runSudo,
 } from '@react-native-community/cli-tools';
+import runBundleInstall from './runBundleInstall';
 
 interface PodInstallOptions {
   newArchEnabled?: boolean;
@@ -140,6 +141,10 @@ async function installPods(loader?: Ora, options?: PodInstallOptions) {
 
     if (!hasPods) {
       return;
+    }
+
+    if (options?.useBundler) {
+      await runBundleInstall(loader);
     }
 
     try {

--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -15,7 +15,6 @@ import {
 } from '@react-native-community/cli-types';
 import {ApplePlatform} from '../types';
 import runCodegen from './runCodegen';
-import runBundleInstall from './runBundleInstall';
 
 interface ResolvePodsOptions {
   forceInstall?: boolean;
@@ -126,8 +125,6 @@ async function install(
   )}.
   Falling back to installing CocoaPods using globally installed "pod".`,
       );
-    } else {
-      await runBundleInstall(loader);
     }
 
     await installPods(loader, {

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -158,7 +158,9 @@ export const projectConfig = t
             automaticPodsInstallation: t.bool().default(true),
             assets: t.array().items(t.string()).default([]),
           })
-          .default({}),
+          .default({
+            automaticPodsInstallation: true,
+          }),
         android: t
           // AndroidProjectParams
           .object({

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -293,7 +293,9 @@ async function createFromTemplate({
               platform: 'ios',
               reactNativePath,
             });
-            await installPods(loader, {});
+            await installPods(loader, {
+              useBundler: true,
+            });
             loader.succeed();
             setEmptyHashForCachedDependencies(projectName);
           } else if (installPodsValue === 'undefined') {
@@ -312,7 +314,9 @@ async function createFromTemplate({
                 platform: 'ios',
                 reactNativePath,
               });
-              await installPods(loader, {});
+              await installPods(loader, {
+                useBundler: true,
+              });
               loader.succeed();
               setEmptyHashForCachedDependencies(projectName);
             }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary


Some projects have `Gemfile` in the root directory but for other purposes, so checking if it's presented is not enough. 

This Pull Request adds reading and simple regex to check if `gem cocoapods` is included which should make the workflow more solid.

Also this Pull Requests adds a fallback if for any reason CLI decided to install with `bundle exec pod install` we fail silently and fallback to globally installed `pod`.

## Test Plan

1. `yarn add react-native-svg`
2. Remove `Gemfile` and run `run-ios`
3. Cocoapods should be properly installed.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
