### PR TITLE
Fix plistPath when using a prebuilt binary (appPath)

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/installApp.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/installApp.ts
@@ -63,7 +63,8 @@ export default async function installApp({
   const targetBuildDir = buildSettings.TARGET_BUILD_DIR;
   const infoPlistPath = buildSettings.INFOPLIST_PATH;
 
-  if (!infoPlistPath) {
+  const plistPath = appPath ? _path().default.join(appPath, "Info.plist") : _path().default.join(targetBuildDir, infoPlistPath)
+  if (!plistPath) {
     throw new CLIError('Failed to find Info.plist');
   }
 
@@ -89,7 +90,7 @@ export default async function installApp({
       [
         '-c',
         'Print:CFBundleIdentifier',
-        path.join(targetBuildDir, infoPlistPath),
+        plistPath,
       ],
       {encoding: 'utf8'},
     )


### PR DESCRIPTION
## Summary

Fix plist path in `installApp` when running with a prebuilt binary (when `appPath` is set) located at a custom path.

As discussed with @thymikee here:
https://github.com/react-native-community/cli/issues/2517#issuecomment-3056728304

## Test Plan

Unfortunately, there are no tests for the `--binary-path` option (which is probably also why this feature broke at some point), but I see it as out of scope for this PR to correct that, so testing will have to be done manually by running

```
npx react-native run-ios --binary-path ./myBinary.app --scheme '<SCHEME_USED_TO_BUILD_APP>'
```
With a prebuilt binary and validate that it actually installs and launches the app.

## Checklist

- [x] Documentation is up to date.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
