### PR TITLE
Build sourceMappingURL constructs with relative paths

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -119,9 +119,7 @@ function buildFile(file, silent) {
 
       // Normalize/override key fields for consistency
       map.file = outFile;
-      map.sources = [
-        path.relative(outDir, file).replace(/\\/g, '/'),
-      ];
+      map.sources = [path.relative(outDir, file).replace(/\\/g, '/')];
 
       code = `${code}\n\n//# sourceMappingURL=${mapFileName}`;
       fs.writeFileSync(mapPath, JSON.stringify(map));


### PR DESCRIPTION
Previously, using this build script would leave the sourceMappingURL with full filenames instead of the correct relative path. This helps with that.

Closes #2662 