### PR TITLE
fix(android): don't hardcode default `cmakeListsPath` for pure c++ modules

### DIFF
--- a/packages/cli-config-android/src/config/__tests__/getDependencyConfig.test.ts
+++ b/packages/cli-config-android/src/config/__tests__/getDependencyConfig.test.ts
@@ -34,12 +34,40 @@ describe('android::getDependencyConfig', () => {
       noPackage: {
         android: {},
       },
+      pureCxx: {
+        android: {},
+      },
     });
   });
 
   it('returns an object with android project configuration', () => {
-    expect(getDependencyConfig('/nested', userConfig)).not.toBeNull();
-    expect(typeof getDependencyConfig('/nested', userConfig)).toBe('object');
+    const config = getDependencyConfig('/nested', userConfig);
+
+    expect(config).not.toBeNull();
+    expect(typeof config).toBe('object');
+    expect(config).toMatchObject({
+      cmakeListsPath:
+        '/nested/android/build/generated/source/codegen/jni/CMakeLists.txt',
+      isPureCxxDependency: false,
+    });
+  });
+
+  it('sets cmakeListsPath to null for pure C++ dependencies', () => {
+    expect(
+      getDependencyConfig('/pureCxx', {
+        cxxModuleCMakeListsModuleName: 'PureCxxModule',
+        cxxModuleCMakeListsPath: 'src/main/jni/CMakeLists.txt',
+        cxxModuleHeaderName: 'PureCxxModule.h',
+      }),
+    ).toMatchObject({
+      cmakeListsPath: null,
+      cxxModuleCMakeListsModuleName: 'PureCxxModule',
+      cxxModuleCMakeListsPath: '/pureCxx/android/src/main/jni/CMakeLists.txt',
+      cxxModuleHeaderName: 'PureCxxModule.h',
+      isPureCxxDependency: true,
+      packageImportPath: null,
+      packageInstance: null,
+    });
   });
 
   it('returns `null` if manifest file has not been found', () => {

--- a/packages/cli-config-android/src/config/index.ts
+++ b/packages/cli-config-android/src/config/index.ts
@@ -165,9 +165,13 @@ export function dependencyConfig(
     userConfig.libraryName || findLibraryName(root, sourceDir);
   const componentDescriptors =
     userConfig.componentDescriptors || findComponentDescriptors(root);
+
   let cmakeListsPath = userConfig.cmakeListsPath
     ? path.join(sourceDir, userConfig.cmakeListsPath)
+    : isPureCxxDependency
+    ? null
     : path.join(sourceDir, 'build/generated/source/codegen/jni/CMakeLists.txt');
+
   const cxxModuleCMakeListsModuleName =
     userConfig.cxxModuleCMakeListsModuleName || null;
   const cxxModuleHeaderName = userConfig.cxxModuleHeaderName || null;
@@ -176,7 +180,10 @@ export function dependencyConfig(
     : null;
 
   if (process.platform === 'win32') {
-    cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
+    if (cmakeListsPath) {
+      cmakeListsPath = cmakeListsPath.replace(/\\/g, '/');
+    }
+
     if (cxxModuleCMakeListsPath) {
       cxxModuleCMakeListsPath = cxxModuleCMakeListsPath.replace(/\\/g, '/');
     }


### PR DESCRIPTION
## Summary

this removes the incorrect default `cmakeListsPath` from android autolinking for pure C++ modules.

currently, the path is always defaulted to a generated file path in the library. this breaks autolinking when a C++ library doesn't ship with prebuilt codegen files (with `includesGeneratedCode: false`).

after this change, it'll only use `cmakeListsPath` from user specified config.

this can potentially break existing libraries if they don't specify the path.
but the behavior is currently not consistent with how regular turbo modules work.
the fix for libraries is to specify explicit `cmakeListsPath` in `react-native.config.js`.

this only fixes part of the issue. the autolinking logic in react native also needs to be updated (PR: https://github.com/facebook/react-native/pull/56938)

related #2739

## Test Plan

- create new cpp library: `npx create-react-native-library@latest awesome-library --yes --description "my library" --type turbo-module --languages cpp`
- run `yarn example android` and notice that the build works
- apply the following patch to remove `includesGeneratedCode: true`:
  ```patch
  diff --git a/package.json b/package.json
  index e3c893a..f41100f 100644
  --- a/package.json
  +++ b/package.json
  @@ -112,22 +112,16 @@
          {
            "project": "tsconfig.build.json"
          }
  -      ],
  -      "codegen"
  +      ]
      ]
    },
    "codegenConfig": {
      "name": "AwesomeLibrarySpec",
      "type": "modules",
      "jsSrcsDir": "src",
  -    "outputDir": {
  -      "ios": "ios/generated",
  -      "android": "android/generated"
  -    },
      "android": {
        "javaPackageName": "com.awesomelibrary"
  -    },
  -    "includesGeneratedCode": true
  +    }
    },
    "prettier": {
      "quoteProps": "consistent",
  diff --git a/react-native.config.js b/react-native.config.js
  index fef2c32..46f9600 100644
  --- a/react-native.config.js
  +++ b/react-native.config.js
  @@ -5,7 +5,6 @@ module.exports = {
    dependency: {
      platforms: {
        android: {
  -        cmakeListsPath: 'generated/jni/CMakeLists.txt',
          cxxModuleCMakeListsModuleName: 'react-native-awesome-library',
          cxxModuleCMakeListsPath: 'CMakeLists.txt',
          cxxModuleHeaderName: 'AwesomeLibraryImpl',
  ```
- run `yarn example android` and notice that the build fails
- apply the patch from this PR and from https://github.com/facebook/react-native/pull/56938 and notice that the module works correctly

## Checklist

- [ ] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
