### PR TITLE
chore(cli): Update macOS / windows docs links

### DIFF
--- a/packages/cli/src/commands/init/printRunInstructions.ts
+++ b/packages/cli/src/commands/init/printRunInstructions.ts
@@ -64,7 +64,7 @@ function printRunInstructions(
     desktopInstructions = `
   ${chalk.magenta(`Run instructions for ${chalk.bold('macOS')}`)}:
     • See ${chalk.underline(
-      'https://aka.ms/ReactNativeGuideMacOS',
+      'https://microsoft.github.io/ract-native-macos',
     )} for the latest up-to-date instructions.
     `;
   }
@@ -73,7 +73,7 @@ function printRunInstructions(
     desktopInstructions = `
   ${chalk.cyan(`Run instructions for ${chalk.bold('Windows')}`)}:
     • See ${chalk.underline(
-      'https://aka.ms/ReactNativeGuideWindows',
+      'https://microsoft.github.io/react-native-windows',
     )} for the latest up-to-date instructions.
     `;
   }


### PR DESCRIPTION
## Summary

Noticed the macOS one was off.. submitting a change to update both to their corresponding docs home pages.

## Test Plan

N/A ?

## Checklist

- [ ] Documentation is up to date.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
