### PR TITLE
test: Replace variable RN version in snapshot tests

### DIFF
--- a/__e2e__/__snapshots__/config.test.ts.snap
+++ b/__e2e__/__snapshots__/config.test.ts.snap
@@ -4,7 +4,7 @@ exports[`shows up current config without unnecessary output 1`] = `
 {
   "root": "<<REPLACED_ROOT>>/TestProject",
   "reactNativePath": "<<REPLACED_ROOT>>/TestProject/node_modules/react-native",
-  "reactNativeVersion": "0.78",
+  "reactNativeVersion": "<<REPLACED>>",
   "dependencies": {},
   "commands": [
     {

--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -70,7 +70,7 @@ test('shows up current config without unnecessary output', () => {
     options: command.options && ['<<REPLACED>>'],
   }));
 
-  expect(parsedStdout.reactNativeVersion).toMatch(/^\d+\.\d+\.\d+$/);
+  expect(parsedStdout.reactNativeVersion).toMatch(/^\d+\.\d+(\.\d+)?$/);
   parsedStdout.reactNativeVersion = '<<REPLACED>>';
 
   const expectedXcodeProject =

--- a/__e2e__/config.test.ts
+++ b/__e2e__/config.test.ts
@@ -70,6 +70,9 @@ test('shows up current config without unnecessary output', () => {
     options: command.options && ['<<REPLACED>>'],
   }));
 
+  expect(parsedStdout.reactNativeVersion).toMatch(/^\d+\.\d+\.\d+$/);
+  parsedStdout.reactNativeVersion = '<<REPLACED>>';
+
   const expectedXcodeProject =
     process.platform === 'darwin'
       ? {


### PR DESCRIPTION
## Summary

Config E2E tests run `init` with an unspecified version in `beforeEach`, so that they run against latest stable. But the "shows up current config" snapshot test includes the version number, so snapshot tests fail whenever a new RN version is published.

This uses the existing convention of normalising variable output to `<<REPLACED>>`, just validating that the version is a semver-stable string.

## Test Plan

CI - snapshot test passes (🤞)

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
