### PR TITLE
Return to less intrusive way of starting server in a new window on macOS

### DIFF
--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -100,7 +100,7 @@ function startServerInNewWindow(
     try {
       return execa.sync(
         'open',
-        ['-na', terminal, launchPackagerScript],
+        ['-a', terminal, launchPackagerScript],
         procConfig,
       );
     } catch (error) {


### PR DESCRIPTION
Fixes #2696. Reverts #2628.

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

A change was made in #2628 to work around a bug in Ghostty by forcing a new _process_ to open in the default terminal app by adding the following option to the macOS `open` command:

`-n  Open a new instance of the application(s) even if one is already running.`

This means that, in iTerm at least (and likely others), an entirely new dock icon will appear, which prevents switching between existing iTerm windows and this new one using the typical `cmd+~` keyboard shortcut.

Furthermore, iTerm has overrides that allow you to open in a tab instead of a window when the command is `open -a`, but it can't do anything to override open `open -na` because of the fact that it launches an entirely separate _process_, not just _window_. (Side note: I would love to understand the rationale behind the fact that metro insists on launching in a new window instead of letting the terminal app in use decide how to handle it per the user's preferences, but I digress).

**This removes the `-n` flag as the Ghostty bug that it added to work around has been [verified fixed](https://github.com/ghostty-org/ghostty/discussions/4839#discussioncomment-14226864) and released in [Ghostty 1.2.0](https://ghostty.org/docs/install/release-notes/1-2-0), out today**

## Test Plan

This reverts to longtime behavior for the CLI when launching the metro server process in a terminal. However, I have tested it with the following, and all seems to behave as expected:

1. `REACT_TERMINAL=iTerm yarn ios`
2. `REACT_TERMINAL=Ghostty yarn ios` (using Ghostty 1.2.0)
3. `REACT_TERMINAL=Terminal yarn ios`

cc @Kamefrede for additional testing

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
