### PR TITLE
feat: Support required arguments in CLI commands

### DIFF
--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -157,6 +157,31 @@ export default {
 };
 `;
 
+const USER_CONFIG_COMMAND_ARG_REQUIRED = `;
+module.exports = {
+  commands: [
+    {
+      name: 'test-command-arg-required',
+      description: 'test command',
+      func: () => {
+        console.log('ok');
+      },
+      options: [
+        {
+          name: '--required-arg <string>',
+          description: 'test command arg',
+          required: true,
+        },
+        {
+          name: '--optional-arg <string>',
+          description: 'test command arg',
+        },
+      ],
+    },
+  ],
+};
+`;
+
 test('should read user config from react-native.config.js', () => {
   writeFiles(path.join(DIR, 'TestProject'), {
     'react-native.config.js': USER_CONFIG,
@@ -274,4 +299,28 @@ test('should read config if using import/export in react-native.config.mjs with 
 
   const {stdout} = runCLI(path.join(DIR, 'TestProject'), ['test-command-esm']);
   expect(stdout).toMatch('test-command-esm');
+});
+
+test('should fail if a required arg is missing, pass if optional missing', () => {
+  writeFiles(path.join(DIR, 'TestProject'), {
+    'react-native.config.cjs': USER_CONFIG_COMMAND_ARG_REQUIRED,
+  });
+
+  const {stderr} = runCLI(
+    path.join(DIR, 'TestProject'),
+    ['test-command-arg-required', '--optional-arg', 'foo'],
+    {
+      expectedFailure: true,
+    },
+  );
+  expect(stderr).toMatch(
+    "required option '--required-arg <string>' not specified",
+  );
+
+  const {stdout} = runCLI(path.join(DIR, 'TestProject'), [
+    'test-command-arg-required',
+    '--required-arg',
+    'bar',
+  ]);
+  expect(stdout).toMatch('ok');
 });

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -47,6 +47,7 @@ type Command = {
       | boolean
       | number
       | ((config: ConfigT) => string | boolean | number);
+    required?: boolean;
   }>;
   examples?: Array<{
     desc: string;
@@ -101,6 +102,10 @@ Parsing function that can be used to transform a raw (string) option as passed b
 Default value for the option when not provided. Can be either a primitive value or a function, that receives a configuration and returns a primitive.
 
 Useful when you want to use project settings as default value for your option.
+
+##### `options.required`
+
+If true and no default is specified, fail with a friendly error if the user doesn't supply this option.
 
 #### `examples`
 

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -27,6 +27,7 @@ const command = t.object({
         default: t
           .alternatives()
           .try(t.bool(), t.number(), t.string().allow(''), t.func()),
+        required: t.bool(),
       })
       .rename('command', 'name', {ignoreUndefined: true}),
   ),

--- a/packages/cli-types/src/index.ts
+++ b/packages/cli-types/src/index.ts
@@ -27,6 +27,7 @@ export type CommandOption<T = (ctx: Config) => OptionValue> = {
   description?: string;
   parse?: (val: string) => any;
   default?: OptionValue | T;
+  required?: boolean;
 };
 
 export type DetachedCommandFunction<Args = Object> = (

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -127,7 +127,7 @@ function attachCommand<C extends Command<boolean>>(
   cmd.addHelpText('after', printExamples(command.examples));
 
   for (const opt of command.options || []) {
-    cmd.option(
+    cmd[opt.required ? 'requiredOption' : 'option'](
       opt.name,
       opt.description ?? '',
       opt.parse || ((val: any) => val),


### PR DESCRIPTION
## Summary

While doing some work on `react-native bundle` I noticed some arguments we require are actually not `requiredOption`s in Commander, and I was surprised that there was no way to mark an option required in config.

This adds the `required` field to `CommandOption` and passes it through so that we can more easily validate and emit user-actionable errors.

## Test Plan

Made these changes locally (with `link`) against RN 0.80-rc.0, and tested by adding `required` to the `bundle` command:

#### Before
 - Fails with obscure error on `path.dirname(undefined)`
```
yarn run react-native bundle --entry-file index.js --verbose --platform ios --dev
yarn run v1.22.22
$ /Users/robhogan/workspace/ReactNative080rc0/node_modules/.bin/react-native bundle --entry-file index.js --verbose --platform ios --dev
                Welcome to Metro v0.82.3
              Fast - Scalable - Integrated


error The "path" argument must be of type string. Received undefined.
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
    at Object.dirname (node:path:1371:5)
    at buildBundleWithConfig (/Users/robhogan/workspace/ReactNative080rc0/node_modules/@react-native/community-cli-plugin/dist/commands/bundle/buildBundle.js:73:44)
    at async Command.handleAction (/Users/robhogan/workspace/ReactNative080rc0/node_modules/@react-native-community/cli/build/index.js:139:9)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### After
 - Fails fast with actionable error
```
yarn run react-native bundle --entry-file index.js --verbose --platform ios --dev
yarn run v1.22.22
$ /Users/robhogan/workspace/ReactNative080rc0/node_modules/.bin/react-native bundle --entry-file index.js --verbose --platform ios --dev
error: required option '--bundle-output <string>' not specified
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).

NOTE: e2e tests are hanging for me so I wasn't able to validate the new tests
