### PR TITLE
fix(iOS): getBuildSettings picking up wrong target

### DIFF
--- a/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
+++ b/packages/cli-platform-apple/src/commands/runCommand/getBuildSettings.ts
@@ -45,7 +45,11 @@ export async function getBuildSettings(
     return null;
   }
 
-  let selectedTarget = applicationTargets[0];
+  // Select target matching with the Scheme name first
+  let selectedTarget =
+    applicationTargets.find(
+      (t: string) => t.toLowerCase() === scheme.toLowerCase(),
+    ) || applicationTargets[0];
 
   if (target) {
     if (!applicationTargets.includes(target)) {
@@ -59,8 +63,7 @@ export async function getBuildSettings(
     }
   }
 
-  const targetIndex = applicationTargets.indexOf(selectedTarget);
-  return settings[targetIndex].buildSettings;
+  return settings.find((s: any) => s.target === selectedTarget).buildSettings;
 }
 
 function getPlatformName(buildOutput: string) {


### PR DESCRIPTION
## Summary

When a project contains multiple build targets where a non-app target (such as a
`.framework` target) appears before the `.app` target in the Xcode build settings
output, the CLI incorrectly installs and launches the framework instead of the app.

**Root Cause**

The code correctly filters `applicationTargets` to only include `.app` targets,
but then uses the index from the filtered array to look up build settings in the
original unfiltered `settings` array:

    const targetIndex = applicationTargets.indexOf(selectedTarget);
    return settings[targetIndex].buildSettings;

For example, given the following build settings output from `xcodebuild -showBuildSettings -json`:

```js
[
  { target: "React-Core", WRAPPER_EXTENSION: "framework" },  // index 0
  { target: "Mattermost", WRAPPER_EXTENSION: "app" },        // index 1
]
```

After filtering by `WRAPPER_EXTENSION === 'app'`:

```js
applicationTargets = ["Mattermost"]  // index 0 in filtered array
```

`applicationTargets.indexOf("Mattermost")` returns `0`, but `settings[0]` is
`React-Core`, not `Mattermost`, so the wrong build settings are returned.

`applicationTargets` after filtering is `["Mattermost"]`, so
`applicationTargets.indexOf("Mattermost")` returns `0`. However `settings[0]`
points to `React-Core`, not `Mattermost`, causing the wrong build settings to
be returned.

**Fix**

Look up the correct entry directly from the `settings` array by target name
instead of relying on the filtered index:

    return settings.find(s => s.target === selectedTarget).buildSettings;

Additionally, improved the default target selection to prefer a target whose
name matches the scheme before falling back to the first available target:

    let selectedTarget =
      applicationTargets.find(t => t.toLowerCase() === scheme.toLowerCase())
      || applicationTargets[0];

## Test Plan

1. Set up a React Native project that produces multiple build targets including
   at least one `.framework` target appearing before the `.app` target in the
   build output (e.g. Mattermost Mobile).
2. Run `npm run ios` or `react-native run-ios`.
3. Verify the correct `.app` target is installed and launched on the simulator
   instead of the `.framework` target.

**Before fix:** CLI installs `React.framework` and attempts to launch
`org.cocoapods.React`, resulting in:

    App installation failed: Unable to Install "React"
    error Failed to launch the app on simulator

**After fix:** CLI correctly installs and launches the `.app` target.

## Checklist
- [x] Documentation is up to date.
- [x] Follows commit message convention described in CONTRIBUTING.md.
- [x] For functional changes, my test plan has linked these CLI changes into a
      local `react-native` checkout.