### PR TITLE
use pod installed by bundler if possible

### DIFF
--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -10,6 +10,7 @@ import {
   runSudo,
 } from '@react-native-community/cli-tools';
 import runBundleInstall from './runBundleInstall';
+import {execaPod} from './pods';
 
 interface PodInstallOptions {
   skipBundleInstall?: boolean;
@@ -31,7 +32,7 @@ async function runPodInstall(loader: Ora, options: RunPodInstallOptions) {
       )} ${chalk.dim('(this may take a few minutes)')}`,
     );
 
-    await execa('bundle', ['exec', 'pod', 'install'], {
+    await execaPod(['install'], {
       env: {
         RCT_NEW_ARCH_ENABLED: options?.newArchEnabled ? '1' : '0',
         RCT_IGNORE_PODS_DEPRECATION: '1', // From React Native 0.79 onwards, users shouldn't install CocoaPods manually.
@@ -77,7 +78,7 @@ async function runPodUpdate(loader: Ora) {
         '(this may take a few minutes)',
       )}`,
     );
-    await execa('pod', ['repo', 'update']);
+    await execaPod(['repo', 'update']);
   } catch (error) {
     // "pod" command outputs errors to stdout (at least some of them)
     logger.log((error as any).stderr || (error as any).stdout);
@@ -151,7 +152,7 @@ async function installPods(loader?: Ora, options?: PodInstallOptions) {
       // Check if "pod" is available and usable. It happens that there are
       // multiple versions of "pod" command and even though it's there, it exits
       // with a failure
-      await execa('pod', ['--version']);
+      await execaPod(['--version']);
     } catch (e) {
       loader.info();
       await installCocoaPods(loader);

--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -14,6 +14,7 @@ import {
 } from '@react-native-community/cli-types';
 import {ApplePlatform} from '../types';
 import runCodegen from './runCodegen';
+import execa from 'execa';
 
 interface ResolvePodsOptions {
   forceInstall?: boolean;
@@ -214,4 +215,24 @@ export default async function resolvePods(
       );
     }
   }
+}
+
+export async function execaPod(args: string[], options?: execa.Options) {
+  let podType: 'system' | 'bundle' = 'system';
+  try {
+    await execa('bundle', ['exec', 'pod', '--version'], options);
+    podType = 'bundle';
+  } catch (bundledPodError) {
+    try {
+      await execa('pod', ['--version'], options);
+      podType = 'system';
+    } catch (systemPodError) {
+      throw new Error('cocoapods not installed');
+    }
+  }
+
+  if (podType === 'bundle') {
+    return execa('bundle', ['exec', 'pod', ...args], options);
+  }
+  return execa('pod', args, options);
 }


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

see https://github.com/react-native-community/cli/issues/2668 and https://github.com/react-native-community/cli/issues/2663 (should fix both).

This change ensures that local installed cocoapods (`bundle exec pod`) is used before system installed `pod`. 

## Test Plan

### A: Bundled Version:

1. make sure no cocoapods is not installed globally: `gem uninstall cocoapods`
2. `npx @react-native-community/cli@latest init MyApp`
3. press `n` for cocoa pods question
4. `cd MyApp`
5. `bundle install`

Now `bundle exec pod --version` has an 0 exit code.

`npx react-native run-ios --force-pods` will not fail nor install cocoapods globally (`pod` will have exit code > 0)

### B: Global Version (someone could argue this should never be supported anyway):

1. make sure cocoapods is installed globally: `gem install cocoapods`
2. `npx @react-native-community/cli@latest init MyApp`
3. press `n` for cocoa pods question
4. `cd MyApp`
5. remove `cocoapods` from `Gemfile`
6. `bundle install`

Now `bundle exec pod --version` has an non 0 exit code.

`npx react-native run-ios --force-pods` will not fail and install cocoapods globally (`pod` will have non 0 exit code)

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
