### PR TITLE
fix: yarn init test case failed (E2E Tests)

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -13,7 +13,7 @@ npx react-native-community/cli@latest init ProjectName
 ## Installing `react-native` and invoking `init` command
 
 ```sh
-yarn init && yarn add react-native && yarn react-native init ProjectName
+yarn init && yarn add react-native-community/cli@latest && yarn react-native-community/cli@latest init ProjectName
 ```
 
 ## Initializing project with custom version of `react-native`


### PR DESCRIPTION
Used "react-native-community/cli@latest init" instead of "react-native init". 

** Try checking for the merge, initializing app through yarn errors.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Help us understand your motivation by explaining why you decided to make this change: -->

## Test Plan

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

## Checklist

- [ ] Documentation is up to date.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
