### PR TITLE
fix: drop RCT_NEW_ARCH_ENABLED flag injection for pod install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ And then:
 
 ```sh
 cd /my/new/react-native/project/
-yarn link "@react-native-community/cli-platform-ios" "@react-native-community/cli-platform-android" "@react-native-community/cli" "@react-native-community/cli-server-api" "@react-native-community/cli-types" "@react-native-community/cli-tools" "@react-native-community/cli-clean" "@react-native-community/cli-doctor" "@react-native-community/cli-config" "@react-native-community/cli-platform-apple" "@react-native-community/cli-link-assets"
+yarn link "@react-native-community/cli-platform-ios" "@react-native-community/cli-platform-android" "@react-native-community/cli" "@react-native-community/cli-server-api" "@react-native-community/cli-types" "@react-native-community/cli-tools" "@react-native-community/cli-clean" "@react-native-community/cli-doctor" "@react-native-community/cli-config" "@react-native-community/cli-config-android" "@react-native-community/cli-platform-apple" "@react-native-community/cli-config-apple" "@react-native-community/cli-link-assets"
 ```
 
 Once you're done with testing and you'd like to get back to regular setup, run `yarn unlink` instead of `yarn link` from above command. Then `yarn install --force`.

--- a/packages/cli-config-apple/src/tools/installPods.ts
+++ b/packages/cli-config-apple/src/tools/installPods.ts
@@ -14,27 +14,24 @@ import {execaPod} from './pods';
 
 interface PodInstallOptions {
   skipBundleInstall?: boolean;
-  newArchEnabled?: boolean;
   iosFolderPath?: string;
 }
 
 interface RunPodInstallOptions {
   shouldHandleRepoUpdate?: boolean;
-  newArchEnabled?: boolean;
 }
 
 async function runPodInstall(loader: Ora, options: RunPodInstallOptions) {
   const shouldHandleRepoUpdate = options?.shouldHandleRepoUpdate || true;
   try {
     loader.start(
-      `Installing CocoaPods dependencies ${pico.bold(
-        options?.newArchEnabled ? 'with New Architecture' : '',
-      )} ${pico.dim('(this may take a few minutes)')}`,
+      `Installing CocoaPods dependencies ${pico.dim(
+        '(this may take a few minutes)',
+      )}`,
     );
 
     await execaPod(['install'], {
       env: {
-        RCT_NEW_ARCH_ENABLED: options?.newArchEnabled ? '1' : '0',
         RCT_IGNORE_PODS_DEPRECATION: '1', // From React Native 0.79 onwards, users shouldn't install CocoaPods manually.
         ...(process.env.USE_THIRD_PARTY_JSC && {
           USE_THIRD_PARTY_JSC: process.env.USE_THIRD_PARTY_JSC,
@@ -63,7 +60,6 @@ async function runPodInstall(loader: Ora, options: RunPodInstallOptions) {
       await runPodUpdate(loader);
       await runPodInstall(loader, {
         shouldHandleRepoUpdate: false,
-        newArchEnabled: options?.newArchEnabled,
       });
     } else {
       loader.fail();
@@ -166,9 +162,7 @@ async function installPods(loader?: Ora, options?: PodInstallOptions) {
       loader.info();
       await installCocoaPods(loader);
     }
-    await runPodInstall(loader, {
-      newArchEnabled: options?.newArchEnabled,
-    });
+    await runPodInstall(loader, {});
   } finally {
     process.chdir('..');
   }

--- a/packages/cli-config-apple/src/tools/pods.ts
+++ b/packages/cli-config-apple/src/tools/pods.ts
@@ -18,7 +18,6 @@ import execa from 'execa';
 
 interface ResolvePodsOptions {
   forceInstall?: boolean;
-  newArchEnabled?: boolean;
 }
 
 interface NativeDependencies {
@@ -188,7 +187,6 @@ export default async function resolvePods(
     try {
       await installPods(loader, {
         skipBundleInstall: !!cachedDependenciesHash,
-        newArchEnabled: options?.newArchEnabled,
         iosFolderPath: platformFolderPath,
       });
       cacheManager.set(

--- a/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
+++ b/packages/cli-platform-apple/src/commands/buildCommand/createBuild.ts
@@ -1,6 +1,5 @@
 import {CLIError} from '@react-native-community/cli-tools';
 import {Config, IOSProjectConfig} from '@react-native-community/cli-types';
-import getArchitecture from '../../tools/getArchitecture';
 import {BuildFlags} from './buildOptions';
 import {buildProject} from './buildProject';
 import {getConfiguration} from './getConfiguration';
@@ -29,10 +28,6 @@ const createBuild =
       args.forcePods ||
       args.onlyPods
     ) {
-      const isAppRunningNewArchitecture = platformConfig.sourceDir
-        ? await getArchitecture(platformConfig.sourceDir)
-        : undefined;
-
       await resolvePods(
         ctx.root,
         platformConfig.sourceDir,
@@ -41,7 +36,6 @@ const createBuild =
         ctx.reactNativePath,
         {
           forceInstall: args.forcePods || args.onlyPods,
-          newArchEnabled: isAppRunningNewArchitecture,
         },
       );
 

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -18,7 +18,6 @@ import {
   findDevServerPort,
   cacheManager,
 } from '@react-native-community/cli-tools';
-import getArchitecture from '../../tools/getArchitecture';
 import listDevices from '../../tools/listDevices';
 import {promptForDeviceSelection} from '../../tools/prompts';
 import {BuildFlags} from '../buildCommand/buildOptions';
@@ -83,10 +82,6 @@ const createRun =
       args.forcePods ||
       args.onlyPods
     ) {
-      const isAppRunningNewArchitecture = platformConfig.sourceDir
-        ? await getArchitecture(platformConfig.sourceDir)
-        : undefined;
-
       await resolvePods(
         ctx.root,
         platformConfig.sourceDir,
@@ -95,7 +90,6 @@ const createRun =
         ctx.reactNativePath,
         {
           forceInstall: args.forcePods || args.onlyPods,
-          newArchEnabled: isAppRunningNewArchitecture,
         },
       );
 


### PR DESCRIPTION
## Summary

This PR removes CLI-side injection of `RCT_NEW_ARCH_ENABLED` env var during iOS pod install.

#### Background:

- The previous behavior forced `RCT_NEW_ARCH_ENABLED` (0 or 1) from CLI when running pod installation paths such as `--only-pods`.
- Based on maintainer [feedback](https://github.com/react-native-community/cli/pull/2772#issuecomment-3940972658) and current RN defaults, the CLI should not force this flag and should let the project/RN configuration drive architecture behavior.

#### What changed:

- Removed `RCT_NEW_ARCH_ENABLED` from `installPods` pod install environment.
  - Removed now-unused `newArchEnabled` plumbing in the iOS pod resolution flow (`run/build` -> `resolvePods` -> `installPods`).

And also updated `CONTRIBUTING.md` to include `cli-config-android` and `cli-config-apple` in the yarn link example, so local-link tests also cover config package changes.

## Test Plan

#### Linked local CLI validation (per CONTRIBUTING.md)

In these cases, `--only-pods` followed project architecture behavior as expected.
- RN 0.81.5 + Reanimated v4
- RN 0.81.5 project without Reanimated (Podfile configured with RCT_NEW_ARCH_ENABLED=0)
- RN 0.84.0 template project


## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
