### PR TITLE
fix: Update link to set-up-your-environment emitted by the CLI

### DIFF
--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -61,7 +61,7 @@ async function runPodInstall(loader: Ora, options: RunPodInstallOptions) {
 
       throw new CLIError(
         `Looks like your iOS environment is not properly set. Please go to ${link.docs(
-          'environment-setup',
+          'set-up-your-environment',
           'ios',
           {guide: 'native'},
         )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,

--- a/packages/cli-config-apple/src/tools/runBundleInstall.ts
+++ b/packages/cli-config-apple/src/tools/runBundleInstall.ts
@@ -12,7 +12,7 @@ async function runBundleInstall(loader: Ora) {
     logger.error((error as any).stderr || (error as any).stdout);
     throw new CLIError(
       `Looks like your iOS environment is not properly set. Please go to ${link.docs(
-        'environment-setup',
+        'set-up-your-environment',
         'ios',
         {guide: 'native'},
       )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,

--- a/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidSDK.ts
@@ -182,7 +182,7 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android SDK',
-      url: link.docs('environment-setup', 'android', {
+      url: link.docs('set-up-your-environment', 'android', {
         hash: 'android-sdk',
         guide: 'native',
       }),

--- a/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/androidStudio.ts
@@ -78,7 +78,7 @@ export default {
 
     return logManualInstallation({
       healthcheck: 'Android Studio',
-      url: link.docs('environment-setup', 'android', {
+      url: link.docs('set-up-your-environment', 'android', {
         hash: 'android-studio',
         guide: 'native',
       }),

--- a/packages/cli-doctor/src/tools/healthchecks/jdk.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/jdk.ts
@@ -61,7 +61,7 @@ export default {
     loader.fail();
     logManualInstallation({
       healthcheck: 'JDK',
-      url: link.docs('environment-setup', 'android', {
+      url: link.docs('set-up-your-environment', 'android', {
         hash: 'jdk-studio',
         guide: 'native',
       }),

--- a/packages/cli-doctor/src/tools/healthchecks/ruby.ts
+++ b/packages/cli-doctor/src/tools/healthchecks/ruby.ts
@@ -174,7 +174,7 @@ export default {
 
     logManualInstallation({
       healthcheck: 'Ruby',
-      url: link.docs('environment-setup', 'ios', {
+      url: link.docs('set-up-your-environment', 'ios', {
         hash: 'ruby',
         guide: 'native',
       }),

--- a/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/runOnAllDevices.ts
@@ -129,7 +129,7 @@ function createInstallError(error: Error & {stderr: string}) {
     )}."`;
   } else if (stderr.includes('requires Java')) {
     message = `Looks like your Android environment is not properly set. Please go to ${chalk.dim.underline(
-      link.docs('environment-setup', 'android', {
+      link.docs('set-up-your-environment', 'android', {
         hash: 'jdk-studio',
         guide: 'native',
       }),

--- a/packages/cli-tools/src/__tests__/doclink.test.ts
+++ b/packages/cli-tools/src/__tests__/doclink.test.ts
@@ -10,20 +10,28 @@ describe('link', () => {
     mockPlatform.mockReturnValueOnce('darwin');
     link.setPlatform('android');
 
-    const url = new URL(link.docs('environment-setup', 'inherit')).toString();
+    const url = new URL(
+      link.docs('set-up-your-environment', 'inherit'),
+    ).toString();
     expect(url).toMatch(/os=macos/);
     expect(url).toMatch(/platform=android/);
     expect(url).toEqual(
-      expect.stringContaining('https://reactnative.dev/docs/environment-setup'),
+      expect.stringContaining(
+        'https://reactnative.dev/docs/set-up-your-environment',
+      ),
     );
 
     // Handles a change of os
     mockPlatform.mockReturnValueOnce('win32');
-    expect(link.docs('environment-setup', 'inherit')).toMatch(/os=windows/);
+    expect(link.docs('set-up-your-environment', 'inherit')).toMatch(
+      /os=windows/,
+    );
 
     // Handles a change of platform
     link.setPlatform('ios');
-    expect(link.docs('environment-setup', 'inherit')).toMatch(/platform=ios/);
+    expect(link.docs('set-up-your-environment', 'inherit')).toMatch(
+      /platform=ios/,
+    );
 
     // Handles cases where we don't need a platform
     expect(link.blog('2019/11/18/react-native-doctor', 'none')).not.toMatch(
@@ -32,7 +40,9 @@ describe('link', () => {
   });
 
   it('preserves anchor-links', () => {
-    expect(link.docs('environment-setup', 'inherit', 'ruby')).toMatch(/#ruby/);
+    expect(link.docs('set-up-your-environment', 'inherit', 'ruby')).toMatch(
+      /#ruby/,
+    );
   });
 
   describe('overrides', () => {
@@ -41,8 +51,8 @@ describe('link', () => {
       [{hash: 'ruby'}, /#ruby/],
       [{hash: 'ruby', os: 'linux'}, /os=linux/],
       [{'extra stuff': 'here?ok'}, /extra\+stuff=here%3Fok/],
-    ])("link.doc('environment-setup, %o) -> %o", (param, re) => {
-      expect(link.docs('environment-setup', 'none', param)).toMatch(re);
+    ])("link.doc('set-up-your-environment, %o) -> %o", (param, re) => {
+      expect(link.docs('set-up-your-environment', 'none', param)).toMatch(re);
     });
   });
 
@@ -59,9 +69,9 @@ describe('link', () => {
     afterAll(() => link.setVersion(null));
     it('supports linking to a specific version of React Native', () => {
       link.setVersion('0.71');
-      expect(link.docs('environment-setup', 'ios', 'ruby')).toEqual(
+      expect(link.docs('set-up-your-environment', 'ios', 'ruby')).toEqual(
         expect.stringContaining(
-          'https://reactnative.dev/docs/0.71/environment-setup',
+          'https://reactnative.dev/docs/0.71/set-up-your-environment',
         ),
       );
     });


### PR DESCRIPTION
## Summary

This fixes some of the link that the CLI is outputting to users.
Specifically instead of pointing users to:

https://reactnative.dev/docs/environment-setup

we should point them to

https://reactnative.dev/docs/set-up-your-environment

## Test Plan

Tests are updated

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
