### PR TITLE
v20.2.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "20.1.3",
+  "version": "20.2.0",
   "npmClient": "yarn",
   "exact": true,
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"

--- a/packages/cli-clean/package.json
+++ b/packages/cli-clean/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli-clean",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
@@ -8,7 +8,7 @@
   },
   "types": "build/index.d.ts",
   "dependencies": {
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-tools": "20.2.0",
     "execa": "^5.0.0",
     "fast-glob": "^3.3.2",
     "picocolors": "^1.1.1"
@@ -19,7 +19,7 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-types": "20.2.0",
     "@types/prompts": "^2.4.4"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-clean",

--- a/packages/cli-config-android/package.json
+++ b/packages/cli-config-android/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@react-native-community/cli-config-android",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-tools": "20.2.0",
     "fast-glob": "^3.3.2",
     "fast-xml-parser": "^5.3.6",
     "picocolors": "^1.1.1"
@@ -19,7 +19,7 @@
     "native_modules.gradle"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3"
+    "@react-native-community/cli-types": "20.2.0"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-config-android",
   "repository": {

--- a/packages/cli-config-apple/package.json
+++ b/packages/cli-config-apple/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@react-native-community/cli-config-apple",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-tools": "20.2.0",
     "execa": "^5.0.0",
     "fast-glob": "^3.3.2",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-types": "20.2.0",
     "ora": "^5.4.1"
   },
   "files": [

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli-config",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
@@ -8,7 +8,7 @@
   },
   "types": "build/index.d.ts",
   "dependencies": {
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-tools": "20.2.0",
     "cosmiconfig": "^9.0.0",
     "deepmerge": "^4.3.0",
     "fast-glob": "^3.3.2",
@@ -21,7 +21,7 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-types": "20.2.0",
     "@types/cosmiconfig": "^5.0.3"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-config",

--- a/packages/cli-doctor/package.json
+++ b/packages/cli-doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli-doctor",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
@@ -8,11 +8,11 @@
   },
   "types": "build/index.d.ts",
   "dependencies": {
-    "@react-native-community/cli-config": "20.1.3",
-    "@react-native-community/cli-platform-android": "20.1.3",
-    "@react-native-community/cli-platform-apple": "20.1.3",
-    "@react-native-community/cli-platform-ios": "20.1.3",
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-config": "20.2.0",
+    "@react-native-community/cli-platform-android": "20.2.0",
+    "@react-native-community/cli-platform-apple": "20.2.0",
+    "@react-native-community/cli-platform-ios": "20.2.0",
+    "@react-native-community/cli-tools": "20.2.0",
     "command-exists": "^1.2.8",
     "deepmerge": "^4.3.0",
     "envinfo": "^7.13.0",
@@ -30,7 +30,7 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-types": "20.2.0",
     "@types/command-exists": "^1.2.0",
     "@types/envinfo": "^7.8.4",
     "@types/ip": "^1.1.0",

--- a/packages/cli-link-assets/package.json
+++ b/packages/cli-link-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli-link-assets",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
@@ -8,11 +8,11 @@
   },
   "types": "build/index.d.ts",
   "dependencies": {
-    "@react-native-community/cli-config": "20.1.3",
-    "@react-native-community/cli-platform-android": "20.1.3",
-    "@react-native-community/cli-platform-apple": "20.1.3",
-    "@react-native-community/cli-platform-ios": "20.1.3",
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-config": "20.2.0",
+    "@react-native-community/cli-platform-android": "20.2.0",
+    "@react-native-community/cli-platform-apple": "20.2.0",
+    "@react-native-community/cli-platform-ios": "20.2.0",
+    "@react-native-community/cli-tools": "20.2.0",
     "fast-glob": "^3.3.2",
     "fast-xml-parser": "^5.3.6",
     "opentype.js": "^1.3.4",
@@ -26,7 +26,7 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-types": "20.2.0",
     "@types/plist": "^3.0.5",
     "type-fest": "^4.10.2"
   },

--- a/packages/cli-platform-android/package.json
+++ b/packages/cli-platform-android/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@react-native-community/cli-platform-android",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@react-native-community/cli-config-android": "20.1.3",
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-config-android": "20.2.0",
+    "@react-native-community/cli-tools": "20.2.0",
     "execa": "^5.0.0",
     "logkitty": "^0.7.1",
     "picocolors": "^1.1.1"
@@ -19,7 +19,7 @@
     "!*.map"
   ],
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3"
+    "@react-native-community/cli-types": "20.2.0"
   },
   "homepage": "https://github.com/react-native-community/cli/tree/main/packages/cli-platform-android",
   "repository": {

--- a/packages/cli-platform-apple/package.json
+++ b/packages/cli-platform-apple/package.json
@@ -1,20 +1,20 @@
 {
   "name": "@react-native-community/cli-platform-apple",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@react-native-community/cli-config-apple": "20.1.3",
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-config-apple": "20.2.0",
+    "@react-native-community/cli-tools": "20.2.0",
     "execa": "^5.0.0",
     "fast-xml-parser": "^5.3.6",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3"
+    "@react-native-community/cli-types": "20.2.0"
   },
   "files": [
     "build",

--- a/packages/cli-platform-ios/package.json
+++ b/packages/cli-platform-ios/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@react-native-community/cli-platform-ios",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@react-native-community/cli-platform-apple": "20.1.3"
+    "@react-native-community/cli-platform-apple": "20.2.0"
   },
   "devDependencies": {
     "hasbin": "^1.2.3"

--- a/packages/cli-server-api/package.json
+++ b/packages/cli-server-api/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@react-native-community/cli-server-api",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@react-native-community/cli-tools": "20.1.3",
+    "@react-native-community/cli-tools": "20.2.0",
     "body-parser": "^2.2.2",
     "compression": "^1.7.1",
     "connect": "^3.6.5",

--- a/packages/cli-tools/package.json
+++ b/packages/cli-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli-tools",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "license": "MIT",
   "main": "build/index.js",
   "publishConfig": {
@@ -19,7 +19,7 @@
     "semver": "^7.5.2"
   },
   "devDependencies": {
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-types": "20.2.0",
     "@types/mime": "^2.0.1",
     "@types/node": "^20.0.0",
     "@types/prompts": "^2.4.4",

--- a/packages/cli-types/package.json
+++ b/packages/cli-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli-types",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "main": "build",
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-community/cli",
-  "version": "20.1.3",
+  "version": "20.2.0",
   "description": "React Native CLI",
   "license": "MIT",
   "main": "build/index.js",
@@ -24,12 +24,12 @@
     "testEnvironment": "node"
   },
   "dependencies": {
-    "@react-native-community/cli-clean": "20.1.3",
-    "@react-native-community/cli-config": "20.1.3",
-    "@react-native-community/cli-doctor": "20.1.3",
-    "@react-native-community/cli-server-api": "20.1.3",
-    "@react-native-community/cli-tools": "20.1.3",
-    "@react-native-community/cli-types": "20.1.3",
+    "@react-native-community/cli-clean": "20.2.0",
+    "@react-native-community/cli-config": "20.2.0",
+    "@react-native-community/cli-doctor": "20.2.0",
+    "@react-native-community/cli-server-api": "20.2.0",
+    "@react-native-community/cli-tools": "20.2.0",
+    "@react-native-community/cli-types": "20.2.0",
     "commander": "^9.4.1",
     "deepmerge": "^4.3.0",
     "execa": "^5.0.0",


### PR DESCRIPTION
## Summary

Primarily for Xcode 27 support on iOS (now that Beta 2 is out)

then after tag and publish, should be good to merge
- https://github.com/react-native-community/template/pull/232

and close
- https://github.com/react/react-native/issues/57160

NB: for early support i fixed the windows paths locally to build, then patched @react-native-community-cli-platform-apple
- https://github.com/react-native-community/cli/pull/2806
- https://github.com/leotm/react-native-template-new-architecture/issues/1994
  - https://github.com/leotm/react-native-template-new-architecture/commit/d1b5e9c177b0f989bc4fd09f40504d191ef54ade

## Test Plan

—

## Checklist

—