### PR TITLE
fix: output codegen'd code in the ios folder

### DIFF
--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -100,6 +100,7 @@ async function install(
       root,
       platform,
       reactNativePath,
+      iosFolderPath,
     });
     await installPods(loader, {
       skipBundleInstall: !!cachedDependenciesHash,

--- a/packages/cli-config-apple/src/tools/runCodegen.ts
+++ b/packages/cli-config-apple/src/tools/runCodegen.ts
@@ -6,6 +6,7 @@ interface CodegenOptions {
   root: string;
   platform: string;
   reactNativePath: string;
+  iosFolderPath: string;
 }
 
 async function runCodegen(options: CodegenOptions): Promise<void> {
@@ -24,7 +25,7 @@ async function runCodegen(options: CodegenOptions): Promise<void> {
     '-p',
     options.root,
     '-o',
-    process.cwd(),
+    options.iosFolderPath,
     '-t',
     options.platform,
   ]);

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -292,6 +292,7 @@ async function createFromTemplate({
               root: projectDirectory,
               platform: 'ios',
               reactNativePath,
+              iosFolderPath: path.join(projectDirectory, 'ios'),
             });
             await installPods(loader, {});
             loader.succeed();
@@ -311,6 +312,7 @@ async function createFromTemplate({
                 root: projectDirectory,
                 platform: 'ios',
                 reactNativePath,
+                iosFolderPath: path.join(projectDirectory, 'ios'),
               });
               await installPods(loader, {});
               loader.succeed();


### PR DESCRIPTION
## Summary

While testing RN 0.81.0-rc.2, we discovered that the CI was not outputting the code generated by codegen in the right folder.
Further exploration revealed that the problem has been there since 0.79!

This PR addresses the problem.

## Test Plan
Tested by manually modifying the CLI code in a new project created from 0.81

## Checklist

- [X] Documentation is up to date.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [X] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
