### PR TITLE
fix(android): hardcoded appName when finding build.gradle

### DIFF
--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -196,7 +196,9 @@ test('should fail if using require() in ES module in react-native.config.mjs', (
     'test-command-esm',
   ]);
   expect(stderr).toMatch('error Failed to load configuration of your project');
-  expect(stdout).toContain('Cannot require() ES Module');
+  expect(stdout).toMatch(
+    'ReferenceError: require is not defined in ES module scope, you can use import instead',
+  );
 });
 
 test('should fail if using require() in ES module with "type": "module" in package.json', () => {

--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -196,9 +196,7 @@ test('should fail if using require() in ES module in react-native.config.mjs', (
     'test-command-esm',
   ]);
   expect(stderr).toMatch('error Failed to load configuration of your project');
-  expect(stdout).toMatch(
-    'ReferenceError: require is not defined in ES module scope, you can use import instead',
-  );
+  expect(stdout).toContain('Cannot require() ES Module');
 });
 
 test('should fail if using require() in ES module with "type": "module" in package.json', () => {

--- a/packages/cli-config-android/src/config/__fixtures__/android.ts
+++ b/packages/cli-config-android/src/config/__fixtures__/android.ts
@@ -71,6 +71,19 @@ function generateValidFileStructureForApp() {
   };
 }
 
+function generateValidFileStructureForAppWithCustomAppName(
+  customAppName: string,
+) {
+  return {
+    'build.gradle': buildGradle,
+    [customAppName]: {
+      'build.gradle': appBuildGradle,
+    },
+    src: {
+      'AndroidManifest.xml': manifest,
+    },
+  };
+}
 export const valid = generateValidFileStructureForLib('ReactPackage.java');
 
 export const validKotlin = generateValidFileStructureForLib('ReactPackage.kt');
@@ -82,6 +95,9 @@ export const validKotlinWithDifferentFileName =
   generateValidFileStructureForLib('React.kt');
 
 export const validApp = generateValidFileStructureForApp();
+
+export const validAppWithCustomAppName =
+  generateValidFileStructureForAppWithCustomAppName('custom');
 
 export const userConfigManifest = {
   src: {

--- a/packages/cli-config-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
+++ b/packages/cli-config-android/src/config/__tests__/__snapshots__/getProjectConfig.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`android::getProjectConfig returns an object with android project configuration for flat structure 1`] = `
 Object {
   "appName": "",
-  "applicationId": "com.some.example",
+  "applicationId": "com.example",
   "assets": Array [],
   "dependencyConfiguration": undefined,
   "mainActivity": ".MainActivity",

--- a/packages/cli-config-android/src/config/__tests__/findBuildGradle.test.ts
+++ b/packages/cli-config-android/src/config/__tests__/findBuildGradle.test.ts
@@ -21,6 +21,9 @@ describe('findBuildGradle for apps', () => {
       flat: {
         android: mocks.validApp,
       },
+      customPath: {
+        android: mocks.validAppWithCustomAppName,
+      },
     });
   });
 
@@ -32,6 +35,12 @@ describe('findBuildGradle for apps', () => {
 
   it('returns `null` if there is no gradle in the app folder', () => {
     expect(findBuildGradle('/empty', 'app')).toBeNull();
+  });
+
+  it('returns the app build.gradle with custom app name', () => {
+    expect(findBuildGradle('/customPath/android', 'custom')).toBe(
+      '/customPath/android/custom/build.gradle',
+    );
   });
 });
 

--- a/packages/cli-config-android/src/config/__tests__/findBuildGradle.test.ts
+++ b/packages/cli-config-android/src/config/__tests__/findBuildGradle.test.ts
@@ -25,13 +25,13 @@ describe('findBuildGradle for apps', () => {
   });
 
   it('returns the app gradle path if file exists in the folder', () => {
-    expect(findBuildGradle('/flat/android', false)).toBe(
+    expect(findBuildGradle('/flat/android', 'app')).toBe(
       '/flat/android/app/build.gradle',
     );
   });
 
   it('returns `null` if there is no gradle in the app folder', () => {
-    expect(findBuildGradle('/empty', false)).toBeNull();
+    expect(findBuildGradle('/empty', 'app')).toBeNull();
   });
 });
 
@@ -46,12 +46,12 @@ describe('findBuildGradle for libraries', () => {
   });
 
   it('returns the app gradle path if file exists in the folder', () => {
-    expect(findBuildGradle('/flat/android', true)).toBe(
+    expect(findBuildGradle('/flat/android', '')).toBe(
       '/flat/android/build.gradle',
     );
   });
 
   it('returns `null` if there is no gradle in the app folder', () => {
-    expect(findBuildGradle('/empty', true)).toBeNull();
+    expect(findBuildGradle('/empty', '')).toBeNull();
   });
 });

--- a/packages/cli-config-android/src/config/findBuildGradle.ts
+++ b/packages/cli-config-android/src/config/findBuildGradle.ts
@@ -1,14 +1,19 @@
 import fs from 'fs';
 import path from 'path';
 
-export function findBuildGradle(sourceDir: string, isLibrary: boolean) {
+/**
+ * Find the build.gradle file for the given app name.
+ * This helper is used to find build.gradle file in both apps and libraries.
+ * For libraries, the appName is empty string.
+ */
+export function findBuildGradle(sourceDir: string, appName: string) {
   const buildGradlePath = path.join(
     sourceDir,
-    isLibrary ? 'build.gradle' : 'app/build.gradle',
+    path.join(appName, 'build.gradle'),
   );
   const buildGradleKtsPath = path.join(
     sourceDir,
-    isLibrary ? 'build.gradle.kts' : 'app/build.gradle.kts',
+    path.join(appName, 'build.gradle.kts'),
   );
 
   if (fs.existsSync(buildGradlePath)) {

--- a/packages/cli-config-android/src/config/index.ts
+++ b/packages/cli-config-android/src/config/index.ts
@@ -48,7 +48,7 @@ export function projectConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(path.join(sourceDir, appName));
-  const buildGradlePath = findBuildGradle(sourceDir, false);
+  const buildGradlePath = findBuildGradle(sourceDir, appName);
 
   if (!manifestPath && !buildGradlePath) {
     return null;
@@ -125,7 +125,7 @@ export function dependencyConfig(
   const manifestPath = userConfig.manifestPath
     ? path.join(sourceDir, userConfig.manifestPath)
     : findManifest(sourceDir);
-  const buildGradlePath = findBuildGradle(sourceDir, true);
+  const buildGradlePath = findBuildGradle(sourceDir, '');
   const isPureCxxDependency =
     userConfig.cxxModuleCMakeListsModuleName != null &&
     userConfig.cxxModuleCMakeListsPath != null &&


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Not all apps have `app` dir and we already have a config for that, which was not used by the `findBuildGradle` helper. 

Closes https://github.com/react-native-community/cli/pull/2524
Closes https://github.com/react-native-community/cli/issues/2516

## Test Plan

Updated tests

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
