### PR TITLE
breaking: Bundle iOS and Android as core platforms

### DIFF
--- a/packages/cli-config/src/loadConfig.ts
+++ b/packages/cli-config/src/loadConfig.ts
@@ -85,14 +85,36 @@ const removeDuplicateCommands = <T extends boolean>(commands: Command<T>[]) => {
 };
 
 /**
+ * Returns the built-in platforms to seed the config with, honoring the
+ * `selectedPlatform` filter the same way dependency platforms are filtered. The
+ * project's own and dependencies' platforms are layered on top of these.
+ */
+const getBasePlatforms = (
+  platforms: Config['platforms'] | undefined,
+  selectedPlatform: string | undefined,
+): {[platform: string]: Config['platforms'][string]} => {
+  if (!platforms) {
+    return {};
+  }
+  if (selectedPlatform != null) {
+    return platforms[selectedPlatform]
+      ? {[selectedPlatform]: platforms[selectedPlatform]}
+      : {};
+  }
+  return platforms;
+};
+
+/**
  * Loads CLI configuration
  */
 export default function loadConfig({
   projectRoot = findProjectRoot(),
   selectedPlatform,
+  platforms,
 }: {
   projectRoot?: string;
   selectedPlatform?: string;
+  platforms?: Config['platforms'];
 }): Config {
   let lazyProject: ProjectConfig;
   const userConfig = readConfigFromDisk(projectRoot);
@@ -110,7 +132,10 @@ export default function loadConfig({
     dependencies: userConfig.dependencies,
     commands: userConfig.commands,
     healthChecks: userConfig.healthChecks || [],
-    platforms: userConfig.platforms,
+    platforms: {
+      ...getBasePlatforms(platforms, selectedPlatform),
+      ...userConfig.platforms,
+    },
     assets: userConfig.assets,
     get project() {
       if (lazyProject) {
@@ -188,9 +213,11 @@ export default function loadConfig({
 export async function loadConfigAsync({
   projectRoot = findProjectRoot(),
   selectedPlatform,
+  platforms,
 }: {
   projectRoot?: string;
   selectedPlatform?: string;
+  platforms?: Config['platforms'];
 }): Promise<Config> {
   let lazyProject: ProjectConfig;
   const userConfig = await readConfigFromDiskAsync(projectRoot);
@@ -208,7 +235,10 @@ export async function loadConfigAsync({
     dependencies: userConfig.dependencies,
     commands: userConfig.commands,
     healthChecks: userConfig.healthChecks || [],
-    platforms: userConfig.platforms,
+    platforms: {
+      ...getBasePlatforms(platforms, selectedPlatform),
+      ...userConfig.platforms,
+    },
     assets: userConfig.assets,
     get project() {
       if (lazyProject) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,8 @@
     "@react-native-community/cli-clean": "20.2.0",
     "@react-native-community/cli-config": "20.2.0",
     "@react-native-community/cli-doctor": "20.2.0",
+    "@react-native-community/cli-platform-android": "20.2.0",
+    "@react-native-community/cli-platform-ios": "20.2.0",
     "@react-native-community/cli-server-api": "20.2.0",
     "@react-native-community/cli-tools": "20.2.0",
     "@react-native-community/cli-types": "20.2.0",

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,12 +2,16 @@ import {Command, DetachedCommand} from '@react-native-community/cli-types';
 import {commands as cleanCommands} from '@react-native-community/cli-clean';
 import {commands as doctorCommands} from '@react-native-community/cli-doctor';
 import {commands as configCommands} from '@react-native-community/cli-config';
+import {commands as androidCommands} from '@react-native-community/cli-platform-android';
+import {commands as iosCommands} from '@react-native-community/cli-platform-ios';
 import init from './init';
 
 export const projectCommands = [
   ...configCommands,
   cleanCommands.clean,
   doctorCommands.info,
+  ...iosCommands,
+  ...androidCommands,
 ] as Command[];
 
 export const detachedCommands = [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,14 @@ import type {
   Config,
   DetachedCommand,
 } from '@react-native-community/cli-types';
+import {
+  projectConfig as androidProjectConfig,
+  dependencyConfig as androidDependencyConfig,
+} from '@react-native-community/cli-platform-android';
+import {
+  projectConfig as iosProjectConfig,
+  dependencyConfig as iosDependencyConfig,
+} from '@react-native-community/cli-platform-ios';
 import childProcess from 'child_process';
 import {Command as CommanderCommand} from 'commander';
 import path from 'path';
@@ -197,6 +205,26 @@ async function setupAndRun(platformName?: string) {
 
     config = await loadConfigAsync({
       selectedPlatform,
+      // iOS and Android are core platforms bundled with the CLI, so they are
+      // always registered. The project's own and dependencies' configs can
+      // still override them.
+      //
+      // The cast is needed because the platform packages' `projectConfig`/
+      // `dependencyConfig` return `null` and take required params, whereas the
+      // `PlatformConfig` interface models these as `void`. These functions are
+      // the canonical implementations the CLI already calls via the config scan.
+      platforms: {
+        ios: {
+          npmPackageName: '@react-native-community/cli-platform-ios',
+          projectConfig: iosProjectConfig,
+          dependencyConfig: iosDependencyConfig,
+        },
+        android: {
+          npmPackageName: '@react-native-community/cli-platform-android',
+          projectConfig: androidProjectConfig,
+          dependencyConfig: androidDependencyConfig,
+        },
+      } as Config['platforms'],
     });
 
     logger.enable();

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -9,6 +9,8 @@
     {"path": "../cli-config"},
     {"path": "../cli-doctor"},
     {"path": "../cli-link-assets"},
+    {"path": "../cli-platform-android"},
+    {"path": "../cli-platform-ios"},
     {"path": "../cli-server-api"},
     {"path": "../cli-types"},
     {"path": "../cli-tools"}


### PR DESCRIPTION
## Summary

Bundle `cli-platform-android` and `cli-platform-ios` in the main `@react-native-community/cli` package.

Relates to this proposed change: https://github.com/react-native-community/template/pull/235

**Motivation**

Simplify Community CLI setup for users (see above). iOS and Android are first-class RN platforms.

- While the CLI was historically separated out into granular plugins, I don't believe we need to be so aggressive in splitting the core Android and iOS platforms into separate installs. This optimisation provides little value when RN itself bundles both — match this baseline.
    - Other plugins, including OOT platforms, remain selectively applied via plugin discovery. Again, the redundant weight of ~20 scripts (each way) being omitted for a single platform repo is a marginal win. The convention (in the case of libraries) is that OOT platform support is *additional*.
    - We can always un-bundle later (in a hypothetical project where RN also separates core from platforms).
- **Prior art**: Expo CLI doesn't bother separating platforms — the dev install impact on projects is negligible. No related artifacts leak into the project.

**Notes**

- `loadConfig` and `loadConfigAsync` gain an optional platforms argument that seeds the config. Project and dependency configs still layer on top and can override it, and the `--platform` filter is honoured.

## Test Plan

TODO

## Checklist

- [x] Documentation is up to date.
- [x] Follows commit message convention described in [CONTRIBUTING.md](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#commit-message-convention).
- [ ] For functional changes, my test plan has linked these CLI changes into a local `react-native` checkout ([instructions](https://github.com/react-native-community/cli/blob/main/CONTRIBUTING.md#testing-your-changes)).
