### PR TITLE
Update installPods.ts

### DIFF
--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -61,7 +61,7 @@ async function runPodInstall(loader: Ora, options: RunPodInstallOptions) {
 
       throw new CLIError(
         `Looks like your iOS environment is not properly set. Please go to ${link.docs(
-          'environment-setup',
+          'set-up-your-environment',
           'ios',
           {guide: 'native'},
         )} and follow the React Native CLI QuickStart guide for macOS and iOS.`,


### PR DESCRIPTION
## Summary

Fix incorrect link (i.e.  https://reactnative.dev/docs/environment-setup?os=macos&platform=ios&guide=native) which leads to "Get Started with React Native" instead of "Set Up Your Environment".

## Test Plan

Verify new link is correct.

## Checklist

- [X] Documentation is up to date.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [X] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
