### PR TITLE
fix: container xcodeproj location resolution

### DIFF
--- a/packages/cli-platform-apple/src/tools/__tests__/getInfo.test.ts
+++ b/packages/cli-platform-apple/src/tools/__tests__/getInfo.test.ts
@@ -16,7 +16,7 @@ describe('getInfo', () => {
   it('handles non-project / workspace locations in a ', () => {
     const name = `YourProjectName`;
     (fs.readFileSync as jest.Mock)
-    .mockReturnValueOnce(`<?xml version="1.0" encoding="UTF-8"?>
+      .mockReturnValueOnce(`<?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
    <FileRef
@@ -44,7 +44,7 @@ describe('getInfo', () => {
   it('handles xcodeproj location in container in a ', () => {
     const name = `YourProjectName`;
     (fs.readFileSync as jest.Mock)
-    .mockReturnValueOnce(`<?xml version="1.0" encoding="UTF-8"?>
+      .mockReturnValueOnce(`<?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
    <FileRef

--- a/packages/cli-platform-apple/src/tools/getInfo.ts
+++ b/packages/cli-platform-apple/src/tools/getInfo.ts
@@ -5,12 +5,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import type {IosInfo} from '../types';
 
-function isErrorLike(err: unknown): err is { message: string } {
+function isErrorLike(err: unknown): err is {message: string} {
   return Boolean(
     err &&
-    typeof err === 'object' &&
-    'message' in err &&
-    typeof err.message === 'string',
+      typeof err === 'object' &&
+      'message' in err &&
+      typeof err.message === 'string',
   );
 }
 


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Since the xcodeproj location in xcworkspacedata can be under the container: prefix, this needs to be accounted for when resolving its path. This PR fixes the issue in a similar way to how the group: prefix is handled.

## Test Plan

This PR includes a unit test to verify that an xcworkspacedata file is processed correctly. I also tested building a real project using the updated CLI changes.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
