### PR TITLE
fix: run-android not running on linux

### DIFF
--- a/packages/cli-tools/src/getDefaultUserTerminal.ts
+++ b/packages/cli-tools/src/getDefaultUserTerminal.ts
@@ -1,10 +1,14 @@
 import os from 'os';
 
 const getDefaultUserTerminal = (): string | undefined => {
-  const {REACT_TERMINAL, TERM_PROGRAM, TERM} = process.env;
+  const {REACT_TERMINAL, TERM_PROGRAM, TERM, SHELL} = process.env;
 
   if (REACT_TERMINAL) {
     return REACT_TERMINAL;
+  }
+	
+  if (os.platform() === 'linux') {
+    return SHELL;
   }
 
   if (os.platform() === 'darwin') {

--- a/packages/cli-tools/src/startServerInNewWindow.ts
+++ b/packages/cli-tools/src/startServerInNewWindow.ts
@@ -109,7 +109,7 @@ function startServerInNewWindow(
   }
   if (process.platform === 'linux') {
     try {
-      return execa.sync(terminal, ['-e', `sh ${launchPackagerScript}`], {
+      return execa(terminal, ['-e', `sh ${launchPackagerScript}`], {
         ...procConfig,
         detached: true,
       });


### PR DESCRIPTION
https://github.com/react-native-community/cli/issues/2674

Patch to tryout. `@react-native-community__cli-tools@20.0.2.patch`

```
diff --git a/build/getDefaultUserTerminal.js b/build/getDefaultUserTerminal.js
index 78e2d78a9dffb127e193e91db10316fade744193..4e8c767fb3508b0a6b231736c0ffb6bbe03b65db 100644
--- a/build/getDefaultUserTerminal.js
+++ b/build/getDefaultUserTerminal.js
@@ -16,10 +16,14 @@ const getDefaultUserTerminal = () => {
   const {
     REACT_TERMINAL,
     TERM_PROGRAM,
-    TERM
+    TERM,
+		 SHELL
   } = process.env;
   if (REACT_TERMINAL) {
     return REACT_TERMINAL;
+  }
+	if (_os().default.platform() === 'linux') {
+    return SHELL;
   }
   if (_os().default.platform() === 'darwin') {
     return TERM_PROGRAM;
diff --git a/build/startServerInNewWindow.js b/build/startServerInNewWindow.js
index 755bf7579c01194d106dca0fd0dcd2147cee39d3..4171b2fefdbe3fea5dc1bb6572b58cd5e0a42dd7 100644
--- a/build/startServerInNewWindow.js
+++ b/build/startServerInNewWindow.js
@@ -107,9 +107,9 @@ function startServerInNewWindow(port, projectRoot, reactNativePath, terminal) {
   }
   if (process.platform === 'linux') {
     try {
-      return _execa().default.sync(terminal, ['-e', `sh ${launchPackagerScript}`], {
+      return (0, _execa().default)(terminal, ['-e', `sh ${launchPackagerScript}`], {
         ...procConfig,
         detached: true
       });
     } catch (error) {
       // By default, the child shell process will be attached to the parent

```