### PR TITLE
chore: specify `packageManager` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
     "./packages/**/*.ts": [
       "yarn lint"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

This PR adds `packageManager` field to `package.json`, allowing users of Corepack (and perhaps other tools in the future) who already use a different version of Yarn to easily start contributing to the project.

## Test Plan

1. Enable Corepack by running `corepack enable`
2a. Try installing this repo. Latest version of Yarn is going to be used; 4.7.0 at the moment of writing.
2b. With this change applied, Corepack asks to install the latest Yarn Classic (1.22.22) and when the user agrees, it correctly installs the repository using Yarn Classic.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
