### PR TITLE
Fix: Remove hardcoded index when selecting the correct build target

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
@@ -36,14 +36,21 @@ export async function getBuildSettings(
 
   const settings = JSON.parse(buildSettings);
 
-  const targets = settings.map(
-    ({target: settingsTarget}: any) => settingsTarget,
-  );
+  // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
+  const applicationTargets = settings
+    .filter(
+      (setting: any) =>
+        setting.buildSettings.WRAPPER_EXTENSION ===
+        'app',
+    )
+    .map(({target: settingsTarget}: any) => settingsTarget);
 
-  let selectedTarget = targets[0];
-
+  if (applicationTargets.length === 0) return null
+  
+  let selectedTarget = applicationTargets[0];
+  
   if (target) {
-    if (!targets.includes(target)) {
+    if (!applicationTargets.includes(target)) {
       logger.info(
         `Target ${chalk.bold(target)} not found for scheme ${chalk.bold(
           scheme,
@@ -53,18 +60,9 @@ export async function getBuildSettings(
       selectedTarget = target;
     }
   }
-
-  // Find app in all building settings - look for WRAPPER_EXTENSION: 'app',
-  const targetIndex = targets.indexOf(selectedTarget);
-  const targetSettings = settings[targetIndex].buildSettings;
-
-  const wrapperExtension = targetSettings.WRAPPER_EXTENSION;
-
-  if (wrapperExtension === 'app') {
-    return settings[targetIndex].buildSettings;
-  }
-
-  return null;
+  
+  const targetIndex = applicationTargets.indexOf(selectedTarget);
+  return settings[targetIndex].buildSettings;
 }
 
 function getPlatformName(buildOutput: string) {


### PR DESCRIPTION
## Summary

In our app we have some old static lib targets that need to be built before the actual application target. This means that our app target is not the first one in the targets list in the Xcode scheme which in turn means `let selectedTarget = targets[0]` is not sophisticated enough to find the actual app target. 

This PR fixes this by only looking at targets with `WRAPPER_EXTENSION === 'app'` which was also partially done before but just at a later stage.

## Test Plan

You can test this in a vanilla RN project by adding e.g. a "Static" library target:
<img width="1247" height="871" alt="Screenshot 2025-08-27 at 12 27 16" src="https://github.com/user-attachments/assets/398feffb-7798-4302-ac2c-f523d581c3b9" />

And then make it the first build target in the default Xcode scheme:
<img width="937" height="513" alt="Screenshot 2025-08-27 at 12 26 37" src="https://github.com/user-attachments/assets/9652f34f-a2cd-4a60-ba21-e534dbe66a2e" />

And then running 
```
npx react-native run-ios
```

Before this PR, this would fail because the application target is now put in `targets[1]`.

If you have multiple application targets you can test out the `--target` parameter like this:
```
npx react-native run-ios --target "<YOUR_APP_TARGET>"
```

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
