### PR TITLE
chore: support RCT_USE_RN_DEP and RCT_USE_PREBUILT_RNCORE flags

### DIFF
--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -35,6 +35,15 @@ async function runPodInstall(loader: Ora, options: RunPodInstallOptions) {
       env: {
         RCT_NEW_ARCH_ENABLED: options?.newArchEnabled ? '1' : '0',
         RCT_IGNORE_PODS_DEPRECATION: '1', // From React Native 0.79 onwards, users shouldn't install CocoaPods manually.
+        ...(process.env.USE_THIRD_PARTY_JSC && {
+          USE_THIRD_PARTY_JSC: process.env.USE_THIRD_PARTY_JSC,
+        }), // This is used to install the third party JSC.
+        ...(process.env.RCT_USE_RN_DEP && {
+          RCT_USE_RN_DEP: process.env.RCT_USE_RN_DEP,
+        }), // prebuilt RN dep available from 0.80 onwards
+        ...(process.env.RCT_USE_PREBUILT_RNCORE && {
+          RCT_USE_PREBUILT_RNCORE: process.env.RCT_USE_PREBUILT_RNCORE,
+        }), // whole RN core prebuilt from 0.81 onwards
       },
     });
   } catch (error) {


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Since running `pod install` is deprecated in favor of running `npm run ios` command, I'm adding a way to support RN prebuilds available in 0.80 and 0.81:

## Test Plan

Example usage:
```
RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1 npm run ios
```
## Checklist

- [ ] Documentation is up to date.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
