### PR TITLE
fix: always launches fallback simulator

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -406,11 +406,12 @@ const createRun =
       );
 
       if (!matchedSimulator) {
-        return logger.error(
+        logger.warn(
           `Could not find a simulator with name or UDID: "${pico.bold(
             args.simulator,
           )}". ${printFoundDevices(devices, 'simulator')}`,
         );
+        logger.info('Falling back to default simulator...');
       }
 
       return runOnSimulator(
@@ -419,7 +420,7 @@ const createRun =
         mode,
         scheme,
         args,
-        matchedSimulator,
+        matchedSimulator ?? fallbackSimulator,
       );
     } else {
       runOnSimulator(

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -27,7 +27,11 @@ import {getConfiguration} from '../buildCommand/getConfiguration';
 import {getXcodeProjectAndDir} from '../buildCommand/getXcodeProjectAndDir';
 import {getFallbackSimulator} from './getFallbackSimulator';
 import {getPlatformInfo} from './getPlatformInfo';
-import {printFoundDevices, matchingDevice} from './matchingDevice';
+import {
+  printFoundDevices,
+  matchingDevice,
+  formattedDeviceName,
+} from './matchingDevice';
 import {runOnDevice} from './runOnDevice';
 import {runOnSimulator} from './runOnSimulator';
 import {BuilderCommand} from '../../types';
@@ -326,7 +330,7 @@ const createRun =
           mode,
           scheme,
           args,
-          fallbackSimulator,
+          device,
         );
       } else {
         if (!device) {
@@ -392,6 +396,31 @@ const createRun =
           args,
         );
       }
+    } else if (args.simulator) {
+      const matchedSimulator = devices.find(
+        (d) =>
+          d.type === 'simulator' &&
+          (d.udid === args.simulator ||
+            d.name === args.simulator ||
+            formattedDeviceName(d) === args.simulator),
+      );
+
+      if (!matchedSimulator) {
+        return logger.error(
+          `Could not find a simulator with name or UDID: "${pico.bold(
+            args.simulator,
+          )}". ${printFoundDevices(devices, 'simulator')}`,
+        );
+      }
+
+      return runOnSimulator(
+        xcodeProject,
+        platformName,
+        mode,
+        scheme,
+        args,
+        matchedSimulator,
+      );
     } else {
       runOnSimulator(
         xcodeProject,


### PR DESCRIPTION
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary

When passing the --simulator flag with either the device name or udid it is ignored and the fallback is used

I believe it is the intended behaviour of the flag to launch with the id you specify but it was not being respected

Heres a video where i first use the current latest version without my change, then I link my local version of the cli and show it working

The udid i specify is for iphone17 so the first time when it launches the iphone16 thats just using the fallback


https://github.com/user-attachments/assets/4f75aea6-9276-41d1-9f1a-69573a0bf4f4



<!-- Help us understand your motivation by explaining why you decided to make this change: -->

## Test Plan

<!-- Write your test plan here (**REQUIRED**). If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

link to a local project and note that you can pick the simulator now

for example
```
yarn ios --simulator 'iPhone 17'
yarn ios --simulator '32D43F28-6167-488D-A94C-7F988698225A'
yarn ios --udid '32D43F28-6167-488D-A94C-7F988698225A'
```

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [x] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
