### PR TITLE
fix: propagate resolved port to build when default port is unavailable

### DIFF
--- a/packages/cli-platform-android/src/commands/runAndroid/index.ts
+++ b/packages/cli-platform-android/src/commands/runAndroid/index.ts
@@ -70,6 +70,10 @@ async function runAndroid(_argv: Array<string>, config: Config, args: Flags) {
         args.terminal,
       );
     }
+
+    if (newPort !== port) {
+      args.port = newPort;
+    }
   }
 
   if (config.reactNativeVersion !== 'unknown') {

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -124,6 +124,10 @@ const createRun =
           args.terminal,
         );
       }
+
+      if (newPort !== port) {
+        args.port = newPort;
+      }
     }
 
     if (ctx.reactNativeVersion !== 'unknown') {

--- a/packages/cli-tools/src/handlePortUnavailable.ts
+++ b/packages/cli-tools/src/handlePortUnavailable.ts
@@ -18,6 +18,7 @@ const handlePortUnavailable = async (
 
   if (!start) {
     packager = false;
+    port = nextPort;
     logAlreadyRunningBundler(nextPort);
   } else {
     const {change} = await askForPortChange(port, nextPort);


### PR DESCRIPTION
## Summary

When the default Metro port (8081) is unavailable, the resolved port is not properly propagated to the native build, causing the app to fail to connect to Metro.

There are two issues fixed:

### 1. `handlePortUnavailable` returns wrong port when packager is already running elsewhere

When port 8081 is busy and `getNextPort` discovers a packager already running on a different port (e.g. 8082) for the same project, `handlePortUnavailable` logs the correct port but returns the original unavailable port. This is the main bug — it affects both the interactive prompt flow and the "already running" flow.

**Fix**: Set `port = nextPort` in the `!start` branch of `handlePortUnavailable`.

### 2. `createRun` (iOS) and `runAndroid` don't propagate the resolved port to the build

When `findDevServerPort` returns a different port than requested (after the user accepts a port change prompt), the new port is only used to start Metro but never written back to `args.port`. This causes:

- **iOS**: `RCT_METRO_PORT` env var passed to `xcodebuild` still contains the original port
- **Android**: `-PreactNativeDevServerPort` gradle arg and `adb reverse` still use the original port

**Fix**: Update `args.port = newPort` when the port changes in both `createRun.ts` and `runAndroid/index.ts`.

## Test plan

- Start a process on port 8081 (e.g. `nc -l 8081`)
- Run `npx react-native start` — accept port 8082
- In another terminal, run `npx react-native run-ios` (or `run-android`)
- Verify the app connects to Metro on 8082
- Also test: with Metro already running on 8082, run `npx react-native run-android` without Metro prompt
- Verify gradle receives `-PreactNativeDevServerPort=8082` and `adb reverse` uses port 8082