### PR TITLE
chore: simplify glob patterns

### DIFF
--- a/packages/cli-config-android/src/config/findComponentDescriptors.ts
+++ b/packages/cli-config-android/src/config/findComponentDescriptors.ts
@@ -16,8 +16,8 @@ export function findComponentDescriptors(packageRoot: string) {
     // no jsSrcsDir, continue with default glob pattern
   }
   const globPattern = jsSrcsDir
-    ? `${jsSrcsDir}/**/+(*.js|*.jsx|*.ts|*.tsx)`
-    : '**/+(*.js|*.jsx|*.ts|*.tsx)';
+    ? `${jsSrcsDir}/**/*{.js,.jsx,.ts,.tsx}`
+    : '**/*{.js,.jsx,.ts,.tsx}';
   const files = glob.sync(globPattern, {
     cwd: unixifyPaths(packageRoot),
     onlyFiles: true,

--- a/packages/cli-config-android/src/config/findPackageClassName.ts
+++ b/packages/cli-config-android/src/config/findPackageClassName.ts
@@ -18,12 +18,12 @@ export function getMainActivityFiles(
   let patternArray = [];
 
   if (includePackage) {
-    patternArray.push('*Package.java', '*Package.kt');
+    patternArray.push('Package.java', 'Package.kt');
   } else {
-    patternArray.push('*.java', '*.kt');
+    patternArray.push('.java', '.kt');
   }
 
-  return glob.sync(`**/+(${patternArray.join('|')})`, {
+  return glob.sync(`**/*{${patternArray.join(',')}}`, {
     cwd: unixifyPaths(folder),
     onlyFiles: true,
     ignore: ['**/.cxx/**'],


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

Simplify by using standard glob rather than extglob. This should be faster as it will be a single pattern to match instead of four patterns to match.

## Test Plan

Covered by existing unit tests

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
