### PR TITLE
Fix destination in `buildproject

### DIFF
--- a/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/buildOptions.ts
@@ -13,6 +13,7 @@ export type BuildFlags = {
   extraParams?: string[];
   forcePods?: boolean;
   onlyPods?: boolean;
+  device?: string | true;
 };
 
 export const getBuildOptions = ({platformName}: BuilderCommand) => {

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -39,7 +39,6 @@ import openApp from './openApp';
 
 export interface FlagsT extends BuildFlags {
   simulator?: string;
-  device?: string | true;
   udid?: string;
   binaryPath?: string;
   listDevices?: boolean;


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Fix destination in `buildProject` when running with device arg but no specific UDID or `args.destination`. Also move `device` property from the run command's `FlagsT` to the build command's `BuildFlags` because that is where it was actually described.

See more discussion with @thymikee here:
https://github.com/react-native-community/cli/issues/2517#issuecomment-3056728304

## Test Plan

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
