### PR TITLE
fix: fail when exact template version does not exist

### DIFF
--- a/packages/cli/src/commands/init/version.ts
+++ b/packages/cli/src/commands/init/version.ts
@@ -59,6 +59,12 @@ export async function createTemplateUri(
       return `${TEMPLATE_PACKAGE_COMMUNITY}@nightly`;
     }
     const templateVersion = await getTemplateVersion(version);
+    if (templateVersion == null) {
+      throw new Error(
+        `Unable to find a template for react-native version '${version}'. ` +
+          `Please check that the version exists and has a corresponding template published to npm.`,
+      );
+    }
     return `${TEMPLATE_PACKAGE_COMMUNITY}@${templateVersion}`;
   }
 

--- a/packages/cli/src/tools/__tests__/npm-test.ts
+++ b/packages/cli/src/tools/__tests__/npm-test.ts
@@ -39,7 +39,7 @@ describe('getTemplateVersion', () => {
     expect(await getTemplateVersion(VERSION)).toEqual('1.2.3');
   });
 
-  it('should matching latest MAJOR.MINOR if MAJOR.MINOR.PATCH has no match', async () => {
+  it('should NOT match if MAJOR.MINOR.PATCH has no exact match', async () => {
     fetchReturn({
       versions: {
         '3.2.1': {scripts: {version: '0.75.1'}},
@@ -51,7 +51,7 @@ describe('getTemplateVersion', () => {
       },
     });
 
-    expect(await getTemplateVersion('0.75.3')).toEqual('3.2.2');
+    expect(await getTemplateVersion('0.75.3')).toEqual(undefined);
   });
 
   it('should NOT matching when MAJOR.MINOR is not found', async () => {

--- a/packages/cli/src/tools/npm.ts
+++ b/packages/cli/src/tools/npm.ts
@@ -119,11 +119,6 @@ class Template {
   }
 }
 
-const minorVersion = (version: string) => {
-  const v = semver.parse(version)!;
-  return `${v.major}.${v.minor}`;
-};
-
 export async function getTemplateVersion(
   reactNativeVersion: string,
 ): Promise<TemplateVersion | undefined> {
@@ -139,11 +134,8 @@ export async function getTemplateVersion(
   // - IF there a match for React Native MAJOR.MINOR.PATCH?
   //    - Yes: if there are >= 2 versions, pick the one last published. This lets us release
   //           specific fixes for React Native versions.
-  // - ELSE, is there a match for React Native MINOR.PATCH?
-  //    - Yes: if there are >= 2 versions, pick the one last published. This decouples us from
-  //           React Native releases.
   //    - No: we don't have a version of the template for a version of React Native. There should
-  //          at a minimum be at last one version cut for each MINOR.PATCH since 0.75. Before this
+  //          at a minimum be at least one version cut for each MAJOR.MINOR.PATCH since 0.75. Before this
   //          the template was shipped with React Native
   const rnToTemplate: VersionedTemplates = {};
   for (const [templateVersion, pkg] of Object.entries(json.versions)) {
@@ -159,12 +151,8 @@ export async function getTemplateVersion(
       json.time[templateVersion],
     );
 
-    const rnMinorVersion = minorVersion(rnVersion);
-
     rnToTemplate[rnVersion] = rnToTemplate[rnVersion] ?? [];
     rnToTemplate[rnVersion].push(template);
-    rnToTemplate[rnMinorVersion] = rnToTemplate[rnMinorVersion] ?? [];
-    rnToTemplate[rnMinorVersion].push(template);
   }
 
   // Make sure the last published is the first one in each version of React Native
@@ -176,10 +164,6 @@ export async function getTemplateVersion(
 
   if (reactNativeVersion in rnToTemplate) {
     return rnToTemplate[reactNativeVersion][0].version;
-  }
-  const rnMinorVersion = minorVersion(reactNativeVersion);
-  if (rnMinorVersion in rnToTemplate) {
-    return rnToTemplate[rnMinorVersion][0].version;
   }
   return;
 }


### PR DESCRIPTION
### Description

**Problem:**
When running `npx @react-native-community/cli init MyApp --version "0.83.3"`, if the template for version `0.83.3` doesn't exist but `0.83.2` exists, the CLI would silently fall back to `0.83.2` instead of failing.

This caused real problems:

1. **rn-diff-purge breakage**: The release job would succeed even when the requested template version didn't exist, because the CLI silently used a different template. This led to incorrect diffs being generated.

2. **Confusing user experience**: Users would see `Welcome to React Native 0.83.3` in the console output, but when they checked their `package.json`, they'd find a different version. This mismatch is confusing and can lead to debugging headaches.

**Solution:**
Removed the minor version fallback logic in `getTemplateVersion()`. The CLI now only matches exact `MAJOR.MINOR.PATCH` versions. If the requested version doesn't have a corresponding template, an error is thrown with a clear message.

### Changes

| File | Change |
|------|--------|
| `packages/cli/src/tools/npm.ts` | Removed minor version fallback logic and unused `minorVersion` helper |
| `packages/cli/src/commands/init/version.ts` | Added error handling when template version is not found |
| `packages/cli/src/tools/__tests__/npm-test.ts` | Updated test to expect `undefined` for non-existent versions |

### Test Plan
```sh
# Should fail with error message
node packages/cli/build/bin.js init Test0833 --version "0.83.3" --skip-install
# Error: Unable to find a template for react-native version '0.83.3'...

# Should succeed (if 0.83.2 template exists)
node packages/cli/build/bin.js init Test0832 --version "0.83.2" --skip-install

# Unit tests
yarn test packages/cli/src/tools/__tests__/npm-test.ts
```