### PR TITLE
[Android] Fix variantPath for multiflavored paths

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/tryInstallAppOnDevice.ts
@@ -26,7 +26,9 @@ function tryInstallAppOnDevice(
     // create path to output file, eg. `production/debug`
     // ensure multiflavored path is correct, e.g. `clientStagingDebug` -> `clientStaging/debug`
     const variantPath = variantFromSelectedTask
-      ? `${variantFromSelectedTask.slice(0, -1).join("")}/${variantFromSelectedTask.at(-1)!.toLocaleLowerCase()}`
+      ? `${variantFromSelectedTask
+          .slice(0, -1)
+          .join('')}/${variantFromSelectedTask.at(-1)!.toLocaleLowerCase()}`
       : defaultVariant;
     // create output file name, eg. `production-debug`
     const variantAppName =


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

When working with multiflavored apps, run-android fails to install app because of incorrect directory. Given we have `clientStagingDebug` variant, current path is `android/app/build/outputs/apk/client/staging/debug` when in fact it should be `android/app/build/outputs/apk/clientStaging/debug`

## Test Plan

Try to run-android with some multiflavored app:

`android/app/build.gradle` should have something like

```
flavorDimensions "account", "environment"
productFlavors {
    client {
        dimension "account"
        applicationIdSuffix '.client'
        versionCode android.defaultConfig.versionCode
    }
    host {
        dimension "account"
        applicationIdSuffix '.host'
        versionCode android.defaultConfig.versionCode
    }

    production {
        dimension "environment"
        versionCode android.defaultConfig.versionCode
    }
    staging {
        dimension "environment"
        applicationIdSuffix '.staging'
        versionCode android.defaultConfig.versionCode
    }
}
```

## Checklist

- [+] Documentation is up to date.
- [+] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [+] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
