### PR TITLE
feat: add option for libs to include codegen

### DIFF
--- a/packages/cli-config-android/src/config/index.ts
+++ b/packages/cli-config-android/src/config/index.ts
@@ -181,6 +181,7 @@ export function dependencyConfig(
       cxxModuleCMakeListsPath = cxxModuleCMakeListsPath.replace(/\\/g, '/');
     }
   }
+  const hasCodegenPrefab = userConfig.hasCodegenPrefab ?? false;
 
   return {
     sourceDir,
@@ -195,5 +196,6 @@ export function dependencyConfig(
     cxxModuleCMakeListsPath,
     cxxModuleHeaderName,
     isPureCxxDependency,
+    hasCodegenPrefab,
   };
 }

--- a/packages/cli-types/src/android.ts
+++ b/packages/cli-types/src/android.ts
@@ -32,6 +32,7 @@ export type AndroidDependencyConfig = {
   cxxModuleCMakeListsPath?: string | null;
   cxxModuleHeaderName?: string | null;
   isPureCxxDependency?: boolean;
+  hasCodegenPrefab: boolean;
 };
 
 export type AndroidDependencyParams = {
@@ -48,4 +49,5 @@ export type AndroidDependencyParams = {
   cxxModuleCMakeListsModuleName?: string | null;
   cxxModuleCMakeListsPath?: string | null;
   cxxModuleHeaderName?: string | null;
+  hasCodegenPrefab?: boolean;
 };


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Help us understand your motivation by explaining why you decided to make this change: -->
PR adding the cli side of https://github.com/facebook/react-native/pull/54382 which lets the library include `hasCodegenPrefab` option in their `react-native.config.js` file. 

## Test Plan

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

## Checklist

- [ ] Documentation is up to date.
- [ ] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
