### PR TITLE
fix(macCatalyst): assume a provided UDID is valid

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -272,12 +272,22 @@ const createRun =
     }
 
     if (args.udid) {
-      const device = devices.find((d) => d.udid === args.udid);
+      let device = devices.find((d) => d.udid === args.udid);
       if (!device) {
-        return logger.error(
-          `Could not find a device with udid: "${chalk.bold(
-            args.udid,
-          )}". ${printFoundDevices(devices)}`,
+        // On arm64 machines, the catalyst UDID returned by 'xcrun xctrace list devices' is not correct
+        // xcodebuild will return an error indicating the UDID is unknown and offering a different one
+        // you may obtain it by running xcodebuild with the UDID you think works then parse out the other one from the returned error:
+        // CATALYST_DESTINATION=$(xcodebuild -workspace ios/rnfbdemo.xcworkspace -configuration Debug -scheme rnfbdemo -destination id=7153382A-C92B-5798-BEA3-D82D195F25F8 2>&1|grep macOS|grep Catalyst|head -1 |cut -d':' -f5 |cut -d' ' -f1)
+        //
+        // How to handle the incorrect catalyst UDID?
+        // Assume if a UDID is specified, the user knows what they are doing.
+        // Use the given UDID and force the type, so "catalyst" will launch the app correctly
+        device = {name: 'unknown', udid: args.udid, type: 'catalyst'};
+        logger.warn(
+          `Could not find a device with udid: "${chalk.bold(args.udid)}".`,
+        );
+        logger.warn(
+          'Running with provided udid anyway, and type "catalyst". \'xcodebuild\' command may return error.',
         );
       }
       if (device.type === 'simulator') {


### PR DESCRIPTION
## Summary

This patch works around a problem where macCatalyst UDIDs are not correct when fetched from system, so attempting to find them in list of UDIDs always fails and macCatalyst apps will not start

It basically just assumes - but with an informative warning - that if you specify a UDID you know what you're doing and it will try to use the one you specified instead of simply erroring out.

- Fixes #2313

## Test Plan

I've been carrying this patch around forever. It's the only way I can get my build demonstrator for react-native-firebase to correctly build-test and run macCatalyst version of react-native + react-native-firebase

Should be noted this very same build test is the source of a large number of macCatalyst build fixes over the years, it's been quite helpful in upstreaming things to make macCatalyst work, this is just another one

https://github.com/mikehardy/rnfbdemo/blob/0f16f47dc9823a592673d849d981db1fb8a96bf9/patches/%40react-native-community%2Bcli-platform-apple%2B15.0.1.patch#L1-L24

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
