### PR TITLE
fix: autolinking.json breaks whenever console.log is added to react-native.config.js

### DIFF
--- a/packages/cli-config/src/readConfigFromDisk.ts
+++ b/packages/cli-config/src/readConfigFromDisk.ts
@@ -22,6 +22,35 @@ const searchPlacesForCJS = [
 ];
 const searchPlaces = [...searchPlacesForCJS, 'react-native.config.mjs'];
 
+/**
+ * Suppress console output temporarily to prevent config file logs from appearing
+ */
+function suppressConsole() {
+  const originalMethods = {
+    log: console.log,
+    warn: console.warn,
+    error: console.error,
+    info: console.info,
+    debug: console.debug,
+  };
+
+  // Override console methods with empty functions
+  console.log = () => {};
+  console.warn = () => {};
+  console.error = () => {};
+  console.info = () => {};
+  console.debug = () => {};
+
+  return () => {
+    // Restore original console methods
+    console.log = originalMethods.log;
+    console.warn = originalMethods.warn;
+    console.error = originalMethods.error;
+    console.info = originalMethods.info;
+    console.debug = originalMethods.debug;
+  };
+}
+
 function parseUserConfig(searchResult: CosmiconfigResult): UserConfig {
   const config = searchResult ? searchResult.config : undefined;
   const result = schema.projectConfig.validate(config);
@@ -45,8 +74,14 @@ export async function readConfigFromDiskAsync(
     searchPlaces,
   });
 
-  const searchResult = await explorer.search(rootFolder);
-  return parseUserConfig(searchResult);
+  // Suppress console output during config loading
+  const restoreConsole = suppressConsole();
+  try {
+    const searchResult = await explorer.search(rootFolder);
+    return parseUserConfig(searchResult);
+  } finally {
+    restoreConsole();
+  }
 }
 
 /**
@@ -60,8 +95,14 @@ export function readConfigFromDisk(rootFolder: string): UserConfig {
     searchPlaces: searchPlacesForCJS,
   });
 
-  const searchResult = explorer.search(rootFolder);
-  return parseUserConfig(searchResult);
+  // Suppress console output during config loading
+  const restoreConsole = suppressConsole();
+  try {
+    const searchResult = explorer.search(rootFolder);
+    return parseUserConfig(searchResult);
+  } finally {
+    restoreConsole();
+  }
 }
 
 function parseDependencyConfig(
@@ -102,8 +143,14 @@ export async function readDependencyConfigFromDiskAsync(
     searchPlaces,
   });
 
-  const searchResult = await explorer.search(rootFolder);
-  return parseDependencyConfig(dependencyName, searchResult);
+  // Suppress console output during config loading
+  const restoreConsole = suppressConsole();
+  try {
+    const searchResult = await explorer.search(rootFolder);
+    return parseDependencyConfig(dependencyName, searchResult);
+  } finally {
+    restoreConsole();
+  }
 }
 
 /**
@@ -120,8 +167,14 @@ export function readDependencyConfigFromDisk(
     searchPlaces: searchPlacesForCJS,
   });
 
-  const searchResult = explorer.search(rootFolder);
-  return parseDependencyConfig(dependencyName, searchResult);
+  // Suppress console output during config loading
+  const restoreConsole = suppressConsole();
+  try {
+    const searchResult = explorer.search(rootFolder);
+    return parseDependencyConfig(dependencyName, searchResult);
+  } finally {
+    restoreConsole();
+  }
 }
 
 const emptyDependencyConfig = {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Fixes https://github.com/react-native-community/cli/issues/2678. Please refer https://github.com/react-native-community/cli/issues/2678 for detailed issue of the bug
<!-- Help us understand your motivation by explaining why you decided to make this change: -->

## Test Plan

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

Can be tested by adding console.log to `react-native.config.js` and then running npx @react-native-community/cli config

## Checklist

- [] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
