### PR TITLE
feat: make the react native package name passable

### DIFF
--- a/packages/cli-config/src/__tests__/index-test.ts
+++ b/packages/cli-config/src/__tests__/index-test.ts
@@ -578,3 +578,22 @@ test('should convert project sourceDir relative path to absolute', async () => {
     path.join(DIR, androidProjectDir),
   );
 });
+
+test('should be able to resolve platform-specific react-native path', async () => {
+  DIR = getTempDirectory('config_test_apply_platform_react_native_path');
+  writeFiles(DIR, {
+    ...REACT_NATIVE_MOCK,
+    ...PLATFORM_MOCK,
+    'package.json': `{
+      "dependencies": {
+        "react-native": "0.0.1",
+        "react-native-os": "0.0.1"
+      }
+    }`,
+  });
+  const {reactNativePath} = await loadConfigAsync({
+    projectRoot: DIR,
+    reactNativePackageName: 'react-native-os',
+  });
+  expect(reactNativePath).toMatch(/\/react-native-os$/);
+});

--- a/packages/cli-config/src/commands/config.ts
+++ b/packages/cli-config/src/commands/config.ts
@@ -27,6 +27,11 @@ export default {
       name: '--platform <platform>',
       description: 'Output configuration for a specific platform',
     },
+    {
+      name: '--react-native-package-name <platform>',
+      description:
+        'Optional package name to use when resolving react-native, passable by out-of-tree platforms.',
+    },
   ],
   func: async (_argv: string[], ctx: Config) => {
     console.log(JSON.stringify(filterConfig(ctx), null, 2));

--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -90,9 +90,11 @@ const removeDuplicateCommands = <T extends boolean>(commands: Command<T>[]) => {
 export default function loadConfig({
   projectRoot = findProjectRoot(),
   selectedPlatform,
+  reactNativePackageName,
 }: {
   projectRoot?: string;
   selectedPlatform?: string;
+  reactNativePackageName?: string;
 }): Config {
   let lazyProject: ProjectConfig;
   const userConfig = readConfigFromDisk(projectRoot);
@@ -102,7 +104,7 @@ export default function loadConfig({
     get reactNativePath() {
       return userConfig.reactNativePath
         ? path.resolve(projectRoot, userConfig.reactNativePath)
-        : resolveReactNativePath(projectRoot);
+        : resolveReactNativePath(projectRoot, reactNativePackageName);
     },
     get reactNativeVersion() {
       return getReactNativeVersion(initialConfig.reactNativePath);
@@ -188,9 +190,11 @@ export default function loadConfig({
 export async function loadConfigAsync({
   projectRoot = findProjectRoot(),
   selectedPlatform,
+  reactNativePackageName,
 }: {
   projectRoot?: string;
   selectedPlatform?: string;
+  reactNativePackageName?: string;
 }): Promise<Config> {
   let lazyProject: ProjectConfig;
   const userConfig = await readConfigFromDiskAsync(projectRoot);
@@ -200,7 +204,7 @@ export async function loadConfigAsync({
     get reactNativePath() {
       return userConfig.reactNativePath
         ? path.resolve(projectRoot, userConfig.reactNativePath)
-        : resolveReactNativePath(projectRoot);
+        : resolveReactNativePath(projectRoot, reactNativePackageName);
     },
     get reactNativeVersion() {
       return getReactNativeVersion(initialConfig.reactNativePath);

--- a/packages/cli-config/src/resolveReactNativePath.ts
+++ b/packages/cli-config/src/resolveReactNativePath.ts
@@ -7,12 +7,15 @@ import {
  * Finds path to React Native inside `node_modules` or throws
  * an error otherwise.
  */
-export default function resolveReactNativePath(root: string) {
+export default function resolveReactNativePath(
+  root: string,
+  reactNativePackageName = 'react-native',
+) {
   try {
-    return resolveNodeModuleDir(root, 'react-native');
+    return resolveNodeModuleDir(root, reactNativePackageName);
   } catch (_ignored) {
     throw new CLIError(`
-      Unable to find React Native files looking up from ${root}. Make sure "react-native" module is installed
+      Unable to find React Native files looking up from ${root}. Make sure "${reactNativePackageName}" module is installed
       in your project dependencies.
 
       If you are using React Native from a non-standard location, consider setting:

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -182,6 +182,7 @@ async function setupAndRun(platformName?: string) {
   let config: Config | undefined;
   try {
     let selectedPlatform: string | undefined;
+    let reactNativePackageName: string | undefined;
 
     /*
       When linking dependencies in iOS and Android build we're passing `--platform` argument,
@@ -193,10 +194,22 @@ async function setupAndRun(platformName?: string) {
       if (platformIndex !== -1 && platformIndex < process.argv.length - 1) {
         selectedPlatform = process.argv[platformIndex + 1];
       }
+
+      const reactNativePackageNameIndex = process.argv.indexOf(
+        '--react-native-package-name',
+      );
+
+      if (
+        reactNativePackageNameIndex !== -1 &&
+        reactNativePackageNameIndex < process.argv.length - 1
+      ) {
+        reactNativePackageName = process.argv[reactNativePackageNameIndex + 1];
+      }
     }
 
     config = await loadConfigAsync({
       selectedPlatform,
+      reactNativePackageName,
     });
 
     logger.enable();


### PR DESCRIPTION
## Summary

In the current version of the React Native Community template, the `reactNativePath` is passed as
- [`:path` argument for the `use_react_native` call](https://github.com/react-native-community/template/blob/e319a2fa9c12a78ad340a03dae7562ef975692c6/template/ios/Podfile#L21).
- [Second argument for the `react_native_post_install` call](https://github.com/react-native-community/template/blob/e319a2fa9c12a78ad340a03dae7562ef975692c6/template/ios/Podfile#L29).

An out-of-tree platform like `react-native-macos` cannot reuse this pattern, as it [needs to pass it's own package path](https://github.com/microsoft/react-native-macos/blob/2b484302ccb716a95d0f26e838fa8eb669903fd7/packages/react-native/local-cli/generator-macos/templates/macos/Podfile#L14) and the value of `reactNativePath` in the output of the `config` command points to React Native Core's path.

Merging this PR will add a new optional `--react-native-package-name` option, which the out-of-tree platform [can pass when linking native modules](https://github.com/microsoft/react-native-macos/blob/2b484302ccb716a95d0f26e838fa8eb669903fd7/packages/react-native/scripts/cocoapods/autolinking.rb#L197) to resolve their own package, instead of `"react-native"`.

## Test Plan

I added a unit test for the new behavior and I manually verified the `--react-native-package-name` was passed correctly through to the `loadConfig` functions into `resolveReactNativePath`.

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention). (or rather the PR title does? 🤷)
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
