### PR TITLE
feat: autolink native peer dependencies

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -23,6 +23,7 @@ The following type describes the configuration of a dependency that can be set u
 
 ```ts
 type DependencyConfig = {
+  autolinkTransitiveDependencies?: boolean;
   platforms: {
     android?: AndroidDependencyParams;
     ios?: IOSDependencyParams;
@@ -36,6 +37,10 @@ type DependencyConfig = {
 ### platforms
 
 A map of specific settings that can be set per platform. The exact shape is always defined by the package that provides given platform.
+
+### autolinkTransitiveDependencies
+
+When set to `true`, the CLI will inspect the dependency's `peerDependencies` and attempt to autolink any peers that are also React Native native modules. The CLI does not install those peers for the user, but they will be linked automatically whenever they are present in `node_modules`. Use this if your library relies on a native peer dependency (for example, `react-native-nitro-text` depending on `react-native-nitro-modules`) and would otherwise require users to manually add that peer.
 
 In most cases, as a library author, you should not need to define any of these.
 

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -40,7 +40,7 @@ A map of specific settings that can be set per platform. The exact shape is alwa
 
 ### autolinkTransitiveDependencies
 
-When set to `true`, the CLI will inspect the dependency's `peerDependencies` and attempt to autolink any peers that are also React Native native modules. The CLI does not install those peers for the user, but they will be linked automatically whenever they are present in `node_modules`. Use this if your library relies on a native peer dependency (for example, `react-native-nitro-text` depending on `react-native-nitro-modules`) and would otherwise require users to manually add that peer.
+When set to `true`, the CLI will inspect the dependency's `peerDependencies` and attempt to autolink any peers that are also React Native native modules. The CLI does not install those peers for the user, but they will be linked automatically whenever they are present in `node_modules`. Use this if your library relies on a native peer dependency (for example, [`react-native-nitro-text`](https://github.com/patrickkabwe/react-native-nitro-text) depending on [`react-native-nitro-modules`](https://github.com/mrousavy/nitro)) and would otherwise require users to manually add that peer.
 
 In most cases, as a library author, you should not need to define any of these.
 

--- a/packages/cli-config/src/schema.ts
+++ b/packages/cli-config/src/schema.ts
@@ -64,6 +64,7 @@ export const dependencyConfig = t
   .object({
     dependency: t
       .object({
+        autolinkTransitiveDependencies: t.boolean(),
         platforms: map(t.string(), t.any())
           .keys({
             ios: t
@@ -120,6 +121,7 @@ export const projectConfig = t
       t
         .object({
           root: t.string(),
+          autolinkTransitiveDependencies: t.boolean(),
           platforms: map(t.string(), t.any()).keys({
             ios: t
               // IOSDependencyConfig

--- a/packages/cli-types/src/index.ts
+++ b/packages/cli-types/src/index.ts
@@ -99,6 +99,7 @@ export type ProjectConfig = {
 export interface DependencyConfig {
   name: string;
   root: string;
+  autolinkTransitiveDependencies?: boolean;
   platforms: {
     android?: Exclude<
       ReturnType<AndroidPlatformConfig['dependencyConfig']>,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
Add opt-in support for autolinking native peer dependencies (closes #870). At the moment the CLI only autolinks packages that are listed directly in an app’s `package.json`, so native peers declared by a library remain invisible unless every app developer installs them manually. This change introduces a `dependency.autolinkTransitiveDependencies` flag that a library can set in its `react-native.config.js`. When enabled, the CLI reads the library’s own package.json, discovers its peer dependencies, and links any native peers that are already present in node_modules. 

The approach stays entirely inside the autolinking pipeline unlike PR #2054’s `--dependency-check`, which mutates app dependencies so it avoids surprise installs, CI failures, and extra workflow steps. Once a library opts in, every app automatically benefits. The updates touch the config loader, schema, public types, documentation, and add `loadConfigAsync` test coverage.

## Test Plan

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
`yarn test packages/cli-config/src/__tests__/index-test.ts
`
## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
