### PR TITLE
fix(ios): never default to a connected device on plain run-ios

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/__tests__/createRun.test.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/__tests__/createRun.test.ts
@@ -1,0 +1,172 @@
+/// <reference types="jest" />
+import {Config} from '@react-native-community/cli-types';
+import createRun from '../createRun';
+import listDevices from '../../../tools/listDevices';
+import {runOnSimulator} from '../runOnSimulator';
+import {runOnDevice} from '../runOnDevice';
+import {getXcodeProjectAndDir} from '../../buildCommand/getXcodeProjectAndDir';
+import {getConfiguration} from '../../buildCommand/getConfiguration';
+import {getFallbackSimulator} from '../getFallbackSimulator';
+import {Device} from '../../../types';
+import path from 'path';
+
+const packageRoot = path.resolve(__dirname, '../../../../');
+
+jest.mock('../../../tools/listDevices');
+jest.mock('../runOnSimulator');
+jest.mock('../runOnDevice');
+jest.mock('../../buildCommand/getXcodeProjectAndDir');
+jest.mock('../../buildCommand/getConfiguration');
+jest.mock('../getFallbackSimulator');
+
+const fallbackSimulator: Device = {
+  name: 'iPhone 14',
+  udid: 'FALLBACK-SIM-UDID',
+  type: 'simulator',
+  state: 'Shutdown',
+  version: '17.0',
+};
+
+const bootedSimulator: Device = {
+  name: 'iPhone 17',
+  udid: 'BOOTED-SIM-UDID',
+  type: 'simulator',
+  state: 'Booted',
+  version: '26.2',
+};
+
+const physicalDevice: Device = {
+  name: 'Stefan’s iPhone 16',
+  udid: 'PHYSICAL-DEVICE-UDID',
+  type: 'device',
+};
+
+function buildCtx(): Config {
+  return {
+    root: packageRoot,
+    reactNativePath: '',
+    reactNativeVersion: 'unknown',
+    project: {
+      ios: {
+        sourceDir: packageRoot,
+        automaticPodsInstallation: false,
+      },
+    },
+    dependencies: {},
+  } as unknown as Config;
+}
+
+function buildArgs(overrides: Record<string, unknown> = {}) {
+  return {
+    packager: false,
+    port: 8081,
+    terminal: undefined,
+    listDevices: false,
+    interactive: false,
+    onlyPods: false,
+    forcePods: false,
+    ...overrides,
+  } as any;
+}
+
+describe('createRun no-flag default targeting (issue #2765)', () => {
+  let chdirSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    chdirSpy = jest.spyOn(process, 'chdir').mockImplementation(() => {});
+    (getXcodeProjectAndDir as jest.Mock).mockReturnValue({
+      xcodeProject: {name: 'Demo', isWorkspace: true},
+      sourceDir: packageRoot,
+    });
+    (getConfiguration as jest.Mock).mockResolvedValue({
+      mode: 'Debug',
+      scheme: 'Demo',
+    });
+    (getFallbackSimulator as jest.Mock).mockReturnValue(fallbackSimulator);
+    (runOnSimulator as jest.Mock).mockResolvedValue(undefined);
+    (runOnDevice as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    chdirSpy.mockRestore();
+  });
+
+  test('connected iPhone + no booted simulator + no flags -> launches fallback simulator only', async () => {
+    (listDevices as jest.Mock).mockResolvedValue([physicalDevice]);
+
+    await createRun({platformName: 'ios'})([], buildCtx(), buildArgs());
+
+    expect(runOnSimulator).toHaveBeenCalledTimes(1);
+    expect(runOnSimulator).toHaveBeenCalledWith(
+      expect.anything(),
+      'ios',
+      'Debug',
+      'Demo',
+      expect.anything(),
+      fallbackSimulator,
+    );
+    expect(runOnDevice).not.toHaveBeenCalled();
+  });
+
+  test('connected iPhone + booted simulator + no flags -> launches booted simulator only', async () => {
+    (listDevices as jest.Mock).mockResolvedValue([
+      physicalDevice,
+      bootedSimulator,
+    ]);
+
+    await createRun({platformName: 'ios'})([], buildCtx(), buildArgs());
+
+    expect(runOnSimulator).toHaveBeenCalledTimes(1);
+    expect(runOnSimulator).toHaveBeenCalledWith(
+      expect.anything(),
+      'ios',
+      'Debug',
+      'Demo',
+      expect.anything(),
+      bootedSimulator,
+    );
+    expect(runOnDevice).not.toHaveBeenCalled();
+  });
+
+  test('connected iPhone + --device "name" -> runs on the physical device', async () => {
+    (listDevices as jest.Mock).mockResolvedValue([
+      physicalDevice,
+      bootedSimulator,
+    ]);
+
+    await createRun({platformName: 'ios'})(
+      [],
+      buildCtx(),
+      buildArgs({device: physicalDevice.name}),
+    );
+
+    expect(runOnDevice).toHaveBeenCalledTimes(1);
+    expect(runOnDevice).toHaveBeenCalledWith(
+      physicalDevice,
+      'ios',
+      'Debug',
+      'Demo',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(runOnSimulator).not.toHaveBeenCalled();
+  });
+
+  test('no devices, no flags -> launches fallback simulator', async () => {
+    (listDevices as jest.Mock).mockResolvedValue([fallbackSimulator]);
+
+    await createRun({platformName: 'ios'})([], buildCtx(), buildArgs());
+
+    expect(runOnSimulator).toHaveBeenCalledTimes(1);
+    expect(runOnSimulator).toHaveBeenCalledWith(
+      expect.anything(),
+      'ios',
+      'Debug',
+      'Demo',
+      expect.anything(),
+      fallbackSimulator,
+    );
+    expect(runOnDevice).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/createRun.ts
@@ -266,48 +266,38 @@ const createRun =
       const bootedSimulators = devices.filter(
         ({state, type}) => state === 'Booted' && type === 'simulator',
       );
-      const bootedDevices = devices.filter(({type}) => type === 'device'); // Physical devices here are always booted
-      const booted = [...bootedSimulators, ...bootedDevices];
+      const connectedDevices = devices.filter(({type}) => type === 'device');
 
-      if (booted.length === 0) {
+      const targetSimulator = bootedSimulators[0] ?? fallbackSimulator;
+
+      if (bootedSimulators.length === 0) {
         logger.info(
-          'No booted devices or simulators found. Launching first available simulator...',
+          'No booted simulators found. Launching first available simulator...',
         );
-        return runOnSimulator(
-          xcodeProject,
-          platformName,
-          mode,
-          scheme,
-          args,
-          fallbackSimulator,
+      } else {
+        logger.info(`Found booted ${targetSimulator.name}`);
+      }
+
+      if (connectedDevices.length > 0) {
+        logger.info(
+          `Ignoring connected ${
+            connectedDevices.length === 1 ? 'device' : 'devices'
+          } (${connectedDevices
+            .map(({name}) => name)
+            .join(
+              ', ',
+            )}). Pass --device or --udid to install on a physical device.`,
         );
       }
 
-      logger.info(`Found booted ${booted.map(({name}) => name).join(', ')}`);
-
-      for (const simulator of bootedSimulators) {
-        await runOnSimulator(
-          xcodeProject,
-          platformName,
-          mode,
-          scheme,
-          args,
-          simulator || fallbackSimulator,
-        );
-      }
-
-      for (const device of bootedDevices) {
-        await runOnDevice(
-          device,
-          platformName,
-          mode,
-          scheme,
-          xcodeProject,
-          args,
-        );
-      }
-
-      return;
+      return runOnSimulator(
+        xcodeProject,
+        platformName,
+        mode,
+        scheme,
+        args,
+        targetSimulator,
+      );
     }
 
     if (args.device && args.udid) {


### PR DESCRIPTION
## Summary

Fixes #2765 (continuation of #2254).

When `react-native run-ios` is invoked **without any of `--device` / `--udid` / `--simulator`**, it should target a simulator (per the [docs](https://github.com/react-native-community/cli/blob/main/packages/cli-platform-ios/README.md): _"Builds your app and starts it on iOS simulator."_). In practice the default path was installing the app on a connected physical iPhone instead. Modern Xcode no longer lets users disable Wi-Fi device pairing, so any developer who has ever paired an iPhone hits this every run.

### Root cause

`packages/cli-platform-apple/src/commands/runCommand/createRun.ts`, the no-flag branch:

```ts
const bootedSimulators = devices.filter(
  ({state, type}) => state === 'Booted' && type === 'simulator',
);
const bootedDevices = devices.filter(({type}) => type === 'device'); // treats every connected iPhone as "booted"
const booted = [...bootedSimulators, ...bootedDevices];
// ...
for (const device of bootedDevices) { await runOnDevice(...); } // wrong: installs on the phone with no opt-in
```

Two problems:

1. `bootedDevices` participates in the no-flag default path at all.
2. When the user hasn't booted a simulator (very common), `booted.length !== 0` because of the iPhone, so the fallback-simulator branch is skipped and the build/install runs on the device — exactly the trace from the issue:
   ```
   info Found booted Stefan's iPhone 16
   info Building (using "xcodebuild -workspace ... -destination id=00008140-…")
   info Installing and launching your app on Stefan's iPhone 16
   ```

### Fix

Replace the no-flag block with simulator-only logic:

- Pick the first booted simulator, otherwise the existing `fallbackSimulator` (computed earlier via `getFallbackSimulator(args)`).
- Call `runOnSimulator` exactly once with that target.
- If any physical device was detected, log a single info hint naming the device(s) and pointing to `--device` / `--udid`, so users understand the change.

Explicit paths (`--device`, `--udid`, `--simulator`, `--list-devices`, `--interactive`) are unchanged — the fix only affects the no-flag default.

## Test Plan

### Unit tests (added)

`packages/cli-platform-apple/src/commands/runCommand/__tests__/createRun.test.ts` covers:

1. **iPhone connected + no booted simulator + no flags** → `runOnSimulator` is called once with the fallback simulator; `runOnDevice` is **not** called. _(Direct repro of #2765.)_
2. **iPhone connected + booted simulator + no flags** → `runOnSimulator` is called once with the booted simulator; `runOnDevice` is **not** called.
3. **iPhone connected + `--device "<name>"`** → `runOnDevice` is called with the iPhone (regression guard for the explicit path).
4. **No physical devices, no flags** → `runOnSimulator` is called once with the fallback simulator (preserves prior behavior).

```
yarn jest --selectProjects unit packages/cli-platform-apple
# Test Suites: 55 passed, 55 total
# Tests:       1 todo, 295 passed, 296 total
```

`yarn lint` and `yarn build` are also green.

### Manual repro

Using https://github.com/swrobel/cli-reproducer:

- iPhone paired in Xcode, no simulator booted, run `npx react-native run-ios` → expect a simulator to launch (e.g. iPhone 14 / first available), not the iPhone. The output now includes `Ignoring connected device (<iPhone name>). Pass --device or --udid to install on a physical device.`
- Boot a simulator, repeat → expect the app to install on the booted simulator only.
- Run `npx react-native run-ios --device "<iPhone name>"` → expect the iPhone path to still work end-to-end.

## Checklist

- [x] Documentation is up to date (the existing `cli-platform-ios/README.md` already describes this behavior — the fix brings code in line with the docs).
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout — manual repro listed above; happy to add screenshots if useful.