### PR TITLE
fix: allow specifying an auth token for third-party registries

### DIFF
--- a/packages/cli/src/commands/init/index.ts
+++ b/packages/cli/src/commands/init/index.ts
@@ -22,6 +22,11 @@ export default {
         'Use specific package manager to initialize the project. Available options: `yarn`, `npm`, `bun`. Default: `npm`',
     },
     {
+      name: '--auth-token <string>',
+      description:
+        'Use a specific authentication token when connecting to the registry, typically only needed for third-party registries',
+    },
+    {
       name: '--directory <string>',
       description: 'Uses a custom directory instead of `<projectName>`.',
     },

--- a/packages/cli/src/commands/init/init.ts
+++ b/packages/cli/src/commands/init/init.ts
@@ -465,6 +465,7 @@ export default (async function initialize(
     const updatedVersion = await npmResolveConcreteVersion(
       options.platformName ?? 'react-native',
       version,
+      options.authToken,
     );
     logger.debug(`Mapped: ${version} -> ${updatedVersion}`);
     version = updatedVersion;

--- a/packages/cli/src/commands/init/types.ts
+++ b/packages/cli/src/commands/init/types.ts
@@ -4,6 +4,7 @@ export type Options = {
   template?: string;
   npm?: boolean;
   pm?: PackageManager;
+  authToken?: string;
   directory?: string;
   displayName?: string;
   title?: string;

--- a/packages/cli/src/commands/init/version.ts
+++ b/packages/cli/src/commands/init/version.ts
@@ -58,7 +58,10 @@ export async function createTemplateUri(
       // lower cadence). We have to assume the user is running against the latest nightly by pointing to the tag.
       return `${TEMPLATE_PACKAGE_COMMUNITY}@nightly`;
     }
-    const templateVersion = await getTemplateVersion(version);
+    const templateVersion = await getTemplateVersion(
+      version,
+      options.authToken,
+    );
     return `${TEMPLATE_PACKAGE_COMMUNITY}@${templateVersion}`;
   }
 

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -58,14 +58,18 @@ export const getNpmRegistryUrl = (() => {
 export async function npmResolveConcreteVersion(
   packageName: string,
   tagOrVersion: string,
+  authToken?: string,
 ): Promise<string> {
   const url = new URL(getNpmRegistryUrl());
-  url.pathname = `${packageName}/${tagOrVersion}`;
-  const resp = await fetch(url);
+  url.pathname = `${url.pathname}${packageName}/${tagOrVersion}`;
+  const headers = authToken
+    ? {Authorization: `Bearer ${authToken}`}
+    : undefined;
+  const resp = await fetch(url, {headers});
   if (
     [
       200, // OK
-      301, // Moved Permanemently
+      301, // Moved Permanently
       302, // Found
       304, // Not Modified
       307, // Temporary Redirect
@@ -126,10 +130,16 @@ const minorVersion = (version: string) => {
 
 export async function getTemplateVersion(
   reactNativeVersion: string,
+  authToken?: string,
 ): Promise<TemplateVersion | undefined> {
-  const json = await fetch(
-    new URL('@react-native-community/template', getNpmRegistryUrl()),
-  ).then((resp) => resp.json() as Promise<NpmTemplateResponse>);
+  const url = new URL(getNpmRegistryUrl());
+  url.pathname = `${url.pathname}@react-native-community/template`;
+  const headers = authToken
+    ? {Authorization: `Bearer ${authToken}`}
+    : undefined;
+  const json = await fetch(url, {headers}).then(
+    (resp) => resp.json() as Promise<NpmTemplateResponse>,
+  );
 
   // We are abusing which npm metadata is publicly available through the registry. Scripts
   // is always captured, and we use this in the Github Action that manages our releases to


### PR DESCRIPTION
## Summary

Currently if we are using a third-party registry, we are unable to initialize a react-native project under either of the following conditions:

1. The registry requires authentication
2. The registry includes a path (e.g., `https://registry.example.com/foo` instead of `https://registry.example.com`)

Related: https://github.com/react-native-community/cli/issues/2718

## Test Plan

I am on an enterprise network with a third-party registry that requires authentication. After making the changes in this PR locally, I was able to initialize a react-native repository locally with the following commands:

1. `yarn install`
2. `npm run build`
4. `chmod 755 packages/cli/build/bin.js`
5. From another directory: `../../packages/cli/build/bin.js init --auth-token ... MyAwesomeProject`

## Checklist

- [X] Documentation is up to date.
- [X] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
