### PR TITLE
chore: fix `buildTs.js` crashing on paths containing spaces

### DIFF
--- a/scripts/buildTs.js
+++ b/scripts/buildTs.js
@@ -21,13 +21,15 @@ const packagesWithTs = packages.filter((p) =>
 );
 
 const args = [
-  path.resolve(
-    require.resolve('typescript/package.json'),
-    '..',
-    require('typescript/package.json').bin.tsc,
-  ),
+  '"' +
+    path.resolve(
+      require.resolve('typescript/package.json'),
+      '..',
+      require('typescript/package.json').bin.tsc,
+    ) +
+    '"',
   '-b',
-  ...packagesWithTs,
+  ...packagesWithTs.map((p) => '"' + p + '"'),
   ...process.argv.slice(2),
 ];
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

This PR fixes a bug in `buildTs.js` that caused the script to crash when ran from a directory full path of which contained space(s). I discovered that when I cloned the repository to "Open source projects" directory.

## Test Plan

1. Clone this repository to any directory full path of which contains space(s).
2. Install the repository.
2a. Without this PR, build will crash on `buildTs.js`.
2b. With this PR, build will succeed.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
